### PR TITLE
Add minimum optional code and documentation QA checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Template JSON schema: [schema.json](https://github.com/indralab/mira/blob/main/m
 
 ## Example notebooks
 
-* Defining multiple model variants using MIRA Templates: [Notebook](https://github.com/indralab/mira/blob/main/notebooks/metamodel_intro.ipynb)
-* Generating an executable model from MIRA Templates and running simulation: [Notebook](https://github.com/indralab/mira/blob/main/notebooks/simulation.ipynb)
+* Defining multiple model variants using MIRA Templates: [Notebook 1](https://github.com/indralab/mira/blob/main/notebooks/metamodel_intro.ipynb)
+* Generating an executable model from MIRA Templates and running simulation: [Notebook 2](https://github.com/indralab/mira/blob/main/notebooks/simulation.ipynb)
 
 ## Related work
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
+    "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -68,12 +68,13 @@ class Model:
                 tkey = get_transition_key((s.key, o.key), template.type)
                 p = self.get_create_parameter(
                     Parameter(get_parameter_key(tkey, 'rate')))
-                self.get_create_transition(Transition(tkey,
-                                                      consumed=(s,),
-                                                      produced=(o,),
-                                                      control=tuple(),
-                                                      rate=p)
-                                            )
+                self.get_create_transition(Transition(
+                    tkey,
+                    consumed=(s,),
+                    produced=(o,),
+                    control=tuple(),
+                    rate=p,
+                ))
             elif isinstance(template, ControlledConversion):
                 s = self.get_create_variable(
                     Variable(get_variable_key(template.subject)))
@@ -84,12 +85,13 @@ class Model:
                 tkey = get_transition_key((s.key, o.key, c.key), template.type)
                 p = self.get_create_parameter(
                     Parameter(get_parameter_key(tkey, 'rate')))
-                self.get_create_transition(Transition(tkey,
-                                                      consumed=(s,),
-                                                      produced=(o,),
-                                                      control=(c,),
-                                                      rate=p)
-                                            )
+                self.get_create_transition(Transition(
+                    tkey,
+                    consumed=(s,),
+                    produced=(o,),
+                    control=(c,),
+                    rate=p,
+                ))
 
     def get_create_variable(self, variable):
         if variable.key not in self.variables:

--- a/mira/modeling/ode.py
+++ b/mira/modeling/ode.py
@@ -18,9 +18,9 @@ class OdeModel:
 
         self.kinetics = [sympy.Add() for _ in self.y]
         for transition in model.transitions.values():
-            rate = self.p[self.pmap[transition.rate.key]] * \
-                   sympy.Mul(
-                       *[self.y[self.vmap[c.key]] for c in transition.consumed])
+            rate = self.p[self.pmap[transition.rate.key]] * sympy.Mul(
+                *[self.y[self.vmap[c.key]] for c in transition.consumed]
+            )
             for c in transition.control:
                 rate *= self.y[self.vmap[c.key]]
             for c in transition.consumed:
@@ -52,4 +52,3 @@ def simulate_ode_model(ode_model: OdeModel, initials,
     for idx, time in enumerate(times[1:]):
         res[idx + 1, :] = solver.integrate(time)
     return res
-

--- a/mira/modeling/viz.py
+++ b/mira/modeling/viz.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Union
 
 import pygraphviz as pgv
-from typing_extensions import Self
 
 from mira.modeling import Model
 
@@ -69,9 +68,14 @@ class GraphicalModel:
     def write(self, path: Union[str, Path], prog: str = "dot", args: str = "") -> None:
         """Write the graphical representation to a file.
 
-        :param path: The path to the output file
-        :param prog: The graphviz layout program to use, such as "dot", "neato", etc.
-        :param args: Additional arguments to pass to the graphviz bash program
+        Parameters
+        ----------
+        path :
+            The path to the output file
+        prog :
+            The graphviz layout program to use, such as "dot", "neato", etc.
+        args :
+            Additional arguments to pass to the graphviz bash program
         """
         path = Path(path).expanduser().resolve()
         self.graph.draw(path, prog=prog, args=args)

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ docs =
     sphinx-automodapi
     autodoc-pydantic
     m2r2
+    pygraphviz
 
 ##########################
 # Darglint Configuration #

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,26 @@ docs =
     sphinx-automodapi
     autodoc-pydantic
     m2r2
+
+##########################
+# Darglint Configuration #
+##########################
+[darglint]
+docstring_style = numpy
+strictness = short
+
+#########################
+# Flake8 Configuration  #
+# (.flake8)             #
+#########################
+[flake8]
+ignore =
+    E203
+    E501  # line length
+    DAR005  # missing type annotation in documentation
+    DAR103  # type annotation mismatch
+max-line-length = 120
+import-order-style = pycharm
+application-import-names =
+    mira
+    tests

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -3,7 +3,7 @@
 import json
 import unittest
 
-from mira.metamodel import Concept, ControlledConversion, NaturalConversion, Template
+from mira.metamodel import Concept, ControlledConversion
 from mira.metamodel.templates import SCHEMA_PATH, get_json_schema
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,4 @@ deps =
     darglint
     flake8<5.0.0
 commands =
-    flake8 mira/
+    flake8 mira/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,10 @@ extras =
     ode
 commands =
     python -m sphinx -W -b {posargs:html} -d docs/build/doctrees docs/source docs/build/{posargs:html}
+
+[testenv:flake8]
+deps =
+    darglint
+    flake8<5.0.0
+commands =
+    flake8 mira/


### PR DESCRIPTION
This PR adds a minimum flake8 configuration, makes a few style tweaks for flake8 to pass, and adds the darglint checker that makes sure documentation is written in the numpy style. This can be run locally with `tox -e flake8` to check that the docstrings are written in full and have the right style as well as the other standard flake8 checks

This PR doesn't enable flake8 during CI, thought that would be highly recommended in the future (along with enforcing black code style, for example)