### PR TITLE
Implement stratification

### DIFF
--- a/docs/source/modeling.rst
+++ b/docs/source/modeling.rst
@@ -2,4 +2,8 @@ Modeling
 ========
 .. automodule:: mira.modeling
 
+.. automodapi:: mira.modeling.ops
+
+.. automodapi:: mira.modeling.viz
+
 .. automodapi:: mira.modeling.ode

--- a/mira/modeling/ops.py
+++ b/mira/modeling/ops.py
@@ -40,6 +40,7 @@ def stratify(
     conversion_cls :
         The template class to be used for conversions between strata
         defined by the network structure. Defaults to :class:`NaturalConversion`
+
     Returns
     -------
     :

--- a/mira/modeling/ops.py
+++ b/mira/modeling/ops.py
@@ -3,8 +3,8 @@
 import itertools as itt
 from typing import Iterable, Optional, Set, Tuple, Type
 
-from .metamodel import ControlledConversion, NaturalConversion, Template
-from .modeling import TemplateModel
+from ..metamodel import ControlledConversion, NaturalConversion, Template
+from . import TemplateModel
 
 __all__ = [
     "stratify",
@@ -36,7 +36,7 @@ def stratify(
     :returns: A stratified template model
     """
     if structure is None:
-        structure = list(itt.combinations(strata, repeat=2))
+        structure = list(itt.combinations(strata, 2))
         directed = False
 
     concepts = _get_concepts(template_model)
@@ -47,13 +47,12 @@ def stratify(
         templates.append(template.with_context(**{key: stratum}))
     # Generate a conversion between each concept of each strata based on the network structure
     for (source_stratum, target_stratum), concept in itt.product(structure, concepts):
-        conversion = conversion_cls(
-            subject=concept.with_context(**{key: source_stratum}),
-            outcome=concept.with_context(**{key: target_stratum}),
-        )
-        templates.append(conversion)
+        subject = concept.with_context(**{key: source_stratum})
+        outcome = concept.with_context(**{key: target_stratum})
+        # todo will need to generalize for different kwargs for different conversions
+        templates.append(conversion_cls(subject=subject, outcome=outcome))
         if not directed:
-            templates.append(conversion.reversed())
+            templates.append(conversion_cls(subject=outcome, outcome=subject))
     return TemplateModel(templates=templates)
 
 

--- a/mira/modeling/ops.py
+++ b/mira/modeling/ops.py
@@ -25,15 +25,25 @@ def stratify(
     E.g., can turn the SIR model into a two-city SIR model by splitting each concept into
     two derived concepts, each with the context for one of the two cities
 
-    :param template_model: A template model
-    :param key: The (singular) name of the stratification, e.g., ``"city"``
-    :param strata: A list of the values for stratitication, e.g., ``["boston", "nyc"]``
-    :param structure: An iterable of pairs corresponding to a directed network structure
+    Parameters
+    ----------
+    template_model :
+        A template model
+    key :
+        The (singular) name of the stratification, e.g., ``"city"``
+    strata :
+        A list of the values for stratification, e.g., ``["boston", "nyc"]``
+    structure :
+        An iterable of pairs corresponding to a directed network structure
         where each of the pairs has two strata. If none given, will assume a complete
         network structure.
-    :param conversion_cls: The template class to be used for conversions between strata
+    conversion_cls :
+        The template class to be used for conversions between strata
         defined by the network structure. Defaults to :class:`NaturalConversion`
-    :returns: A stratified template model
+    Returns
+    -------
+    :
+        A stratified template model
     """
     if structure is None:
         structure = list(itt.combinations(strata, 2))

--- a/mira/modeling/ops.py
+++ b/mira/modeling/ops.py
@@ -1,0 +1,71 @@
+"""Operations for template models."""
+
+import itertools as itt
+from typing import Iterable, Optional, Set, Tuple, Type
+
+from .metamodel import ControlledConversion, NaturalConversion, Template
+from .modeling import TemplateModel
+
+__all__ = [
+    "stratify",
+]
+
+
+def stratify(
+    template_model: TemplateModel,
+    *,
+    key: str,
+    strata: Set[str],
+    structure: Optional[Iterable[Tuple[str, str]]] = None,
+    directed: bool = False,
+    conversion_cls: Type[Template] = NaturalConversion,
+) -> TemplateModel:
+    """Multiplies a model into several strata.
+
+    E.g., can turn the SIR model into a two-city SIR model by splitting each concept into
+    two derived concepts, each with the context for one of the two cities
+
+    :param template_model: A template model
+    :param key: The (singular) name of the stratification, e.g., ``"city"``
+    :param strata: A list of the values for stratitication, e.g., ``["boston", "nyc"]``
+    :param structure: An iterable of pairs corresponding to a directed network structure
+        where each of the pairs has two strata. If none given, will assume a complete
+        network structure.
+    :param conversion_cls: The template class to be used for conversions between strata
+        defined by the network structure. Defaults to :class:`NaturalConversion`
+    :returns: A stratified template model
+    """
+    if structure is None:
+        structure = list(itt.combinations(strata, repeat=2))
+        directed = False
+
+    concepts = _get_concepts(template_model)
+
+    templates = []
+    # Generate a derived template for each strata
+    for stratum, template in itt.product(strata, template_model.templates):
+        templates.append(template.with_context(**{key: stratum}))
+    # Generate a conversion between each concept of each strata based on the network structure
+    for (source_stratum, target_stratum), concept in itt.product(structure, concepts):
+        conversion = conversion_cls(
+            subject=concept.with_context(**{key: source_stratum}),
+            outcome=concept.with_context(**{key: target_stratum}),
+        )
+        templates.append(conversion)
+        if not directed:
+            templates.append(conversion.reversed())
+    return TemplateModel(templates=templates)
+
+
+def _get_concepts(template_model: TemplateModel):
+    return list({concept.get_key(): concept for concept in _iter_concepts(template_model)}.values())
+
+
+def _iter_concepts(template_model: TemplateModel):
+    for template in template_model.templates:
+        if isinstance(template, ControlledConversion):
+            yield from (template.subject, template.outcome, template.controller)
+        elif isinstance(template, NaturalConversion):
+            yield from (template.subject, template.outcome)
+        else:
+            raise TypeError(f"could not handle template: {template}")

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from mira.examples import cities, sir, sir_2_city
+from mira.examples.sir import cities, sir, sir_2_city
 from mira.metamodel import NaturalConversion
 from mira.modeling import TemplateModel
 from mira.modeling.ops import stratify

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,20 @@
+"""Tests for operations on template models."""
+
+import unittest
+
+from mira.examples import cities, sir, sir_2_city
+from mira.metamodel import NaturalConversion
+from mira.modeling import TemplateModel
+from mira.modeling.ops import stratify
+
+
+class TestOperations(unittest.TestCase):
+    """A test case for operations on template models."""
+
+    def test_stratify(self):
+        """Test stratifying a template model by labels."""
+        actual = stratify(sir, key="city", strata=cities)
+        self.assertEqual(
+            {template.get_key() for template in sir_2_city.templates},
+            {template.get_key() for template in actual.templates},
+        )


### PR DESCRIPTION
This PR implements `stratify()`, which multiplies a model into several strata. For example, can turn the SIR model into a two-city SIR model by splitting each concept into two derived concepts, each with the context for one of the two cities. This is accomplished with the following:

```python
from mira.examples.sir import sir
from mira.modeling.ops import stratify

sir_2_city = stratify(
    sir,
    key="city",
    strata=[
        "geonames:5128581",  # NYC
        "geonames:4930956",  # boston
    ],
)
```

For when there are more than two strata, it also allows for the specification of the network structure in case you don't want a fully connected network of all strata (e.g., if you only want to model train connections between cities)

```python
from mira.examples.sir import sir
from mira.modeling.ops import stratify

sir_3_city = stratify(
    sir,
    key="city",
    strata=[
        "geonames:5128581",  # NYC
        "geonames:4839366", # New Haven
        "geonames:4930956",  # Boston
    ],
    structure=[
        ("geonames:5128581", "geonames:4839366"),  # train from NYC to New Haven
        ("geonames:4839366", "geonames:4930956"),  # train from New Haven to Boston
    ],
)
```

## Example

![MIRA Stratification](https://user-images.githubusercontent.com/5069736/184621860-51bdd871-db52-4011-b145-b7b8b4d9fafe.png)


