### PR TITLE
Auto-generate JSON schema for metamodel templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 MIRA is a framework for representing systems using ontology-grounded **meta-model templates**, and generating various model implementations and exchange formats from these templates. It also implements algorithms for assembling and querying **domain knowledge graphs** in support of modeling.
 
+Template JSON schema: [schema.json](https://github.com/indralab/mira/blob/main/mira/metamodel/schema.json)
+
 ## Example notebooks
 
 * Defining multiple model variants using MIRA Templates: [Notebook](https://github.com/indralab/mira/blob/main/notebooks/metamodel_intro.ipynb)

--- a/mira/metamodel/__init__.py
+++ b/mira/metamodel/__init__.py
@@ -1,43 +1,15 @@
-__all__ = ["Concept", "Template", "Provenance", "ControlledConversion",
-           "NaturalConversion"]
+from .models import (
+    Concept,
+    ControlledConversion,
+    NaturalConversion,
+    Provenance,
+    Template,
+)
 
-import sys
-
-from typing import List, Mapping
-
-from pydantic import BaseModel, Field
-
-
-class Concept(BaseModel):
-    name: str = Field(..., description="The name of the concept.")
-    identifiers: Mapping[str, str] = Field(default_factory=dict,
-                                           description="A mapping of namespaces to identifiers.")
-    context: Mapping[str, str] = Field(default_factory=dict,
-                                       description="A mapping of context keys to values.")
-
-
-class Template(BaseModel):
-    @classmethod
-    def from_json(cls, data) -> "Template":
-        template_type = data.pop('type')
-        stmt_cls = getattr(sys.modules[__name__], template_type)
-        return stmt_cls(**data)
-
-
-class Provenance(BaseModel):
-    pass
-
-
-class ControlledConversion(Template):
-    type: str = Field("ControlledConversion", const=True)
-    controller: Concept
-    subject: Concept
-    outcome: Concept
-    provenance: List[Provenance] = Field(default_factory=list)
-
-
-class NaturalConversion(Template):
-    type: str = Field("NaturalConversion", const=True)
-    subject: Concept
-    outcome: Concept
-    provenance: List[Provenance] = Field(default_factory=list)
+__all__ = [
+    "Concept",
+    "Template",
+    "Provenance",
+    "ControlledConversion",
+    "NaturalConversion",
+]

--- a/mira/metamodel/__init__.py
+++ b/mira/metamodel/__init__.py
@@ -1,4 +1,4 @@
-from .models import (
+from .templates import (
     Concept,
     ControlledConversion,
     NaturalConversion,

--- a/mira/metamodel/models.py
+++ b/mira/metamodel/models.py
@@ -1,0 +1,71 @@
+__all__ = ["Concept", "Template", "Provenance", "ControlledConversion", "NaturalConversion"]
+
+import json
+import sys
+from pathlib import Path
+from typing import List, Mapping
+
+import pydantic
+from pydantic import BaseModel, Field
+
+HERE = Path(__file__).parent.resolve()
+SCHEMA_PATH = HERE.joinpath("schema.json")
+
+
+class Concept(BaseModel):
+    name: str = Field(..., description="The name of the concept.")
+    identifiers: Mapping[str, str] = Field(default_factory=dict, description="A mapping of namespaces to identifiers.")
+    context: Mapping[str, str] = Field(default_factory=dict, description="A mapping of context keys to values.")
+
+
+class Template(BaseModel):
+    @classmethod
+    def from_json(cls, data) -> "Template":
+        template_type = data.pop("type")
+        stmt_cls = getattr(sys.modules[__name__], template_type)
+        return stmt_cls(**data)
+
+
+class Provenance(BaseModel):
+    pass
+
+
+class ControlledConversion(Template):
+    type: str = Field("ControlledConversion", const=True)
+    controller: Concept
+    subject: Concept
+    outcome: Concept
+    provenance: List[Provenance] = Field(default_factory=list)
+
+
+class NaturalConversion(Template):
+    type: str = Field("NaturalConversion", const=True)
+    subject: Concept
+    outcome: Concept
+    provenance: List[Provenance] = Field(default_factory=list)
+
+
+def get_json_schema():
+    """Get the JSON schema for MIRA."""
+    rv = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://raw.githubusercontent.com/indralab/mira/main/mira/metamodel/schema.json",
+    }
+    rv.update(
+        pydantic.schema.schema(
+            [Concept, Template, NaturalConversion, ControlledConversion],
+            title="MIRA Metamodel Template Schema",
+            description="MIRA metamodel templates give a high-level abstraction of modeling appropriate for many domains.",
+        )
+    )
+    return rv
+
+
+def main():
+    """Generate the JSON schema file."""
+    schema = get_json_schema()
+    SCHEMA_PATH.write_text(json.dumps(schema, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/mira/metamodel/models.py
+++ b/mira/metamodel/models.py
@@ -1,3 +1,8 @@
+"""
+Data models for metamodel templates.
+
+Regenerate the JSON schema by running ``python -m mira.metamodel.models``.
+"""
 __all__ = ["Concept", "Template", "Provenance", "ControlledConversion", "NaturalConversion"]
 
 import json

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/indralab/mira/main/mira/metamodel/schema.json",
+  "title": "MIRA Metamodel Template Schema",
+  "description": "MIRA metamodel templates give a high-level abstraction of modeling appropriate for many domains.",
+  "definitions": {
+    "Concept": {
+      "title": "Concept",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the concept.",
+          "type": "string"
+        },
+        "identifiers": {
+          "title": "Identifiers",
+          "description": "A mapping of namespaces to identifiers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "context": {
+          "title": "Context",
+          "description": "A mapping of context keys to values.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "Template": {
+      "title": "Template",
+      "type": "object",
+      "properties": {}
+    },
+    "Provenance": {
+      "title": "Provenance",
+      "type": "object",
+      "properties": {}
+    },
+    "NaturalConversion": {
+      "title": "NaturalConversion",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "const": "NaturalConversion",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/definitions/Concept"
+        },
+        "outcome": {
+          "$ref": "#/definitions/Concept"
+        },
+        "provenance": {
+          "title": "Provenance",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Provenance"
+          }
+        }
+      },
+      "required": [
+        "subject",
+        "outcome"
+      ]
+    },
+    "ControlledConversion": {
+      "title": "ControlledConversion",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "const": "ControlledConversion",
+          "type": "string"
+        },
+        "controller": {
+          "$ref": "#/definitions/Concept"
+        },
+        "subject": {
+          "$ref": "#/definitions/Concept"
+        },
+        "outcome": {
+          "$ref": "#/definitions/Concept"
+        },
+        "provenance": {
+          "title": "Provenance",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Provenance"
+          }
+        }
+      },
+      "required": [
+        "controller",
+        "subject",
+        "outcome"
+      ]
+    }
+  }
+}

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -1,7 +1,7 @@
 """
 Data models for metamodel templates.
 
-Regenerate the JSON schema by running ``python -m mira.metamodel.models``.
+Regenerate the JSON schema by running ``python -m mira.metamodel.templates``.
 """
 __all__ = ["Concept", "Template", "Provenance", "ControlledConversion", "NaturalConversion"]
 

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -1,12 +1,19 @@
 """Tests for the metamodel."""
 
