### PR TITLE
Add packaging, tests, and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.7", "3.10" ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install tox
+      - name: Test with pytest
+        run:
+          tox -e py
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v1
+        if: success()
+        with:
+          file: coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.10" ]
+        python-version: [ "3.8", "3.10" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+# See https://setuptools.readthedocs.io/en/latest/build_meta.html
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,13 @@ zip_safe = false
 include_package_data = True
 python_requires = >=3.8
 
+# Where is my code
+packages = find:
+
+[options.packages.find]
+exclude =
+    notebooks
+
 [options.extras_require]
 ode =
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,24 @@
+##########################
+# Setup.py Configuration #
+##########################
+# Configuring setup()
+[metadata]
+name = mira
+version = 0.1.0
+
+[options]
+install_requires =
+    pydantic
+
+[options.extras_require]
+ode =
+    numpy
+    scipy
+    sympy
+tests =
+    pytest
+    coverage
+
+zip_safe = false
+include_package_data = True
+python_requires = >=3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,17 @@
 name = mira
 version = 0.1.0
 
+license = BSD-2-Clause
+license_files =
+    LICENSE
+
 [options]
 install_requires =
     pydantic
+
+zip_safe = false
+include_package_data = True
+python_requires = >=3.8
 
 [options.extras_require]
 ode =
@@ -18,7 +26,3 @@ ode =
 tests =
     pytest
     coverage
-
-zip_safe = false
-include_package_data = True
-python_requires = >=3.7

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for MIRA."""

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -1,0 +1,24 @@
+"""Tests for the metamodel."""
+
+import unittest
+
+from mira.metamodel import Concept, ControlledConversion, NaturalConversion, Template
+
+
+class TestMetaModel(unittest.TestCase):
+    """A test case for the metamodel."""
+
+    def test_controlled_conversion(self):
+        """Test instantiating the controlled conversion."""
+        infected = Concept(name="infected population", identifiers={"ido": "0000511"})
+        susceptible = Concept(name="susceptible population", identifiers={"ido": "0000514"})
+        immune = Concept(name="immune population", identifiers={"ido": "0000592"})
+
+        t1 = ControlledConversion(
+            controller=immune,
+            subject=susceptible,
+            outcome=infected,
+        )
+        self.assertEqual(infected, t1.outcome)
+        self.assertEqual(susceptible, t1.subject)
+        self.assertEqual(immune, t1.controller)

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,8 @@ commands =
 description = Apply automatic formatters
 
 [testenv]
-deps =
-    pytest
-    coverage
+extras =
+    tests
 commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,15 @@
+
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+isolated_build = true
+envlist =
+    lint
+    py
+
 [testenv:lint]
 deps =
     black[jupyter]
@@ -7,3 +19,12 @@ commands =
     black . --line-length 120
     isort . --profile=black
 description = Apply automatic formatters
+
+[testenv]
+deps =
+    pytest
+    coverage
+commands =
+    coverage run -p -m pytest --durations=20 {posargs:tests}
+    coverage combine
+    coverage xml


### PR DESCRIPTION
This PR does the following:

1. Adds packaging using a declarative `setup.cfg` in combination with `pyproject.toml` (which allows for skipping having a `setup.py`)
2. Adds a simple test and configuration for running with `tox`
3. Adds a GitHub action that runs the tests via `tox`