### PR TITLE
Update pydantic version

### DIFF
--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -50,6 +50,7 @@
       "properties": {
         "type": {
           "title": "Type",
+          "default": "NaturalConversion",
           "const": "NaturalConversion",
           "type": "string"
         },
@@ -78,6 +79,7 @@
       "properties": {
         "type": {
           "title": "Type",
+          "default": "ControlledConversion",
           "const": "ControlledConversion",
           "type": "string"
         },

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ license_files =
 
 [options]
 install_requires =
-    pydantic
+    pydantic>=1.10,<1.11
 
 zip_safe = false
 include_package_data = True


### PR DESCRIPTION
This PR updates pydantic to the most recent version (though puts an upper bound, since there's an imminent pydantic 2.0 that's backed with rust) and updates the schema to match suit.