### PR TITLE
Template equality

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
           #cd ..
       - name: Test with pytest
         run: |
+          export MIRA_REST_URL=http://34.230.33.149:8771
           #export PYTHONPATH=$PYTHONPATH:`pwd`/automates/scripts/gromet/gromet_v1
           tox -e py
       - name: Upload coverage report to codecov

--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -49,4 +49,4 @@ PREFIXES = [
 
 
 #: A list of all relation types that are considered refinement relations
-dkg_refiner_rels = ["rdfs:subClassOf", "part_of"]
+DKG_REFINER_RELS = ["rdfs:subClassOf", "part_of"]

--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -9,6 +9,7 @@ from mira.dkg.client import Neo4jClient
 __all__ = [
     "MiraState",
     "PREFIXES",
+    "DKG_REFINER_RELS",
 ]
 
 

--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -46,3 +46,7 @@ PREFIXES = [
     # "chebi",
     # "mondo",
 ]
+
+
+#: A list of all relation types that are considered refinement relations
+dkg_refiner_rels = ["rdfs:subClassOf", "part_of"]

--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -50,4 +50,4 @@ PREFIXES = [
 
 
 #: A list of all relation types that are considered refinement relations
-DKG_REFINER_RELS = ["rdfs:subClassOf", "part_of"]
+DKG_REFINER_RELS = ["subclassof", "part_of"]

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -4,6 +4,8 @@ from typing import Optional, Union, List, Literal, Dict, Any
 import pystow
 import requests
 
+from mira.dkg.utils import dkg_refiner_rels
+
 
 def web_client(query_json: Dict[str, Any], endpoint: str, api_url: Optional[str] = None):
     """A wrapper for sending requests to the REST API"""
@@ -112,7 +114,6 @@ def is_ontological_child(child_curie: str, parent_curie: str) -> bool:
         True if the assumption that `child_curie` is an ontological child of
         `parent_curie` holds
     """
-    dkg_refiner_rels = ["rdfs:subClassOf", "part_of"]
     res = get_relations_web(
         source_curie=child_curie, relations=dkg_refiner_rels, target_curie=parent_curie
     )

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -4,8 +4,6 @@ from typing import Optional, Union, List, Literal, Dict, Any
 import pystow
 import requests
 
-dkg_refiner_rels = ["rdfs:subClassOf", "part_of"]
-
 
 def web_client(query_json: Dict[str, Any], endpoint: str, api_url: Optional[str] = None):
     """A wrapper for sending requests to the REST API"""
@@ -114,6 +112,7 @@ def is_ontological_child(child_curie: str, parent_curie: str) -> bool:
         True if the assumption that `child_curie` is an ontological child of
         `parent_curie` holds
     """
+    dkg_refiner_rels = ["rdfs:subClassOf", "part_of"]
     res = get_relations_web(
         source_curie=child_curie, relations=dkg_refiner_rels, target_curie=parent_curie
     )

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -21,7 +21,7 @@ def web_client(query_json: Dict[str, Any], endpoint: str, api_url: Optional[str]
             "parameter to this function."
         )
 
-    base_url = base_url + "/api" if not base_url.endswith("/api") else base_url
+    base_url = base_url.rstrip("/") + "/api" if not base_url.endswith("/api") else base_url
 
     endpoint_url = base_url + endpoint
     res = requests.post(endpoint_url, json=query_json)

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -1,0 +1,90 @@
+import os
+from typing import Optional, Union, List, Literal
+
+import pystow
+import requests
+
+
+def get_relations_web(
+    source_type: Optional[str] = None,
+    source_curie: Optional[str] = None,
+    target_type: Optional[str] = None,
+    target_curie: Optional[str] = None,
+    # "relations" is "relation_type" in client.query_relations
+    relations: Union[None, str, List[str]] = None,
+    relation_direction: Literal["right", "left", "both"] = "right",
+    relation_min_hops: int = 1,
+    relation_max_hops: int = 1,
+    limit: Optional[int] = None,
+    full: bool = False,
+    distinct: bool = False,
+    api_url: str = None,
+):
+    """A wrapper that call the rest API's get_relations endpoint
+
+    Parameters
+    ----------
+    source_type :
+        The source type (i.e., prefix). Example: "vo".
+    source_curie :
+        The source compact URI (CURIE). example="doid:946".
+    target_type :
+        "The target type (i.e., prefix)", example="ncbitaxon"
+    target_curie :
+        "The target compact URI (CURIE)", example="ncbitaxon:10090"
+    relations :
+        "A relation string or list of relation strings", example="vo:0001243"
+    relation_direction :
+        "The direction of the relationship". Options are "left", "right" and "both". Default: "right".
+    relation_min_hops :
+        "The minimum number of relationships between the subject and
+        object.". Default: 1.
+    relation_max_hops :
+        The maximum number of relationships between the subject and object.
+        Set to 0 to make infinite. Default: 1
+    limit :
+        A limit on the number of records returned. Example=50. Default: no
+        limit.
+    full :
+        A flag to turn on full entity and relation metadata return. Warning, this gets pretty verbose. Default: False.
+    distinct :
+        A flag to turn on the DISTINCT flag in the return of a cypher query. Default: False
+    api_url :
+        Use this parameter to specify the REST API base url or to override
+        the url set
+
+    Returns
+    -------
+
+    """
+    # todo: use the corresponding BaseModel to validate the args *before*
+    #  sending the request
+    base_url = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
+
+    if not base_url:
+        raise ValueError(
+            "The base url for the rest api needs to either be set in the "
+            "environment using the variable 'MIRA_REST_URL', be set in the "
+            "pystow config 'mira'->'rest_url' or by passing it the 'api_url' "
+            "parameter to this function."
+        )
+
+    base_url = base_url + "/api" if not base_url.endswith("/api") else base_url
+
+    query_json = {
+        "source_type": source_type,
+        "source_curie": source_curie,
+        "relations": relations,
+        "relation_direction": relation_direction,
+        "relation_min_hops": relation_min_hops,
+        "relation_max_hops": relation_max_hops,
+        "target_type": target_type,
+        "target_curie": target_curie,
+        "full": full,
+        "distinct": distinct,
+        "limit": limit,
+    }
+    res = requests.post(base_url + "/relations", json=query_json)
+    res.raise_for_status()
+
+    return res.json()

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -4,7 +4,7 @@ from typing import Optional, Union, List, Literal, Dict, Any
 import pystow
 import requests
 
-from mira.dkg.utils import dkg_refiner_rels
+from mira.dkg.utils import DKG_REFINER_RELS
 
 
 def web_client(query_json: Dict[str, Any], endpoint: str, api_url: Optional[str] = None):
@@ -115,6 +115,6 @@ def is_ontological_child(child_curie: str, parent_curie: str) -> bool:
         `parent_curie` holds
     """
     res = get_relations_web(
-        source_curie=child_curie, relations=dkg_refiner_rels, target_curie=parent_curie
+        source_curie=child_curie, relations=DKG_REFINER_RELS, target_curie=parent_curie
     )
     return len(res) > 0

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -4,6 +4,8 @@ from typing import Optional, Union, List, Literal
 import pystow
 import requests
 
+dkg_refiner_rels = ["rdfs:subClassOf", "part_of"]
+
 
 def get_relations_web(
     source_type: Optional[str] = None,
@@ -88,3 +90,25 @@ def get_relations_web(
     res.raise_for_status()
 
     return res.json()
+
+
+def is_ontological_child(child_curie: str, parent_curie: str) -> bool:
+    """Check if one curie is a child term of another curie
+
+    Parameters
+    ----------
+    child_curie :
+        The entity, identified by its CURIE that is assumed to be a child term
+    parent_curie :
+        The entity, identified by its CURIE that is assumed to be a parent term
+
+    Returns
+    -------
+    :
+        True if the assumption that `child_curie` is an ontological child of
+        `parent_curie` holds
+    """
+    res = get_relations_web(
+        source_curie=child_curie, relations=dkg_refiner_rels, target_curie=parent_curie
+    )
+    return len(res) > 0

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -424,6 +424,8 @@ def get_relations_web(
     -------
 
     """
+    # todo: use the corresponding BaseModel to validate the args *before*
+    #  sending the request
     base_url = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
 
     if not base_url:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -87,9 +87,7 @@ class Concept(BaseModel):
             True if ``other`` is the same Concept as this one
         """
         if not isinstance(other, Concept):
-            raise TypeError(
-                f"Cannot check equality between instances {type(other)} and Concept."
-            )
+            raise TypeError(f"Cannot check equality between {type(other)} and Concept.")
 
         # With context
         if with_context:
@@ -175,9 +173,7 @@ class Template(BaseModel):
 
     def is_equal_to(self, other: "Template", with_context: bool = False) -> bool:
         if not isinstance(other, Template):
-            raise TypeError(
-                f"Comparison between Template and {type(other)} not implemented"
-            )
+            raise TypeError(f"Comparison between Template and {type(other)} not implemented")
         return templates_equal(self, other, with_context)
 
     def refinement_of(
@@ -191,7 +187,9 @@ class Template(BaseModel):
             )
 
         if self.type != other.type:
-            return False
+            raise TypeError(
+                f"Cannot compare Template type {self.type} with Template type {other.type}"
+            )
 
         for field_name in self.__fields__:
             this_value = getattr(self, field_name)

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -103,7 +103,7 @@ class Concept(BaseModel):
 
 
 class Template(BaseModel):
-    type: str = NotImplemented
+    type: str
 
     @classmethod
     def from_json(cls, data) -> "Template":

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -434,7 +434,7 @@ def get_relations_web(
             "'api_url' parameter to this function."
         )
 
-    base_url = base_url + "/api" if not api_url.endswith("/api") else base_url
+    base_url = base_url + "/api" if not base_url.endswith("/api") else base_url
 
     query_json = {
         "source_type": source_type,

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -147,6 +147,12 @@ class Template(BaseModel):
 
     def refinement_of(self, other: "Template", dkg_client: Neo4jClient) -> bool:
         """Check if this template is a more detailed version of another"""
+        if not isinstance(other, Template):
+            raise TypeError(
+                f"Only refinement check between Template instances possible, "
+                f"got instance of type {type(other)}"
+            )
+
         if self.type != other.type:
             return False
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -19,8 +19,6 @@ from mira.dkg.web_client import get_relations_web
 
 HERE = Path(__file__).parent.resolve()
 SCHEMA_PATH = HERE.joinpath("schema.json")
-dkg_refiner_rels = ["rdfs:subClassOf", "part_of"]
-
 
 logger = logging.getLogger(__name__)
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -429,9 +429,9 @@ def get_relations_web(
     if not base_url:
         raise ValueError(
             "The base url for the rest api needs to either be set in the "
-            "environment using the variable 'MIRA_REST_URL',by setting it in "
-            "the pystow config 'mira'->'rest_url' or by passing it the "
-            "'api_url' parameter to this function."
+            "environment using the variable 'MIRA_REST_URL', be set in the "
+            "pystow config 'mira'->'rest_url' or by passing it the 'api_url' "
+            "parameter to this function."
         )
 
     base_url = base_url + "/api" if not base_url.endswith("/api") else base_url

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -7,12 +7,15 @@ __all__ = ["Concept", "Template", "Provenance", "ControlledConversion", "Natural
 
 import json
 import logging
+import os
 import sys
 from collections import ChainMap
 from pathlib import Path
-from typing import List, Mapping, Optional, Tuple
+from typing import List, Mapping, Optional, Tuple, Union, Literal
 
 import pydantic
+import pystow
+import requests
 from pydantic import BaseModel, Field
 
 from mira.dkg.client import Neo4jClient
@@ -377,6 +380,85 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
             raise ValueError("Unhandled logic, missing at least one logical option")
 
     return True
+
+
+def get_relations_web(
+    source_type: Optional[str] = None,
+    source_curie: Optional[str] = None,
+    target_type: Optional[str] = None,
+    target_curie: Optional[str] = None,
+    # "relations" is "relation_type" in client.query_relations
+    relations: Union[None, str, List[str]] = None,
+    relation_direction: Literal["right", "left", "both"] = "right",
+    relation_min_hops: int = 1,
+    relation_max_hops: int = 1,
+    limit: Optional[int] = None,
+    full: bool = False,
+    distinct: bool = False,
+    api_url: str = None,
+):
+    """A wrapper that call the rest API's get_relations endpoint
+
+    Parameters
+    ----------
+    source_type :
+        The source type (i.e., prefix). Example: "vo".
+    source_curie :
+        The source compact URI (CURIE). example="doid:946".
+    target_type :
+        "The target type (i.e., prefix)", example="ncbitaxon"
+    target_curie :
+        "The target compact URI (CURIE)", example="ncbitaxon:10090"
+    relations :
+        "A relation string or list of relation strings", example="vo:0001243"
+    relation_direction :
+        "The direction of the relationship". Options are "left", "right" and "both". Default: "right".
+    relation_min_hops :
+        "The minimum number of relationships between the subject and
+        object.". Default: 1.
+    relation_max_hops :
+        The maximum number of relationships between the subject and object.
+        Set to 0 to make infinite. Default: 1
+    limit :
+        A limit on the number of records returned. Example=50. Default: no
+        limit.
+    full :
+        A flag to turn on full entity and relation metadata return. Warning, this gets pretty verbose. Default: False.
+    distinct :
+        A flag to turn on the DISTINCT flag in the return of a cypher query. Default: False
+    api_url :
+        Use this parameter to specify the REST API base url or to override
+        the url set
+
+    Returns
+    -------
+
+    """
+    base = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
+    if not base:
+        raise ValueError(
+            "The base url for the rest api needs to either beset in the "
+            "environment using the variable 'MIRA_REST_URL',by setting it in "
+            "the pystow config 'mira'->'rest_url' or by passing it the "
+            "'api_url' parameter to this function."
+        )
+    query_json = {
+        "source_type": source_type,
+        "source_curie": source_curie,
+        "relations": relations,
+        "relation_direction": relation_direction,
+        "relation_min_hops": relation_min_hops,
+        "relation_max_hops": relation_max_hops,
+        "target_type": target_type,
+        "target_curie": target_curie,
+        "full": full,
+        "distinct": distinct,
+        "limit": limit,
+    }
+    res = requests.post(base + "/api/relations", json=query_json)
+    res.raise_for_status()
+
+    return res.json()
 
 
 def main():

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -161,7 +161,6 @@ class Template(BaseModel):
         if self.type != other.type:
             return False
 
-        concept_checked = False
         for field_name in self.__fields__:
             this_value = getattr(self, field_name)
 
@@ -173,14 +172,10 @@ class Template(BaseModel):
             # strict in the sense that unless every concept of this template is a
             # refinement of the other, the Template as a whole cannot be
             # considered a refinement
-            # Todo: if context is produced as it currently is, then only one
-            #  Concept's context needs to be checked since they are all the
-            #  same
-            elif isinstance(this_value, Concept) and not concept_checked:
+            elif isinstance(this_value, Concept):
                 other_concept = getattr(other, field_name)
                 if not this_value.refinement_of(other_concept, dkg_client):
                     return False
-                concept_checked = True
 
             # todo: Handle Provenance
             elif isinstance(this_value, List):

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -7,16 +7,15 @@ __all__ = ["Concept", "Template", "Provenance", "ControlledConversion", "Natural
 
 import json
 import logging
-import os
 import sys
 from collections import ChainMap
 from pathlib import Path
-from typing import List, Mapping, Optional, Tuple, Union, Literal
+from typing import List, Mapping, Optional, Tuple
 
 import pydantic
-import pystow
-import requests
 from pydantic import BaseModel, Field
+
+from mira.dkg.web_client import get_relations_web
 
 HERE = Path(__file__).parent.resolve()
 SCHEMA_PATH = HERE.joinpath("schema.json")
@@ -361,91 +360,6 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
             raise ValueError("Unhandled logic, missing at least one logical option")
 
     return True
-
-
-def get_relations_web(
-    source_type: Optional[str] = None,
-    source_curie: Optional[str] = None,
-    target_type: Optional[str] = None,
-    target_curie: Optional[str] = None,
-    # "relations" is "relation_type" in client.query_relations
-    relations: Union[None, str, List[str]] = None,
-    relation_direction: Literal["right", "left", "both"] = "right",
-    relation_min_hops: int = 1,
-    relation_max_hops: int = 1,
-    limit: Optional[int] = None,
-    full: bool = False,
-    distinct: bool = False,
-    api_url: str = None,
-):
-    """A wrapper that call the rest API's get_relations endpoint
-
-    Parameters
-    ----------
-    source_type :
-        The source type (i.e., prefix). Example: "vo".
-    source_curie :
-        The source compact URI (CURIE). example="doid:946".
-    target_type :
-        "The target type (i.e., prefix)", example="ncbitaxon"
-    target_curie :
-        "The target compact URI (CURIE)", example="ncbitaxon:10090"
-    relations :
-        "A relation string or list of relation strings", example="vo:0001243"
-    relation_direction :
-        "The direction of the relationship". Options are "left", "right" and "both". Default: "right".
-    relation_min_hops :
-        "The minimum number of relationships between the subject and
-        object.". Default: 1.
-    relation_max_hops :
-        The maximum number of relationships between the subject and object.
-        Set to 0 to make infinite. Default: 1
-    limit :
-        A limit on the number of records returned. Example=50. Default: no
-        limit.
-    full :
-        A flag to turn on full entity and relation metadata return. Warning, this gets pretty verbose. Default: False.
-    distinct :
-        A flag to turn on the DISTINCT flag in the return of a cypher query. Default: False
-    api_url :
-        Use this parameter to specify the REST API base url or to override
-        the url set
-
-    Returns
-    -------
-
-    """
-    # todo: use the corresponding BaseModel to validate the args *before*
-    #  sending the request
-    base_url = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
-
-    if not base_url:
-        raise ValueError(
-            "The base url for the rest api needs to either be set in the "
-            "environment using the variable 'MIRA_REST_URL', be set in the "
-            "pystow config 'mira'->'rest_url' or by passing it the 'api_url' "
-            "parameter to this function."
-        )
-
-    base_url = base_url + "/api" if not base_url.endswith("/api") else base_url
-
-    query_json = {
-        "source_type": source_type,
-        "source_curie": source_curie,
-        "relations": relations,
-        "relation_direction": relation_direction,
-        "relation_min_hops": relation_min_hops,
-        "relation_max_hops": relation_max_hops,
-        "target_type": target_type,
-        "target_curie": target_curie,
-        "full": full,
-        "distinct": distinct,
-        "limit": limit,
-    }
-    res = requests.post(base_url + "/relations", json=query_json)
-    res.raise_for_status()
-
-    return res.json()
 
 
 def main():

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -188,7 +188,10 @@ def get_json_schema():
 
 def templates_equal(templ: Template, other_templ: Template, with_context: bool) -> bool:
     if templ.type != other_templ.type:
-        return False
+        raise TypeError(
+            f"Cannot compare template of type {templ.type} with template of "
+            f"type {other_templ.type}"
+        )
 
     other_dict = other_templ.__dict__
     for key, value in templ.__dict__.items():

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -340,10 +340,9 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
     """
     refined_context = refined_concept.context
     other_context = other_concept.context
-    # 1. Undecided if both don't have context -> True so that other factors
-    #    outside of context can decide
+    # 1. False if no context for both
     if len(refined_context) == 0 and len(other_context) == 0:
-        return True
+        return False
     # 2. True if refined concept has context and the other one not
     elif len(refined_context) > 0 and len(other_context) == 0:
         return True

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -15,8 +15,6 @@ from typing import List, Mapping, Optional, Tuple, Callable
 import pydantic
 from pydantic import BaseModel, Field
 
-from mira.dkg.web_client import is_ontological_child
-
 HERE = Path(__file__).parent.resolve()
 SCHEMA_PATH = HERE.joinpath("schema.json")
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -211,12 +211,15 @@ class Template(BaseModel):
                 ):
                     return False
 
-            # todo: Handle Provenance
-            elif isinstance(this_value, List):
-                if isinstance(this_value[0], Provenance):
-                    pass
+            elif isinstance(this_value, list):
+                # todo: Handle Provenance
+                if len(this_value) > 0:
+                    if isinstance(this_value[0], Provenance):
+                        pass
+                    else:
+                        logger.warning(f"Unhandled type List[{type(this_value[0])}]")
                 else:
-                    logger.warning(f"Unhandled type List[{type(this_value[0])}]")
+                    pass
 
             else:
                 logger.warning(f"Unhandled type {type(this_value)}")

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -103,7 +103,6 @@ class Concept(BaseModel):
 
 
 class Template(BaseModel):
-    type: str
 
     @classmethod
     def from_json(cls, data) -> "Template":

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -424,14 +424,18 @@ def get_relations_web(
     -------
 
     """
-    base = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
-    if not base:
+    base_url = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
+
+    if not base_url:
         raise ValueError(
             "The base url for the rest api needs to either beset in the "
             "environment using the variable 'MIRA_REST_URL',by setting it in "
             "the pystow config 'mira'->'rest_url' or by passing it the "
             "'api_url' parameter to this function."
         )
+
+    base_url = base_url + "/api" if not api_url.endswith("/api") else base_url
+
     query_json = {
         "source_type": source_type,
         "source_curie": source_curie,
@@ -445,7 +449,7 @@ def get_relations_web(
         "distinct": distinct,
         "limit": limit,
     }
-    res = requests.post(base + "/api/relations", json=query_json)
+    res = requests.post(base_url + "/relations", json=query_json)
     res.raise_for_status()
 
     return res.json()

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -99,8 +99,10 @@ class Concept(BaseModel):
 
         # Check that they are grounded to the same identifier
         if len(self.identifiers) > 0 and len(other.identifiers) > 0:
-            if not self.get_curie() == other.get_curie():
+            if self.get_curie() != other.get_curie():
                 return False
+            else:
+                pass
         # If either or both are ungrounded -> can't know -> False
         else:
             return False

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -179,6 +179,31 @@ def get_json_schema():
     return rv
 
 
+def templates_equal(templ: Template, other_templ: Template, with_context: bool) -> bool:
+    if templ.type != other_templ.type:
+        return False
+
+    other_dict = other_templ.__dict__
+    for key, value in templ.__dict__.items():
+        # Already checked type
+        if key == "type":
+            continue
+
+        if isinstance(value, Concept):
+            other_concept: Concept = other_dict[key]
+            if not value.is_equal_to(other_concept, with_context=with_context):
+                return False
+
+        elif isinstance(value, list):
+            if not all(i1 == i2 for i1, i2 in zip(value, other_dict[key])):
+                return False
+        else:
+            raise NotImplementedError(
+                f"No comparison implemented for type {type(value)} for Template"
+            )
+    return True
+
+
 def main():
     """Generate the JSON schema file."""
     schema = get_json_schema()

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -64,7 +64,7 @@ class Concept(BaseModel):
             tuple(sorted(self.context.items())),
         )
 
-    def is_equal_to(self, other: "Concept", with_context: bool = False):
+    def is_equal_to(self, other: "Concept", with_context: bool = False) -> bool:
         """Test for equality between concepts
 
         Parameters
@@ -132,7 +132,6 @@ class Concept(BaseModel):
 
 
 class Template(BaseModel):
-
     @classmethod
     def from_json(cls, data) -> "Template":
         template_type = data.pop("type")

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -111,7 +111,7 @@ class Template(BaseModel):
         stmt_cls = getattr(sys.modules[__name__], template_type)
         return stmt_cls(**data)
 
-    def is_equal_to(self, other: "Template", with_context: bool) -> bool:
+    def is_equal_to(self, other: "Template", with_context: bool = False) -> bool:
         if not isinstance(other, Template):
             raise NotImplementedError(
                 f"Comparison between Template and {type(other)} not implemented"

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -151,7 +151,7 @@ class Template(BaseModel):
 
     def is_equal_to(self, other: "Template", with_context: bool = False) -> bool:
         if not isinstance(other, Template):
-            raise NotImplementedError(
+            raise TypeError(
                 f"Comparison between Template and {type(other)} not implemented"
             )
         return templates_equal(self, other, with_context)

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -58,6 +58,49 @@ class Concept(BaseModel):
             tuple(sorted(self.context.items())),
         )
 
+    def is_equal_to(self, other: "Concept", with_context: bool = False):
+        """Test for equality between concepts
+
+        Parameters
+        ----------
+        other :
+            Other Concept to test equality with
+        with_context :
+            If True, do not consider the two Concepts equal unless they also
+            have exactly the same context. If there is no context,
+            ``with_context`` has no effect.
+
+        Returns
+        -------
+        :
+            True if ``other`` is the same Concept as this one
+        """
+        if not isinstance(other, Concept):
+            raise NotImplementedError(
+                f"No comparison implemented for type {type(other)} with Concept"
+            )
+
+        # With context
+        if with_context:
+            # Check that the same keys appear in both
+            if set(self.context.keys()) != set(other.context.keys()):
+                return False
+
+            # Check that the values are the same
+            for k1, v1 in self.context.items():
+                if v1 != other.context[k1]:
+                    return False
+
+        # Check that they are grounded to the same identifier
+        if (
+            len(self.identifiers) > 0
+            and len(other.identifiers) > 0
+            and not self.get_curie() == other.get_curie()
+        ):
+            return False
+
+        return True
+
 
 class Template(BaseModel):
     type: str = NotImplemented

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -128,6 +128,11 @@ class Concept(BaseModel):
             if len(res) == 0:
                 return False
 
+        # Any of them are ungrounded -> cannot know if there is a refinement
+        # -> return False
+        elif len(self.identifiers) == 0 or len(other.identifiers) == 0:
+            return False
+
         return True
 
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -207,13 +207,10 @@ class Template(BaseModel):
             elif isinstance(this_value, list):
                 if len(this_value) > 0:
                     if isinstance(this_value[0], Provenance):
-                        # todo: Handle Provenance
-                        pass
+                        # Skip Provenance
+                        continue
                     else:
                         logger.warning(f"Unhandled type List[{type(this_value[0])}]")
-                else:
-                    # Empty list
-                    pass
 
             else:
                 logger.warning(f"Unhandled type {type(this_value)}")

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -213,6 +213,47 @@ def templates_equal(templ: Template, other_templ: Template, with_context: bool) 
     return True
 
 
+def assert_concept_context_refinement(refined_concept: Concept, other_concept: Concept) -> bool:
+    """Check if one Concept's context is a refinement of another Concept's
+
+    Parameters
+    ----------
+    refined_concept :
+        The more detailed Concept
+    other_concept :
+        The less detailed Concept
+
+    Returns
+    -------
+    :
+        True if `refined_concept` truly is strictly more detailed than 
+        `other_concept`, i.e. two identical Concept contexts can't be 
+        refinements of each other.
+    """
+    # 1. Undecided/True if both don't have context
+    if len(refined_concept.context) == 0 and len(other_concept.context) == 0:
+        return True
+    # 2. True if refined concept has context and the other one not
+    elif len(refined_concept.context) > 0 and len(other_concept.context) == 0:
+        return True
+    # 3. False if refined concept does not have context and the other does
+    elif len(refined_concept.context) == 0 and len(other_concept.context) > 0:
+        return False
+    # 4. Both have context
+    else:
+        # False if refined Concept has less (or equal) context
+        if set(refined_concept.context.keys()).issubset(
+                other_concept.context.keys()):
+            return False
+
+        # Other Concept context is a subset; check equality for the matches
+        for other_context_key, other_context_value in other_concept.context.items():
+            if refined_concept.context[other_context_key] != other_context_value:
+                return False
+
+    return True
+
+
 def main():
     """Generate the JSON schema file."""
     schema = get_json_schema()

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -186,18 +186,14 @@ class Template(BaseModel):
         if self.type != other.type:
             return False
 
-        for field_name in self.__fields__:
+        for field_name in self.dict(exclude={"type"}):
             this_value = getattr(self, field_name)
-
-            # Skip 'type'
-            if field_name == "type":
-                continue
 
             # Check refinement for any attribute that is a Concept; this is
             # strict in the sense that unless every concept of this template is a
             # refinement of the other, the Template as a whole cannot be
             # considered a refinement
-            elif isinstance(this_value, Concept):
+            if isinstance(this_value, Concept):
                 other_concept = getattr(other, field_name)
                 if not this_value.refinement_of(
                     other_concept, refinement_func=refinement_func, with_context=with_context

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -88,7 +88,7 @@ class Concept(BaseModel):
             True if ``other`` is the same Concept as this one
         """
         if not isinstance(other, Concept):
-            raise TypeError(f"Cannot check equality between {type(other)} and Concept.")
+            return False
 
         # With context
         if with_context:
@@ -130,7 +130,7 @@ class Concept(BaseModel):
             True if this Concept is a refinement of another Concept
         """
         if not isinstance(other, Concept):
-            raise TypeError(f"Cannot check refinement between {type(other)} and Concept")
+            return False
 
         contextual_refinement = False
         if with_context and assert_concept_context_refinement(
@@ -168,21 +168,16 @@ class Template(BaseModel):
 
     def is_equal_to(self, other: "Template", with_context: bool = False) -> bool:
         if not isinstance(other, Template):
-            raise TypeError(f"Comparison between Template and {type(other)} not implemented")
+            return False
         return templates_equal(self, other, with_context)
 
     def refinement_of(self, other: "Template", with_context: bool = False) -> bool:
         """Check if this template is a more detailed version of another"""
         if not isinstance(other, Template):
-            raise TypeError(
-                f"Only refinement check between Template instances possible, "
-                f"got instance of type {type(other)}"
-            )
+            return False
 
         if self.type != other.type:
-            raise TypeError(
-                f"Cannot compare Template type {self.type} with Template type {other.type}"
-            )
+            return False
 
         for field_name in self.__fields__:
             this_value = getattr(self, field_name)
@@ -286,9 +281,7 @@ def get_json_schema():
 
 def templates_equal(templ: Template, other_templ: Template, with_context: bool) -> bool:
     if templ.type != other_templ.type:
-        raise TypeError(
-            f"Cannot compare Template type {templ.type} with Template type {other_templ.type}"
-        )
+        return False
 
     other_dict = other_templ.__dict__
     for key, value in templ.__dict__.items():

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -111,6 +111,13 @@ class Template(BaseModel):
         stmt_cls = getattr(sys.modules[__name__], template_type)
         return stmt_cls(**data)
 
+    def is_equal_to(self, other: "Template", with_context: bool) -> bool:
+        if not isinstance(other, Template):
+            raise NotImplementedError(
+                f"Comparison between Template and {type(other)} not implemented"
+            )
+        return templates_equal(self, other, with_context)
+
 
 class Provenance(BaseModel):
     pass

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -119,6 +119,9 @@ class Concept(BaseModel):
         """Check if this Concept is a more detailed version of another"""
         # Check context subset; either both concepts have context, or this
         # concept has context and the other, less detailed, concept does not
+        if not isinstance(other, Concept):
+            raise TypeError(f"Cannot check refinement between {type(other)} and Concept")
+
         if with_context:
             if not assert_concept_context_refinement(refined_concept=self, other_concept=other):
                 return False

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -119,18 +119,16 @@ class Concept(BaseModel):
         Parameters
         ----------
         other :
-            The other, assumed to be less detailed, Concept to compare with
+            The other Concept to compare with. Assumed to be less detailed.
         with_context :
-            If True, also consider one Concept a refinement of another
-            Concept if the formers' context is a refinement of the latter's
+            If True, also consider the context of the Concepts for the
+            refinement.
 
         Returns
         -------
         :
             True if this Concept is a refinement of another Concept
         """
-        # todo: Discuss: do all conditions need to be met for a Concept to
-        #  be consider a refinement or can it be any?
         if not isinstance(other, Concept):
             raise TypeError(f"Cannot check refinement between {type(other)} and Concept")
 
@@ -203,13 +201,14 @@ class Template(BaseModel):
                     return False
 
             elif isinstance(this_value, list):
-                # todo: Handle Provenance
                 if len(this_value) > 0:
                     if isinstance(this_value[0], Provenance):
+                        # todo: Handle Provenance
                         pass
                     else:
                         logger.warning(f"Unhandled type List[{type(this_value[0])}]")
                 else:
+                    # Empty list
                     pass
 
             else:
@@ -316,7 +315,7 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
     """Check if one Concept's context is a refinement of another Concept's
 
     Special case:
-    - Both contexts are empty: True
+    - Both contexts are empty => special case of equal context => False
 
     Parameters
     ----------
@@ -364,9 +363,8 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
         elif set(other_context.keys()).symmetric_difference(set(refined_context.keys())):
             return False
 
-        # Can't come up with what other situation would arise
+        # 5. All cases should be covered, but in case something is missing
         else:
-            # FixMe: Remove before PR
             raise ValueError("Unhandled logic, missing at least one logical option")
 
     return True

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -219,15 +219,15 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
     Parameters
     ----------
     refined_concept :
-        The more detailed Concept
+        The *more* detailed Concept
     other_concept :
-        The less detailed Concept
+        The *less* detailed Concept
 
     Returns
     -------
     :
-        True if `refined_concept` truly is strictly more detailed than 
-        `other_concept`, i.e. two identical Concept contexts can't be 
+        True if `refined_concept` truly is strictly more detailed than
+        `other_concept`, i.e. two identical Concept contexts can't be
         refinements of each other.
     """
     # 1. Undecided/True if both don't have context
@@ -242,11 +242,11 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
     # 4. Both have context
     else:
         # False if refined Concept has less (or equal) context
-        if set(refined_concept.context.keys()).issubset(
-                other_concept.context.keys()):
+        if set(refined_concept.context.keys()).issubset(other_concept.context.keys()):
             return False
 
         # Other Concept context is a subset; check equality for the matches
+        # todo: Is this correct?
         for other_context_key, other_context_value in other_concept.context.items():
             if refined_concept.context[other_context_key] != other_context_value:
                 return False

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -37,8 +37,12 @@ DEFAULT_CONFIG = Config(
 
 class Concept(BaseModel):
     name: str = Field(..., description="The name of the concept.")
-    identifiers: Mapping[str, str] = Field(default_factory=dict, description="A mapping of namespaces to identifiers.")
-    context: Mapping[str, str] = Field(default_factory=dict, description="A mapping of context keys to values.")
+    identifiers: Mapping[str, str] = Field(
+        default_factory=dict, description="A mapping of namespaces to identifiers."
+    )
+    context: Mapping[str, str] = Field(
+        default_factory=dict, description="A mapping of context keys to values."
+    )
 
     def with_context(self, **context) -> "Concept":
         """Return this concept with extra context."""
@@ -82,8 +86,8 @@ class Concept(BaseModel):
             True if ``other`` is the same Concept as this one
         """
         if not isinstance(other, Concept):
-            raise NotImplementedError(
-                f"No comparison implemented for type {type(other)} with Concept"
+            raise TypeError(
+                f"Cannot check equality between instances {type(other)} and Concept."
             )
 
         # With context
@@ -262,8 +266,7 @@ def get_json_schema():
 def templates_equal(templ: Template, other_templ: Template, with_context: bool) -> bool:
     if templ.type != other_templ.type:
         raise TypeError(
-            f"Cannot compare template of type {templ.type} with template of "
-            f"type {other_templ.type}"
+            f"Cannot compare Template type {templ.type} with Template type {other_templ.type}"
         )
 
     other_dict = other_templ.__dict__

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -180,7 +180,9 @@ class Template(BaseModel):
             )
         return templates_equal(self, other, with_context)
 
-    def refinement_of(self, other: "Template", dkg_client: Neo4jClient) -> bool:
+    def refinement_of(
+        self, other: "Template", dkg_client: Neo4jClient, with_context: bool = False
+    ) -> bool:
         """Check if this template is a more detailed version of another"""
         if not isinstance(other, Template):
             raise TypeError(
@@ -204,7 +206,9 @@ class Template(BaseModel):
             # considered a refinement
             elif isinstance(this_value, Concept):
                 other_concept = getattr(other, field_name)
-                if not this_value.refinement_of(other_concept, dkg_client):
+                if not this_value.refinement_of(
+                    other_concept, dkg_client, with_context=with_context
+                ):
                     return False
 
             # todo: Handle Provenance

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -428,7 +428,7 @@ def get_relations_web(
 
     if not base_url:
         raise ValueError(
-            "The base url for the rest api needs to either beset in the "
+            "The base url for the rest api needs to either be set in the "
             "environment using the variable 'MIRA_REST_URL',by setting it in "
             "the pystow config 'mira'->'rest_url' or by passing it the "
             "'api_url' parameter to this function."

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -114,7 +114,7 @@ class Concept(BaseModel):
         self,
         other: "Concept",
         with_context: bool = False,
-        is_ont_refinement: Optional[Callable[[str, str], bool]] = None,
+        ont_refinement_func: Optional[Callable[[str, str], bool]] = None,
     ) -> bool:
         """Check if this Concept is a more detailed version of another
 
@@ -125,7 +125,7 @@ class Concept(BaseModel):
         with_context :
             If True, also consider the context of the Concepts for the
             refinement.
-        is_ont_refinement :
+        ont_refinement_func :
             A function that given a source/more detailed entity and a
             target/less detailed entity checks if they are in a child-parent and
             returns a boolean. If not provided, the default
@@ -148,13 +148,13 @@ class Concept(BaseModel):
         # Check if this concept is a child term to other?
         if len(self.identifiers) > 0 and len(other.identifiers) > 0:
             # Set the default function if not provided
-            if is_ont_refinement is None:
-                is_ont_refinement = is_ontological_child
+            if ont_refinement_func is None:
+                ont_refinement_func = is_ontological_child
 
             # Check if other is a parent of this concept
             this_curie = ":".join(self.get_curie())
             other_curie = ":".join(other.get_curie())
-            ontological_refinement = is_ont_refinement(this_curie, other_curie)
+            ontological_refinement = ont_refinement_func(this_curie, other_curie)
 
         # Any of them are ungrounded -> cannot know if there is a refinement
         # -> return False

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -98,11 +98,11 @@ class Concept(BaseModel):
                     return False
 
         # Check that they are grounded to the same identifier
-        if (
-            len(self.identifiers) > 0
-            and len(other.identifiers) > 0
-            and not self.get_curie() == other.get_curie()
-        ):
+        if len(self.identifiers) > 0 and len(other.identifiers) > 0:
+            if not self.get_curie() == other.get_curie():
+                return False
+        # If either or both are ungrounded -> can't know -> False
+        else:
             return False
 
         return True

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -45,6 +45,8 @@ def test_template_type_inequality():
     except Exception as exc:
         assert isinstance(exc, TypeError)
         assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
+    else:
+        raise AssertionError("Expected TypeError")
 
 
 def test_class_incompatibility():
@@ -56,8 +58,12 @@ def test_class_incompatibility():
         infected.is_equal_to(nc)
     except Exception as exc:
         assert isinstance(exc, NotImplementedError)
+    else:
+        raise AssertionError("Expected NotImplementedError")
 
     try:
         nc.is_equal_to(infected)
     except Exception as exc:
         assert isinstance(exc, NotImplementedError)
+    else:
+        raise AssertionError("Expected NotImplementedError")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,4 +1,4 @@
-from mira.metamodel import ControlledConversion, Concept
+from mira.metamodel import ControlledConversion, Concept, NaturalConversion
 
 
 def test_templates_equal():
@@ -28,3 +28,36 @@ def test_concepts_equal():
     assert not c1_w_ctx.is_equal_to(c2_w_ctx, with_context=True)
     assert c1_w_ctx.is_equal_to(c2_w_ctx, with_context=False)
 
+
+def test_template_type_inequality():
+    infected = Concept(name='infected population', identifiers={'ido': '0000511'})
+    susceptible = Concept(name='susceptible population', identifiers={'ido': '0000514'})
+    immune = Concept(name='immune population', identifiers={'ido': '0000592'})
+    c1 = ControlledConversion(
+        subject=susceptible,
+        outcome=infected,
+        controller=infected,
+    )
+    n1 = NaturalConversion(subject=infected, outcome=immune)
+
+    try:
+        c1.is_equal_to(n1)
+    except Exception as exc:
+        assert isinstance(exc, TypeError)
+        assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
+
+
+def test_class_incompatibility():
+    infected = Concept(name='infected population', identifiers={'ido': '0000511'})
+    immune = Concept(name='immune population', identifiers={'ido': '0000592'})
+    nc = NaturalConversion(subject=infected, outcome=immune)
+
+    try:
+        infected.is_equal_to(nc)
+    except Exception as exc:
+        assert isinstance(exc, NotImplementedError)
+
+    try:
+        nc.is_equal_to(infected)
+    except Exception as exc:
+        assert isinstance(exc, NotImplementedError)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -16,3 +16,15 @@ def test_templates_equal():
     assert c1.is_equal_to(c2, with_context=False)
     assert not c1.is_equal_to(c2_w_ctx, with_context=True)
     assert c1.is_equal_to(c2_w_ctx, with_context=False)
+
+
+def test_concepts_equal():
+    c1 = Concept(name='infected population', identifiers={'ido': '0000511'})
+    c1_w_ctx = c1.with_context(location="Berlin")
+    c2 = Concept(name='infected population', identifiers={'ido': '0000511'})
+    c2_w_ctx = c2.with_context(location="Stockholm")
+
+    assert c1.is_equal_to(c2)
+    assert not c1_w_ctx.is_equal_to(c2_w_ctx, with_context=True)
+    assert c1_w_ctx.is_equal_to(c2_w_ctx, with_context=False)
+

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,6 +2,7 @@ from mira.dkg.client import Neo4jClient
 from mira.metamodel import ControlledConversion, Concept, NaturalConversion
 
 
+# fixme: how to solve neo4j client?
 client = Neo4jClient(url="bolt://0.0.0.0:7687")
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3,15 +3,15 @@ from mira.metamodel import ControlledConversion, Concept, NaturalConversion
 
 def test_templates_equal():
     c1 = ControlledConversion(
-            subject=Concept(name='susceptible'),
-            outcome=Concept(name='infected'),
-            controller=Concept(name='infected')
-        )
+        subject=Concept(name="susceptible"),
+        outcome=Concept(name="infected"),
+        controller=Concept(name="infected"),
+    )
     c2 = ControlledConversion(
-            subject=Concept(name='susceptible'),
-            outcome=Concept(name='infected'),
-            controller=Concept(name='infected')
-        )
+        subject=Concept(name="susceptible"),
+        outcome=Concept(name="infected"),
+        controller=Concept(name="infected"),
+    )
     c2_w_ctx = c2.with_context(location="Stockholm")
     assert c1.is_equal_to(c2, with_context=False)
     assert not c1.is_equal_to(c2_w_ctx, with_context=True)
@@ -19,9 +19,9 @@ def test_templates_equal():
 
 
 def test_concepts_equal():
-    c1 = Concept(name='infected population', identifiers={'ido': '0000511'})
+    c1 = Concept(name="infected population", identifiers={"ido": "0000511"})
     c1_w_ctx = c1.with_context(location="Berlin")
-    c2 = Concept(name='infected population', identifiers={'ido': '0000511'})
+    c2 = Concept(name="infected population", identifiers={"ido": "0000511"})
     c2_w_ctx = c2.with_context(location="Stockholm")
 
     assert c1.is_equal_to(c2)
@@ -30,9 +30,9 @@ def test_concepts_equal():
 
 
 def test_template_type_inequality():
-    infected = Concept(name='infected population', identifiers={'ido': '0000511'})
-    susceptible = Concept(name='susceptible population', identifiers={'ido': '0000514'})
-    immune = Concept(name='immune population', identifiers={'ido': '0000592'})
+    infected = Concept(name="infected population", identifiers={"ido": "0000511"})
+    susceptible = Concept(name="susceptible population", identifiers={"ido": "0000514"})
+    immune = Concept(name="immune population", identifiers={"ido": "0000592"})
     c1 = ControlledConversion(
         subject=susceptible,
         outcome=infected,
@@ -48,8 +48,8 @@ def test_template_type_inequality():
 
 
 def test_class_incompatibility():
-    infected = Concept(name='infected population', identifiers={'ido': '0000511'})
-    immune = Concept(name='immune population', identifiers={'ido': '0000592'})
+    infected = Concept(name="infected population", identifiers={"ido": "0000511"})
+    immune = Concept(name="immune population", identifiers={"ido": "0000592"})
     nc = NaturalConversion(subject=infected, outcome=immune)
 
     try:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -52,14 +52,7 @@ def test_template_type_inequality_is_equal():
         controller=infected,
     )
     n1 = NaturalConversion(subject=infected, outcome=immune)
-
-    try:
-        c1.is_equal_to(n1)
-    except Exception as exc:
-        assert isinstance(exc, TypeError), "Expected TypeError"
-        assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
-    else:
-        raise AssertionError("Expected TypeError")
+    assert not c1.is_equal_to(n1)
 
 
 def test_template_type_inequality_refinement():
@@ -73,21 +66,8 @@ def test_template_type_inequality_refinement():
     )
     n1 = NaturalConversion(subject=infected, outcome=immune)
 
-    try:
-        c1.refinement_of(n1)
-    except Exception as exc:
-        assert isinstance(exc, TypeError), "Expected TypeError"
-        assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
-    else:
-        raise AssertionError("Expected TypeError")
-
-    try:
-        n1.refinement_of(c1)
-    except Exception as exc:
-        assert isinstance(exc, TypeError), "Expected TypeError"
-        assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
-    else:
-        raise AssertionError("Expected TypeError")
+    assert not c1.refinement_of(n1)
+    assert not n1.refinement_of(c1)
 
 
 def test_class_incompatibility_is_equal():
@@ -95,19 +75,8 @@ def test_class_incompatibility_is_equal():
     immune = Concept(name="immune population", identifiers={"ido": "0000592"})
     nc = NaturalConversion(subject=infected, outcome=immune)
 
-    try:
-        infected.is_equal_to(nc)
-    except Exception as exc:
-        assert isinstance(exc, TypeError), "Expected TypeError"
-    else:
-        raise AssertionError("Expected TypeError")
-
-    try:
-        nc.is_equal_to(infected)
-    except Exception as exc:
-        assert isinstance(exc, TypeError), "Expected TypeError"
-    else:
-        raise AssertionError("Expected TypeError")
+    assert not infected.is_equal_to(nc)
+    assert not nc.is_equal_to(infected)
 
 
 def test_class_incompatibility_refinement():
@@ -115,19 +84,8 @@ def test_class_incompatibility_refinement():
     immune = Concept(name="immune population", identifiers={"ido": "0000592"})
     natural_conversion = NaturalConversion(subject=infected, outcome=immune)
 
-    try:
-        infected.refinement_of(natural_conversion)
-    except Exception as exc:
-        assert isinstance(exc, TypeError), "Expected TypeError"
-    else:
-        raise AssertionError("Expected TypeError")
-
-    try:
-        natural_conversion.is_equal_to(infected)
-    except Exception as exc:
-        assert isinstance(exc, TypeError), "Expected TypeError"
-    else:
-        raise AssertionError("Expected TypeError")
+    assert not infected.refinement_of(natural_conversion)
+    assert not natural_conversion.is_equal_to(infected)
 
 
 # test refinement for Templates

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,18 @@
+from mira.metamodel import ControlledConversion, Concept
+
+
+def test_templates_equal():
+    c1 = ControlledConversion(
+            subject=Concept(name='susceptible'),
+            outcome=Concept(name='infected'),
+            controller=Concept(name='infected')
+        )
+    c2 = ControlledConversion(
+            subject=Concept(name='susceptible'),
+            outcome=Concept(name='infected'),
+            controller=Concept(name='infected')
+        )
+    c2_w_ctx = c2.with_context(location="Stockholm")
+    assert c1.is_equal_to(c2, with_context=False)
+    assert not c1.is_equal_to(c2_w_ctx, with_context=True)
+    assert c1.is_equal_to(c2_w_ctx, with_context=False)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,4 +1,8 @@
+from mira.dkg.client import Neo4jClient
 from mira.metamodel import ControlledConversion, Concept, NaturalConversion
+
+
+client = Neo4jClient(url="bolt://0.0.0.0:7687")
 
 
 def test_templates_equal():
@@ -29,7 +33,7 @@ def test_concepts_equal():
     assert c1_w_ctx.is_equal_to(c2_w_ctx, with_context=False)
 
 
-def test_template_type_inequality():
+def test_template_type_inequality_is_equal():
     infected = Concept(name="infected population", identifiers={"ido": "0000511"})
     susceptible = Concept(name="susceptible population", identifiers={"ido": "0000514"})
     immune = Concept(name="immune population", identifiers={"ido": "0000592"})
@@ -43,13 +47,41 @@ def test_template_type_inequality():
     try:
         c1.is_equal_to(n1)
     except Exception as exc:
-        assert isinstance(exc, TypeError)
+        assert isinstance(exc, TypeError), "Expected TypeError"
         assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
     else:
         raise AssertionError("Expected TypeError")
 
 
-def test_class_incompatibility():
+def test_template_type_inequality_refinement():
+    infected = Concept(name="infected population", identifiers={"ido": "0000511"})
+    susceptible = Concept(name="susceptible population", identifiers={"ido": "0000514"})
+    immune = Concept(name="immune population", identifiers={"ido": "0000592"})
+    c1 = ControlledConversion(
+        subject=susceptible,
+        outcome=infected,
+        controller=infected,
+    )
+    n1 = NaturalConversion(subject=infected, outcome=immune)
+
+    try:
+        c1.refinement_of(n1, client)
+    except Exception as exc:
+        assert isinstance(exc, TypeError), "Expected TypeError"
+        assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
+    else:
+        raise AssertionError("Expected TypeError")
+
+    try:
+        n1.refinement_of(c1, None)
+    except Exception as exc:
+        assert isinstance(exc, TypeError), "Expected TypeError"
+        assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
+    else:
+        raise AssertionError("Expected TypeError")
+
+
+def test_class_incompatibility_is_equal():
     infected = Concept(name="infected population", identifiers={"ido": "0000511"})
     immune = Concept(name="immune population", identifiers={"ido": "0000592"})
     nc = NaturalConversion(subject=infected, outcome=immune)
@@ -57,13 +89,103 @@ def test_class_incompatibility():
     try:
         infected.is_equal_to(nc)
     except Exception as exc:
-        assert isinstance(exc, TypeError)
+        assert isinstance(exc, TypeError), "Expected TypeError"
     else:
-        raise AssertionError("Expected NotImplementedError")
+        raise AssertionError("Expected TypeError")
 
     try:
         nc.is_equal_to(infected)
     except Exception as exc:
-        assert isinstance(exc, TypeError)
+        assert isinstance(exc, TypeError), "Expected TypeError"
     else:
-        raise AssertionError("Expected NotImplementedError")
+        raise AssertionError("Expected TypeError")
+
+
+def test_class_incompatibility_refinement():
+    infected = Concept(name="infected population", identifiers={"ido": "0000511"})
+    immune = Concept(name="immune population", identifiers={"ido": "0000592"})
+    natural_conversion = NaturalConversion(subject=infected, outcome=immune)
+
+    try:
+        infected.refinement_of(natural_conversion, None)
+    except Exception as exc:
+        assert isinstance(exc, TypeError), "Expected TypeError"
+    else:
+        raise AssertionError("Expected TypeError")
+
+    try:
+        natural_conversion.is_equal_to(infected)
+    except Exception as exc:
+        assert isinstance(exc, TypeError), "Expected TypeError"
+    else:
+        raise AssertionError("Expected TypeError")
+
+
+# test refinement for Templates
+def test_template_refinement():
+    infected = Concept(name="infected population", identifiers={"ido": "0000511"})
+    immune = Concept(name="immune population", identifiers={"ido": "0000592"})
+    natural_conversion = NaturalConversion(subject=infected, outcome=immune)
+    nc_context = natural_conversion.with_context(location="Boston")
+    assert nc_context.refinement_of(natural_conversion, client, with_context=True)
+
+
+def test_concept_refinement_grounding():
+    # spatial region
+    spatial_region = Concept(name="spatial region")
+    spatial_region_gnd = Concept(name="spatial region", identifiers={"bfo": "0000006"})
+    # one-dimensional spatial region
+    one_dim_spat = Concept(name="one-dimensional spatial region")
+    one_dim_spat_gnd = Concept(
+        name="one-dimensional spatial region", identifiers={"bfo": "0000026"}
+    )
+    # test grounded
+    assert one_dim_spat_gnd.refinement_of(spatial_region_gnd, dkg_client=client, with_context=False)
+    assert not one_dim_spat_gnd.refinement_of(spatial_region, dkg_client=client, with_context=False)
+    assert one_dim_spat_gnd.refinement_of(spatial_region_gnd, dkg_client=client, with_context=True)
+    assert not one_dim_spat_gnd.refinement_of(spatial_region, dkg_client=client, with_context=True)
+
+    # test ungrounded
+    assert not spatial_region.refinement_of(one_dim_spat, dkg_client=client, with_context=False)
+    spatial_region_ctx = spatial_region.with_context(location="Stockholm")
+    assert spatial_region_ctx.refinement_of(spatial_region, dkg_client=client, with_context=True)
+    assert spatial_region_ctx.refinement_of(
+        spatial_region_gnd, dkg_client=client, with_context=True
+    )
+
+
+def test_concept_refinement_simple_context():
+    spatial_region_gnd = Concept(name="spatial region", identifiers={"bfo": "0000006"})
+    spatial_region_ctx = spatial_region_gnd.with_context(location="Stockholm")
+    assert len(spatial_region_ctx.context)
+    kw = {"dkg_client": client, "with_context": True}
+
+    # Test both empty
+    assert not spatial_region_gnd.refinement_of(spatial_region_gnd, **kw)
+
+    # Test refined has context, other does not
+    assert spatial_region_ctx.refinement_of(spatial_region_gnd, **kw)
+
+    # Test other has context, refined does not
+    assert not spatial_region_gnd.refinement_of(spatial_region_ctx, **kw)
+
+
+def test_concept_refinement_context():
+    spatial_region_gnd = Concept(name="spatial region", identifiers={"bfo": "0000006"})
+    spatial_region_ctx = spatial_region_gnd.with_context(location="Stockholm")
+    spatial_region_more_ctx = spatial_region_gnd.with_context(location="Stockholm", year=2010)
+    spatial_region_diff_ctx = spatial_region_gnd.with_context(year=2007, count=10)
+
+    kw = {"dkg_client": client, "with_context": True}
+
+    # Exactly equal context
+    assert not spatial_region_ctx.refinement_of(spatial_region_ctx, **kw)
+
+    # Refined is subset of other
+    assert not spatial_region_ctx.refinement_of(spatial_region_more_ctx, **kw)
+
+    # Different contexts
+    assert not spatial_region_more_ctx.refinement_of(spatial_region_diff_ctx, **kw)
+
+    # Other is subset of refined
+    assert spatial_region_more_ctx.refinement_of(spatial_region_ctx, **kw)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,9 +1,4 @@
-from mira.dkg.client import Neo4jClient
 from mira.metamodel import ControlledConversion, Concept, NaturalConversion
-
-
-# fixme: how to solve neo4j client?
-client = Neo4jClient(url="bolt://0.0.0.0:7687")
 
 
 def test_templates_equal():
@@ -79,7 +74,7 @@ def test_template_type_inequality_refinement():
     n1 = NaturalConversion(subject=infected, outcome=immune)
 
     try:
-        c1.refinement_of(n1, client)
+        c1.refinement_of(n1)
     except Exception as exc:
         assert isinstance(exc, TypeError), "Expected TypeError"
         assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
@@ -87,7 +82,7 @@ def test_template_type_inequality_refinement():
         raise AssertionError("Expected TypeError")
 
     try:
-        n1.refinement_of(c1, None)
+        n1.refinement_of(c1)
     except Exception as exc:
         assert isinstance(exc, TypeError), "Expected TypeError"
         assert "ControlledConversion" in str(exc) and "NaturalConversion" in str(exc)
@@ -121,7 +116,7 @@ def test_class_incompatibility_refinement():
     natural_conversion = NaturalConversion(subject=infected, outcome=immune)
 
     try:
-        infected.refinement_of(natural_conversion, None)
+        infected.refinement_of(natural_conversion)
     except Exception as exc:
         assert isinstance(exc, TypeError), "Expected TypeError"
     else:
@@ -141,7 +136,7 @@ def test_template_refinement():
     immune = Concept(name="immune population", identifiers={"ido": "0000592"})
     natural_conversion = NaturalConversion(subject=infected, outcome=immune)
     nc_context = natural_conversion.with_context(location="Boston")
-    assert nc_context.refinement_of(natural_conversion, client, with_context=True)
+    assert nc_context.refinement_of(natural_conversion, with_context=True)
 
 
 def test_concept_refinement_grounding():
@@ -154,17 +149,17 @@ def test_concept_refinement_grounding():
         name="one-dimensional spatial region", identifiers={"bfo": "0000026"}
     )
     # test grounded
-    assert one_dim_spat_gnd.refinement_of(spatial_region_gnd, dkg_client=client, with_context=False)
-    assert not one_dim_spat_gnd.refinement_of(spatial_region, dkg_client=client, with_context=False)
-    assert one_dim_spat_gnd.refinement_of(spatial_region_gnd, dkg_client=client, with_context=True)
-    assert not one_dim_spat_gnd.refinement_of(spatial_region, dkg_client=client, with_context=True)
+    assert one_dim_spat_gnd.refinement_of(spatial_region_gnd, with_context=False)
+    assert not one_dim_spat_gnd.refinement_of(spatial_region, with_context=False)
+    assert one_dim_spat_gnd.refinement_of(spatial_region_gnd, with_context=True)
+    assert not one_dim_spat_gnd.refinement_of(spatial_region, with_context=True)
 
     # test ungrounded
-    assert not spatial_region.refinement_of(one_dim_spat, dkg_client=client, with_context=False)
+    assert not spatial_region.refinement_of(one_dim_spat, with_context=False)
     spatial_region_ctx = spatial_region.with_context(location="Stockholm")
-    assert spatial_region_ctx.refinement_of(spatial_region, dkg_client=client, with_context=True)
+    assert spatial_region_ctx.refinement_of(spatial_region, with_context=True)
     assert spatial_region_ctx.refinement_of(
-        spatial_region_gnd, dkg_client=client, with_context=True
+        spatial_region_gnd, with_context=True
     )
 
 
@@ -172,7 +167,7 @@ def test_concept_refinement_simple_context():
     spatial_region_gnd = Concept(name="spatial region", identifiers={"bfo": "0000006"})
     spatial_region_ctx = spatial_region_gnd.with_context(location="Stockholm")
     assert len(spatial_region_ctx.context)
-    kw = {"dkg_client": client, "with_context": True}
+    kw = {"with_context": True}
 
     # Test both empty
     assert not spatial_region_gnd.refinement_of(spatial_region_gnd, **kw)
@@ -190,7 +185,7 @@ def test_concept_refinement_context():
     spatial_region_more_ctx = spatial_region_gnd.with_context(location="Stockholm", year=2010)
     spatial_region_diff_ctx = spatial_region_gnd.with_context(year=2007, count=10)
 
-    kw = {"dkg_client": client, "with_context": True}
+    kw = {"with_context": True}
 
     # Exactly equal context
     assert not spatial_region_ctx.refinement_of(spatial_region_ctx, **kw)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -6,20 +6,33 @@ client = Neo4jClient(url="bolt://0.0.0.0:7687")
 
 
 def test_templates_equal():
+    infected = Concept(name='infected population',
+                       identifiers={'ido': '0000511'})
+    susceptible = Concept(name='susceptible population',
+                          identifiers={'ido': '0000514'})
     c1 = ControlledConversion(
         subject=Concept(name="susceptible"),
         outcome=Concept(name="infected"),
         controller=Concept(name="infected"),
+    )
+    c1_gnd = ControlledConversion(
+        subject=susceptible,
+        outcome=infected,
+        controller=infected,
     )
     c2 = ControlledConversion(
         subject=Concept(name="susceptible"),
         outcome=Concept(name="infected"),
         controller=Concept(name="infected"),
     )
-    c2_w_ctx = c2.with_context(location="Stockholm")
-    assert c1.is_equal_to(c2, with_context=False)
-    assert not c1.is_equal_to(c2_w_ctx, with_context=True)
-    assert c1.is_equal_to(c2_w_ctx, with_context=False)
+    c1_gnd_ctx = c1_gnd.with_context(location="Stockholm")
+    c2_ctx = c2.with_context(location="Stockholm")
+    assert not c1.is_equal_to(c2, with_context=False)
+    assert c1_gnd.is_equal_to(c1_gnd, with_context=False)
+    assert c1_gnd.is_equal_to(c1_gnd_ctx, with_context=False)
+    assert not c1_gnd.is_equal_to(c1_gnd_ctx, with_context=True)
+    assert not c1.is_equal_to(c2_ctx, with_context=True)
+    assert not c1.is_equal_to(c2_ctx, with_context=False)
 
 
 def test_concepts_equal():

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,10 +2,8 @@ from mira.metamodel import ControlledConversion, Concept, NaturalConversion
 
 
 def test_templates_equal():
-    infected = Concept(name='infected population',
-                       identifiers={'ido': '0000511'})
-    susceptible = Concept(name='susceptible population',
-                          identifiers={'ido': '0000514'})
+    infected = Concept(name="infected population", identifiers={"ido": "0000511"})
+    susceptible = Concept(name="susceptible population", identifiers={"ido": "0000514"})
     c1 = ControlledConversion(
         subject=Concept(name="susceptible"),
         outcome=Concept(name="infected"),
@@ -116,9 +114,7 @@ def test_concept_refinement_grounding():
     assert not spatial_region.refinement_of(one_dim_spat, with_context=False)
     spatial_region_ctx = spatial_region.with_context(location="Stockholm")
     assert spatial_region_ctx.refinement_of(spatial_region, with_context=True)
-    assert spatial_region_ctx.refinement_of(
-        spatial_region_gnd, with_context=True
-    )
+    assert spatial_region_ctx.refinement_of(spatial_region_gnd, with_context=True)
 
 
 def test_concept_refinement_simple_context():
@@ -156,3 +152,22 @@ def test_concept_refinement_context():
 
     # Other is subset of refined
     assert spatial_region_more_ctx.refinement_of(spatial_region_ctx, **kw)
+
+
+def test_provide_ont_func():
+    spatial_region_gnd = Concept(name="spatial region", identifiers={"bfo": "0000006"})
+    two_dim_region_gnd = Concept(
+        name="two-dimensional spatial region", identifiers={"bfo": "0000009"}
+    )
+
+    # This random function only check bfo grounded entities and the
+    # identifier numbers, which is probably not a good idea in a real use case
+    def refiner_func(child: str, parent: str) -> bool:
+        if child.startswith("bfo") and parent.startswith("bfo"):
+            child_id = int(child.split(":")[1])
+            parent_id = int(parent.split(":")[1])
+            return child_id > parent_id
+
+        return False
+
+    assert two_dim_region_gnd.refinement_of(spatial_region_gnd, ont_refinement_func=refiner_func)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -57,13 +57,13 @@ def test_class_incompatibility():
     try:
         infected.is_equal_to(nc)
     except Exception as exc:
-        assert isinstance(exc, NotImplementedError)
+        assert isinstance(exc, TypeError)
     else:
         raise AssertionError("Expected NotImplementedError")
 
     try:
         nc.is_equal_to(infected)
     except Exception as exc:
-        assert isinstance(exc, NotImplementedError)
+        assert isinstance(exc, TypeError)
     else:
         raise AssertionError("Expected NotImplementedError")

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Apply automatic formatters
 
 [testenv]
-passenv = PYTHONPATH
+passenv = PYTHONPATH MIRA_REST_URL
 extras =
     tests
     web


### PR DESCRIPTION
This PR implements two new methods, `is_equal_to` and `refinement_of`, for both the `Concept` and `Template` classes.

A boolean flag, `with_context`, is provided as a way to distinguish equality/refinement between concepts/templates that are the same but for context, e.g. location or date.

Another important addition in this PR is a wrapper function, `get_relations_web`, that provides access to `client.query_relations` via a REST API call.