+import json
 import unittest
 
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion, Template
+from mira.metamodel.models import SCHEMA_PATH, get_json_schema
 
 
 class TestMetaModel(unittest.TestCase):
     """A test case for the metamodel."""
+
+    def test_schema(self):
+        """Test that the schema is up to date."""
+        self.assertTrue(SCHEMA_PATH.is_file())
+        self.assertEqual(get_json_schema(), json.loads(SCHEMA_PATH.read_text()))
 
     def test_controlled_conversion(self):
         """Test instantiating the controlled conversion."""

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -13,7 +13,11 @@ class TestMetaModel(unittest.TestCase):
     def test_schema(self):
         """Test that the schema is up to date."""
         self.assertTrue(SCHEMA_PATH.is_file())
-        self.assertEqual(get_json_schema(), json.loads(SCHEMA_PATH.read_text()))
+        self.assertEqual(
+            get_json_schema(),
+            json.loads(SCHEMA_PATH.read_text()),
+            msg="Regenerate an updated JSON schema by running `python -m mira.metamodel.models`",
+        )
 
     def test_controlled_conversion(self):
         """Test instantiating the controlled conversion."""

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -4,7 +4,7 @@ import json
 import unittest
 
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion, Template
-from mira.metamodel.models import SCHEMA_PATH, get_json_schema
+from mira.metamodel.templates import SCHEMA_PATH, get_json_schema
 
 
 class TestMetaModel(unittest.TestCase):
@@ -16,7 +16,7 @@ class TestMetaModel(unittest.TestCase):
         self.assertEqual(
             get_json_schema(),
             json.loads(SCHEMA_PATH.read_text()),
-            msg="Regenerate an updated JSON schema by running `python -m mira.metamodel.models`",
+            msg="Regenerate an updated JSON schema by running `python -m mira.metamodel.templates`",
         )
 
     def test_controlled_conversion(self):


### PR DESCRIPTION
This PR does the following:

1. Move the model definitions from `mira.metamodel.__init__` to`mira.metamodel.templates`
2. Add function for auto-generating a JSON schema based on the pydantic models
3. Add a test to make sure that we keep the JSON schema up to date

The JSON schema can be regenerated with `python -m mira.metamodel.templates`. There are notes in two places on how to do this.