### PR TITLE
Switch API to FastAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 import.report
+scratch/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN sed -i 's/#dbms.default_listen_address/dbms.default_listen_address/' /etc/ne
 RUN apt-get install -y git wget zip unzip bzip2 gcc graphviz graphviz-dev \
         pkg-config python3 python3-pip && \
     ln -s /usr/bin/python3 /usr/bin/python && \
-    python -m pip install git+https://github.com/indralab/mira.git@main#egg=mira[web,gunicorn] && \
+    python -m pip install git+https://github.com/indralab/mira.git@main#egg=mira[web,uvicorn] && \
     python -m pip uninstall -y flask_bootstrap && \
     python -m pip uninstall -y bootstrap_flask && \
     python -m pip install bootstrap_flask

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -2,4 +2,4 @@
 neo4j start
 sleep 100
 neo4j status
-gunicorn --bind 0.0.0.0:8771 mira.dkg.wsgi:app
+uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -87,6 +87,8 @@ def get_relations(relation_query: RelationQuery, request: Request):
     to the following query:
 
         {"target_curie": "ncbitaxon:10090", "relation": vo:0001243"}
+
+    Note that you will rarely use all possible values in this endpoint at the same time.
     """
     records = request.app.state.client.query_relations(
         source_type=relation_query.source_type,
@@ -103,8 +105,6 @@ def get_relations(relation_query: RelationQuery, request: Request):
         distinct=relation_query.distinct,
         limit=relation_query.limit,
     )
-    if query:
-        print("invalid stuff remains in query:", query)
     if relation_query.full:
         records = [
             (dict(s), dict(p) if isinstance(p, Relationship) else [dict(r) for r in p], dict(o))

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -1,8 +1,10 @@
 """API endpoints."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from flask import Blueprint, jsonify, request
 from neo4j.graph import Relationship
+
+from mira.dkg.client import Entity
 
 from .proxies import client
 
@@ -16,8 +18,8 @@ api_blueprint = APIRouter(
 
 
 @api_blueprint.route("/entity/{curie}")
-def get_entity(curie: str):
-    """Get information about an entity
+def get_entity(request: Request, curie: str) -> Entity:
+    """Get information about an entity.
 
     ---
     parameters:
@@ -27,7 +29,7 @@ def get_entity(curie: str):
       required: true
       example: vo:0000001
     """
-    return jsonify(client.get_entity(curie))
+    return request.app.client.get_entity(curie)
 
 
 @api_blueprint.route("/lexical")

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -12,36 +12,29 @@ __all__ = [
     "api_blueprint",
 ]
 
-api_blueprint = APIRouter(
-    prefix="/api",
-)
+api_blueprint = APIRouter()
 
 
-@api_blueprint.route("/entity/{curie}")
-def get_entity(request: Request, curie: str) -> Entity:
-    """Get information about an entity.
+@api_blueprint.get("/entity/{curie}", response_model=Entity)
+def get_entity(curie: str, request: Request):
+    """Get information about an entity based on its compact URI (CURIE).
 
-    ---
-    parameters:
-    - name: curie
-      description: A compact URI (CURIE)
-      in: path
-      required: true
-      example: vo:0000001
+    Parameters
+    ----------
+    curie :
+        A compact URI (CURIE) for an entity in the form of <prefix>:<local unique identifier>
     """
-    return request.app.client.get_entity(curie)
+    # vo:0000001
+    return request.app.neo4j_client.get_entity(curie)
 
 
-@api_blueprint.route("/lexical")
+@api_blueprint.get("/lexical")
 def get_lexical():
-    """Get information about an entity.
-
-    ---
-    """
-    return jsonify(client.get_lexical())
+    """Get information about an entity."""
+    return request.app.neo4j_client.get_lexical()
 
 
-@api_blueprint.route("/relations", methods=["POST"])
+@api_blueprint.post("/relations")
 def get_relations():
     """Get relations based on the query sent.
 

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -1,5 +1,6 @@
 """API endpoints."""
 
+from fastapi import APIRouter
 from flask import Blueprint, jsonify, request
 from neo4j.graph import Relationship
 
@@ -9,11 +10,13 @@ __all__ = [
     "api_blueprint",
 ]
 
-api_blueprint = Blueprint("api", __name__)
+api_blueprint = APIRouter(
+    prefix="/api",
+)
 
 
-@api_blueprint.route("/entity/<curie>")
-def get_entity(curie):
+@api_blueprint.route("/entity/{curie}")
+def get_entity(curie: str):
     """Get information about an entity
 
     ---

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -74,7 +74,7 @@ def get_lexical(request: Request):
     return request.app.state.client.get_lexical()
 
 
-@api_blueprint.post("/relations")
+@api_blueprint.post("/relations", response_model=List)
 def get_relations(relation_query: RelationQuery, request: Request):
     """Get relations based on the query sent.
 

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -55,7 +55,7 @@ class RelationQuery(BaseModel):
     )
 
 
-@api_blueprint.get("/entity/{curie}", response_model=Entity)
+@api_blueprint.get("/entity/{curie}", response_model=Entity, tags=["entities"])
 def get_entity(curie: str, request: Request):
     """Get information about an entity based on its compact URI (CURIE).
 
@@ -68,13 +68,13 @@ def get_entity(curie: str, request: Request):
     return request.app.state.client.get_entity(curie)
 
 
-@api_blueprint.get("/lexical", response_model=List[LexicalRow])
+@api_blueprint.get("/lexical", response_model=List[LexicalRow], tags=["entities"])
 def get_lexical(request: Request):
     """Get information about an entity."""
     return request.app.state.client.get_lexical()
 
 
-@api_blueprint.post("/relations", response_model=List)
+@api_blueprint.post("/relations", response_model=List, tags=["relations"])
 def get_relations(relation_query: RelationQuery, request: Request):
     """Get relations based on the query sent.
 

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -1,10 +1,14 @@
 """API endpoints."""
 
+from typing import List, Optional, Union
+
 from fastapi import APIRouter, Request
 from flask import Blueprint, jsonify, request
 from neo4j.graph import Relationship
+from pydantic import BaseModel, Field
+from typing_extensions import Literal
 
-from mira.dkg.client import Entity
+from mira.dkg.client import Entity, LexicalRow
 
 from .proxies import client
 
@@ -13,6 +17,45 @@ __all__ = [
 ]
 
 api_blueprint = APIRouter()
+
+
+class RelationQuery(BaseModel):
+    """A query for relations in the domain knowledge graph."""
+
+    source_type: Optional[str] = Field(description="The source type (i.e., prefix)", example="vo")
+    source_curie: Optional[str] = Field(
+        description="The source compact URI (CURIE)", example="doid:946"
+    )
+    target_type: Optional[str] = Field(
+        description="The target type (i.e., prefix)", example="ncbitaxon"
+    )
+    target_curie: Optional[str] = Field(
+        description="The target compact URI (CURIE)", example="ncbitaxon:10090"
+    )
+    relations: Union[None, str, List[str]] = Field(
+        description="A relation string or list of relation strings", example="vo:0001243"
+    )
+    relation_direction: Literal["right", "left", "both"] = Field(
+        "right", description="The direction of the relationship"
+    )
+    relation_min_hops: int = Field(
+        1, description="The minimum number of relationships between the subject and object.", ge=1
+    )
+    relation_max_hops: int = Field(
+        1,
+        description="The maximum number of relationships between the subject and object. Set to 0 to make infinite.",
+        ge=0,
+    )
+    limit: Optional[int] = Field(
+        description="A limit on the number of records returned", example=50, ge=0
+    )
+    full: bool = Field(
+        False,
+        description="A flag to turn on full entity and relation metadata return. Warning, this gets pretty verbose.",
+    )
+    distinct: bool = Field(
+        False, description="A flag to turn on the DISTINCT flag in the return of a cypher query"
+    )
 
 
 @api_blueprint.get("/entity/{curie}", response_model=Entity)
@@ -28,14 +71,14 @@ def get_entity(curie: str, request: Request):
     return request.app.neo4j_client.get_entity(curie)
 
 
-@api_blueprint.get("/lexical")
+@api_blueprint.get("/lexical", response_model=List[LexicalRow])
 def get_lexical():
     """Get information about an entity."""
     return request.app.neo4j_client.get_lexical()
 
 
 @api_blueprint.post("/relations")
-def get_relations():
+def get_relations(relation_query: RelationQuery):
     """Get relations based on the query sent.
 
     The question *which hosts get immunized by the Brucella
@@ -47,96 +90,30 @@ def get_relations():
     to the following query:
 
         {"target_curie": "ncbitaxon:10090", "relation": vo:0001243"}
-    ---
-    parameters:
-    - name: source_type
-      description: The source type (i.e., prefix)
-      in: body
-      required: false
-      example: doid
-    - name: source_curie
-      description: The source CURIE
-      in: body
-      required: false
-      example: doid:946
-
-    - name: target_type
-      description: The target type (i.e., prefix)
-      in: body
-      required: false
-      example: symp
-    - name: target_curie
-      description: The target CURIE
-      in: body
-      required: false
-      example: symp:0000570
-
-    - name: relations
-      description: A relation string or list of relation strings
-      in: body
-      required: false
-      example: vo:0001243
-    - name: relation_direction
-      description: The direction of the relationship
-      in: body
-      required: false
-      example: right
-      schema:
-        type: string
-        enum: ["right", "left", "both"]
-        default: "right"
-    - name: relation_min_hops
-      description: The minimum number of hops between the entitis
-      in: body
-      required: false
-      example: 1
-      schema:
-        type: integer
-        minimum: 1
-        default: 1
-    - name: relation_max_hops
-      description: The maximum number of hops between the entities. If 0 is given, makes infinite.
-      in: body
-      required: false
-      example: 0
-      schema:
-        type: integer
-        minimum: 0
-        default: 1
-
-    - name: limit
-      description: A limit on the number of records returned
-      in: body
-      required: false
-      example: 50
-      schema:
-        type: integer
-        minimum: 1
     """
-    query = dict(request.json)
-    full = query.pop("full", False)
     records = client.query_relations(
-        source_type=query.pop("source_type", None),
-        source_curie=query.pop("source_curie", None),
+        source_type=relation_query.source_type,
+        source_curie=relation_query.source_curie,
         relation_name="r",
-        relation_type=_get_relations(query),
-        relation_direction=query.pop("relation_direction", "right"),
-        relation_min_hops=query.pop("relation_min_hops", 1),
-        relation_max_hops=query.pop("relation_max_hops", 1),
+        relation_type=query.relations,
+        relation_direction=relation_query.relation_direction,
+        relation_min_hops=relation_query.relation_min_hops,
+        relation_max_hops=relation_query.relation_max_hops,
         target_name="t",
-        target_type=query.pop("target_type", None),
-        target_curie=query.pop("target_curie", None),
-        full=full,
-        distinct=query.pop("distinct", False),
-        limit=query.pop("limit", None),
+        target_type=relation_query.target_type,
+        target_curie=relation_query.target_curie,
+        full=relation_query.full,
+        distinct=relation_query.distinct,
+        limit=relation_query.limit,
     )
     if query:
         print("invalid stuff remains in query:", query)
-    if full:
+    if relation_query.full:
         records = [
-            (dict(s), dict(p) if isinstance(p, Relationship) else [dict(r) for r in p], dict(o)) for s, p, o in records
+            (dict(s), dict(p) if isinstance(p, Relationship) else [dict(r) for r in p], dict(o))
+            for s, p, o in records
         ]
-    return jsonify(records)
+    return records
 
 
 def _get_relations(query):

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -14,7 +14,7 @@ from gilda.grounder import Grounder
 from gilda.process import normalize
 from gilda.term import Term
 from neo4j import GraphDatabase
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from tqdm import tqdm
 from typing_extensions import Literal, TypeAlias
 
@@ -30,14 +30,15 @@ TxResult: TypeAlias = Optional[List[List[Any]]]
 class Entity(BaseModel):
     """An entity in the domain knowledge graph."""
 
-    synonyms: List[str]
-    alts: List[str]
-    name: str
-    obsolete: bool
-    xrefs: List[str]
     id: str
+    name: str
     type: str
-    labels: List[str]
+    obsolete: bool
+    description: Optional[str] = None
+    synonyms: List[str] = Field(default_factory=list)
+    alts: List[str] = Field(default_factory=list)
+    xrefs: List[str] = Field(default_factory=list)
+    labels: List[str]= Field(default_factory=list)
 
 
 class Neo4jClient:

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -47,7 +47,7 @@ class GroundResults(BaseModel):
 
 
 @grounding_blueprint.post("/ground", response_model=GroundResults)
-def ground(ground_request: GroundRequest, request: Request) -> GroundResults:
+def ground(ground_request: GroundRequest, request: Request):
     """Ground text with Gilda."""
     return _ground(
         request=request,
@@ -58,7 +58,7 @@ def ground(ground_request: GroundRequest, request: Request) -> GroundResults:
     )
 
 
-@grounding_blueprint.get("/ground/<text>", response_model=GroundResults)
+@grounding_blueprint.get("/ground/{text}", response_model=GroundResults)
 def ground_get(text: str, request: Request):
     """Ground text with Gilda."""
     return _ground(request=request, text=text)

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -31,7 +31,7 @@ class GroundResult(BaseModel):
     def from_scored_match(cls, scored_match: ScoredMatch) -> "GroundResult":
         identifier = scored_match.term.id
         if identifier.startswith(scored_match.term.db):
-            identifier = identifier[len(scored_match.term.db) + 1:]
+            identifier = identifier[len(scored_match.term.db) + 1 :]
         return cls(
             url=scored_match.url,
             score=scored_match.score,

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -2,8 +2,8 @@
 
 from typing import List, Optional
 
-from gilda.grounder import ScoredMatch
 from fastapi import APIRouter, Request
+from gilda.grounder import ScoredMatch
 from pydantic import BaseModel, Field
 
 __all__ = [
@@ -57,5 +57,5 @@ def _ground(request: Request, text: str) -> GroundResults:
     results = request.app.state.grounder.ground(text)
     return GroundResults(
         query=text,
-        results=[GroundResult.from_scored_match(scored_match) for scored_match in results]
+        results=[GroundResult.from_scored_match(scored_match) for scored_match in results],
     )

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -46,7 +46,7 @@ class GroundResults(BaseModel):
     results: List[GroundResult]
 
 
-@grounding_blueprint.post("/ground", response_model=GroundResults)
+@grounding_blueprint.post("/ground", response_model=GroundResults, tags=["grounding"])
 def ground(ground_request: GroundRequest, request: Request):
     """Ground text with Gilda."""
     return _ground(
@@ -58,7 +58,7 @@ def ground(ground_request: GroundRequest, request: Request):
     )
 
 
-@grounding_blueprint.get("/ground/{text}", response_model=GroundResults)
+@grounding_blueprint.get("/ground/{text}", response_model=GroundResults, tags=["grounding"])
 def ground_get(text: str, request: Request):
     """Ground text with Gilda."""
     return _ground(request=request, text=text)

--- a/mira/dkg/templates/base.html
+++ b/mira/dkg/templates/base.html
@@ -46,7 +46,7 @@
     <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav">
             <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('flasgger.apidocs') }}">API</a>
+                <a class="nav-link" href="/docs">API</a>
             </li>
         </ul>
     </div>

--- a/mira/dkg/templates/entity.html
+++ b/mira/dkg/templates/entity.html
@@ -7,9 +7,11 @@
 {% block container %}
     <div class="card card-body">
         <dl>
-            {% for k,v in entity.items()|sort %}
-                <dt>{{ k }}</dt>
-                <dd>{{ v }}</dd>
+            {% for k,v in entity.dict().items()|sort %}
+                {% if v %}
+                    <dt>{{ k }}</dt>
+                    <dd>{{ v }}</dd>
+                {% endif %}
             {% endfor %}
         </dl>
     </div>

--- a/mira/dkg/templates/home.html
+++ b/mira/dkg/templates/home.html
@@ -24,8 +24,8 @@
         <h4>Grounding</h4>
         <p>
             Identify a standard database identifier for a string using GET request to <code>/ground/&lt;text&gt;</code>
-            to see grounding results such as <a href="{{ url_for("grounding.ground_get", text="vaccine") }}">
-            <code>/ground/vaccine</code></a>
+            to see grounding results such as <a href="/api/ground/vaccine">
+            <code>/api/ground/vaccine</code></a>
         </p>
     </div>
 {% endblock %}

--- a/mira/dkg/ui.py
+++ b/mira/dkg/ui.py
@@ -4,7 +4,7 @@ import flask
 from flask import Blueprint, Response, render_template, request
 from gilda.grounder import ScoredMatch
 
-from .proxies import grounder, client
+from .proxies import client, grounder
 
 __all__ = ["ui_blueprint"]
 

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -16,22 +16,14 @@ __all__ = [
     "flask_app",
 ]
 
-app = FastAPI()
+app = FastAPI(
+    title="MIRA Domain Knowledge Graph",
+    description="A service for building and interacting with domain knowledge graphs",
+)
 app.include_router(api_blueprint, prefix="/api")
 
 flask_app = flask.Flask(__name__)
 
-Swagger.DEFAULT_CONFIG.update(
-    {
-        "info": {
-            "title": "MIRA Domain Knowledge Graph",
-            "description": "A service for building and interacting with domain knowledge graphs",
-        },
-        # This is where the OpenAPI gets mounted
-        "specs_route": "/apidocs/",
-    }
-)
-Swagger(flask_app)
 Bootstrap5(flask_app)
 
 # Set MIRA_NEO4J_URL in the environment
@@ -46,3 +38,4 @@ flask_app.register_blueprint(ui_blueprint)
 flask_app.register_blueprint(grounding_blueprint)
 
 app.mount("/", WSGIMiddleware(flask_app))
+app.client = client

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -14,6 +14,7 @@ from mira.dkg.utils import PREFIXES, MiraState
 
 __all__ = [
     "flask_app",
+    "app",
 ]
 
 app = FastAPI(

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -1,5 +1,7 @@
 """Neo4j client module."""
 
+from textwrap import dedent
+
 import flask
 from fastapi import FastAPI
 from fastapi.middleware.wsgi import WSGIMiddleware
@@ -17,9 +19,37 @@ __all__ = [
     "app",
 ]
 
+tags_metadata = [
+    {
+        "name": "grounding",
+        "description": "Identify appropriate ontology/database terms for text using Gilda.",
+        "externalDocs": {
+            # "description": "Gilda is a Python package and REST service that grounds (i.e., finds appropriate identifiers in namespaces for) named entities in biomedical text.",
+            "url": "https://github.com/indralab/gilda",
+        },
+    },
+]
+
+
 app = FastAPI(
+    openapi_tags=tags_metadata,
     title="MIRA Domain Knowledge Graph",
-    description="A service for building and interacting with domain knowledge graphs",
+    description=dedent(
+        """\
+    A service for building and interacting with domain knowledge graphs.
+
+    Further information can be found at:
+    - https://github.com/indralab/mira
+    """
+    ),
+    contact={
+        "name": "Benjamin M. Gyori",
+        "email": "benjamin_gyori@hms.harvard.edu",
+    },
+    license_info={
+        "name": "BSD-2-Clause license",
+        "url": "https://github.com/indralab/mira/blob/main/LICENSE",
+    },
 )
 app.include_router(api_blueprint, prefix="/api")
 app.include_router(grounding_blueprint, prefix="/api")

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -21,6 +21,7 @@ app = FastAPI(
     description="A service for building and interacting with domain knowledge graphs",
 )
 app.include_router(api_blueprint, prefix="/api")
+app.include_router(grounding_blueprint, prefix="/api")
 
 flask_app = flask.Flask(__name__)
 
@@ -29,13 +30,11 @@ Bootstrap5(flask_app)
 # Set MIRA_NEO4J_URL in the environment
 # to point this somewhere specific
 client = Neo4jClient()
-flask_app.config["mira"] = MiraState(
+app.state = flask_app.config["mira"] = MiraState(
     client=client,
     grounder=client.get_grounder(PREFIXES),
 )
 
 flask_app.register_blueprint(ui_blueprint)
-flask_app.register_blueprint(grounding_blueprint)
 
 app.mount("/", WSGIMiddleware(flask_app))
-app.client = client

--- a/notebooks/dkg_api.ipynb
+++ b/notebooks/dkg_api.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "94e747b1",
    "metadata": {},
    "source": [
     "## Using the MIRA Domain Knowledge Graph REST API\n",
@@ -17,6 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "701e2dec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,6 +27,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1d354304",
    "metadata": {},
    "source": [
     "Below we refer to the URL of a public MIRA epidemiology DKG instance. The URL is subject to change later."
@@ -33,6 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "f35998bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,6 +45,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "da56999c",
    "metadata": {},
    "source": [
     "### Export lexical information from the DKG\n",
@@ -49,7 +54,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
+   "id": "3055bd64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,6 +64,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8e1d9529",
    "metadata": {},
    "source": [
     "The result is a list of lists, where elements in each list include the CURIE label of the node, its standard name, its list of synonyms and its description."
@@ -65,7 +72,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
+   "id": "fea3977e",
    "metadata": {
     "scrolled": true
    },
@@ -83,7 +91,7 @@
        " ['vo:0000216', 'pCMV-1 DNA vaccine plasmid', None, None]]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -94,6 +102,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2c2d07a2",
    "metadata": {},
    "source": [
     "### Structured graph pattern queries in the DKG\n",
@@ -102,7 +111,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
+   "id": "642f3977",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,6 +124,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4a00ace0",
    "metadata": {},
    "source": [
     "#### Find relations with a given type of source node\n",
@@ -122,7 +133,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
+   "id": "2dae3ea6",
    "metadata": {},
    "outputs": [
     {
@@ -132,7 +144,7 @@
        " ['vo:0000000', 'rdfs:subClassOf', 'vo:0000420']]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -143,6 +155,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "200ac26a",
    "metadata": {},
    "source": [
     "#### Find relations with a given type of target node\n",
@@ -151,7 +164,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
+   "id": "11eb7730",
    "metadata": {
     "scrolled": true
    },
@@ -163,7 +177,7 @@
        " ['symp:0000375', 'rdfs:subClassOf', 'symp:0000001']]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -174,6 +188,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a385c2b9",
    "metadata": {},
    "source": [
     "#### Find relations between a given type of source node and target node\n",
@@ -182,7 +197,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
+   "id": "82e50571",
    "metadata": {},
    "outputs": [
     {
@@ -192,7 +208,7 @@
        " ['doid:946', 'ro:0002452', 'symp:0000001']]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -203,6 +219,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3c468057",
    "metadata": {},
    "source": [
     "#### Find relations with a specific source node\n",
@@ -211,7 +228,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
+   "id": "42389a2c",
    "metadata": {},
    "outputs": [
     {
@@ -221,7 +239,7 @@
        " ['doid:946', 'ro:0002452', 'symp:0000570']]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -232,6 +250,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "12740b81",
    "metadata": {},
    "source": [
     "#### Find relations with a specific target node\n",
@@ -240,7 +259,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
+   "id": "639dc677",
    "metadata": {},
    "outputs": [
     {
@@ -250,7 +270,7 @@
        " ['symp:0000738', 'rdfs:subClassOf', 'symp:0000570']]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -261,6 +281,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fbcd0009",
    "metadata": {},
    "source": [
     "#### Adding relation type constraints\n",
@@ -269,6 +290,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c084b5ad",
    "metadata": {},
    "source": [
     "Example: Query for subclass relations of a term in the Basic Formal Ontology (bfo:0000002)."
@@ -276,7 +298,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
+   "id": "0598ada3",
    "metadata": {},
    "outputs": [
     {
@@ -286,19 +309,18 @@
        " ['bfo:0000002', 'rdfs:subClassOf', 'bfo:0000001']]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "query({\"source_curie\": \"bfo:0000002\",\n",
-    "       \"relation\": \"rdfs:subClassOf\",\n",
-    "       \"limit\": 2})"
+    "query({\"source_curie\": \"bfo:0000002\", \"relation\": \"rdfs:subClassOf\", \"limit\": 2})"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "b790891f",
    "metadata": {},
    "source": [
     "#### Adding constraints on path length\n",
@@ -309,7 +331,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 12,
+   "id": "06c9aa0e",
    "metadata": {},
    "outputs": [
     {
@@ -319,7 +342,7 @@
        " ['bfo:0000002', ['rdfs:subClassOf', 'rdfs:subClassOf'], 'owl:Thing']]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -337,7 +360,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 13,
+   "id": "77bed7fc",
    "metadata": {},
    "outputs": [
     {
@@ -361,7 +385,7 @@
        "  'owl:Thing']]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,6 +404,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "25495f00",
    "metadata": {},
    "source": [
     "#### Querying over unconstrained path lengths\n",
@@ -390,7 +415,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 14,
+   "id": "e5ad2fd2",
    "metadata": {},
    "outputs": [
     {
@@ -509,7 +535,7 @@
        "  'owl:Thing']]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,6 +553,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "40ad81f4",
    "metadata": {},
    "source": [
     "#### Including node properties in results\n",
@@ -537,7 +564,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 15,
+   "id": "59f45966",
    "metadata": {},
    "outputs": [
     {
@@ -585,7 +613,7 @@
        "   'xrefs': ['icd9cm:787.91', 'umls:C0011991', 'umls.aui:A0048148']}]]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -597,7 +625,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -611,7 +639,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,13 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"
+
+[tool.black]
+line_length = 100
+target-version = ["py38", "py39", "py310"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+reverse_relative = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ dkg-construct =
     tabulate
     tqdm
 web =
+    fastapi
     flask
     flasgger
     bootstrap-flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,8 @@ web =
     neo4j
     pystow
     tabulate
+uvicorn =
+    uvicorn
 gunicorn =
     gunicorn
 docs =

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -11,7 +11,7 @@ import os
 MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
 
 
-@unittest.skipIf(MIRA_NEO4J_URL is None, reason="Missing neo4j connection configuration")
+@unittest.skipIf(bool(MIRA_NEO4J_URL), reason="Missing neo4j connection configuration")
 class TestDKG(unittest.TestCase):
     """Test the DKG."""
 

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -1,0 +1,27 @@
+"""Tests for the domain knowledge graph app."""
+
+import unittest
+from fastapi.testclient import TestClient
+from mira.dkg.wsgi import app, MiraState
+from gilda.grounder import Grounder
+
+
+class TestDKG(unittest.TestCase):
+    """Test the DKG."""
+
+    def setUp(self) -> None:
+        """Set up the test case."""
+        self.client = TestClient(app)
+
+    def test_state(self):
+        """Test the app is filled up with MIRA goodness."""
+        self.assertIsInstance(self.client.app.state, MiraState)
+
+    def test_grounding(self):
+        """Test grounding."""
+        response = self.client.get("/api/ground/vaccine")
+        self.assertEqual(200, response.status_code, msg=response.content)
+        self.assertTrue(any(
+            r["prefix"] == "vo" and r["identifier"] == "0000001"
+            for r in response.json()["results"]
+        ))

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -2,7 +2,6 @@
 
 import unittest
 from fastapi.testclient import TestClient
-from mira.dkg.wsgi import app
 from gilda.grounder import Grounder
 from mira.dkg.utils import MiraState
 
@@ -18,6 +17,8 @@ class TestDKG(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up the test case."""
+        from mira.dkg.wsgi import app
+
         self.client = TestClient(app)
 
     def test_state(self):

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -11,7 +11,7 @@ import os
 MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
 
 
-@unittest.skipIf(bool(MIRA_NEO4J_URL), reason="Missing neo4j connection configuration")
+@unittest.skipIf(not MIRA_NEO4J_URL, reason="Missing neo4j connection configuration")
 class TestDKG(unittest.TestCase):
     """Test the DKG."""
 

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -6,7 +6,13 @@ from mira.dkg.wsgi import app
 from gilda.grounder import Grounder
 from mira.dkg.utils import MiraState
 
+import pystow
+import os
 
+MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
+
+
+@unittest.skipIf(MIRA_NEO4J_URL is None, reason="Missing neo4j connection configuration")
 class TestDKG(unittest.TestCase):
     """Test the DKG."""
 

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -2,8 +2,9 @@
 
 import unittest
 from fastapi.testclient import TestClient
-from mira.dkg.wsgi import app, MiraState
+from mira.dkg.wsgi import app
 from gilda.grounder import Grounder
+from mira.dkg.utils import MiraState
 
 
 class TestDKG(unittest.TestCase):
@@ -16,6 +17,7 @@ class TestDKG(unittest.TestCase):
     def test_state(self):
         """Test the app is filled up with MIRA goodness."""
         self.assertIsInstance(self.client.app.state, MiraState)
+        self.assertIsInstance(self.client.app.state.grounder, Grounder)
 
     def test_grounding(self):
         """Test grounding."""

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,20 @@ deps =
     isort
 skip_install = true
 commands =
-    black . --line-length 120
-    isort . --profile=black
+    black \
+        mira/dkg \
+        mira/examples \
+        mira/modeling/ops.py \
+        mira/modeling/viz.py \
+        notebooks/dkg_api.ipynb \
+        tests/test_ops.py
+    isort \
+        mira/dkg \
+        mira/examples \
+        mira/modeling/ops.py \
+        mira/modeling/viz.py \
+        notebooks/dkg_api.ipynb \
+        tests/test_ops.py
 description = Apply automatic formatters
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ description = Apply automatic formatters
 [testenv]
 extras =
     tests
+    web
 commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine


### PR DESCRIPTION
This maintains the Flask application as middleware (whatever that means :p).

Now, you can run with `uvicorn mira.dkg.wsgi:app`

Two different flavors of API documentation are generated by FastAPI:
- http://localhost:8000/docs with OpenAPI / Swagger
- http://localhost:8000/redoc using https://redocly.com/