### PR TITLE
Update FastAPI documentation

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -66,7 +66,9 @@ def get_entity(
         example="ido:0000511",
     ),
 ):
-    """Get information about an entity based on its compact URI (CURIE)."""
+    """Get information about an entity (e.g., its name, description synonyms, alternative identifiers,
+    database cross-references, etc.) debased on its compact URI (CURIE).
+    """
     return request.app.state.client.get_entity(curie)
 
 
@@ -76,6 +78,9 @@ def get_entity(
     tags=["entities"],
     response_model_include={"name", "synonyms", "description", "id"},
     response_model_exclude_unset=True,
+    response_description="A successful response contains a list of Entity objects, subset to only "
+    "include the id, name, synonyms, and description fields. Note that below "
+    "in the example, several additional fields are shown, but they are not actually returned.",
 )
 def get_lexical(request: Request):
     """Get lexical information (i.e., name, synonyms, and description) for all entities in the graph."""

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional, Union
 
-from fastapi import APIRouter, Path, Request
+from fastapi import APIRouter, Body, Path, Request
 from neo4j.graph import Relationship
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
@@ -83,7 +83,76 @@ def get_lexical(request: Request):
 
 
 @api_blueprint.post("/relations", response_model=List, tags=["relations"])
-def get_relations(relation_query: RelationQuery, request: Request):
+def get_relations(
+    request: Request,
+    relation_query: RelationQuery = Body(
+        ...,
+        examples={
+            "source type query": {
+                "summary": "Query relations with a given source node type",
+                "value": {
+                    "source_type": "vo",
+                    "limit": 2,
+                },
+            },
+            "target type query": {
+                "summary": "Query relations with a given target node type",
+                "value": {
+                    "target_type": "stmp",
+                    "limit": 2,
+                },
+            },
+            "source/target types query": {
+                "summary": "Query relations with given source/target types",
+                "value": {
+                    "source_type": "doid",
+                    "target_type": "symp",
+                    "limit": 2,
+                },
+            },
+            "source query": {
+                "summary": "Query relations with given source node, by CURIE",
+                "value": {
+                    "source_node": "doid:946",
+                },
+            },
+            "target query": {
+                "summary": "Query relations with given target node, by CURIE",
+                "value": {
+                    "target_node": "symp:0000570",
+                },
+            },
+            "single relation type query": {
+                "summary": "Query relations with given single relation type",
+                "value": {"relation": "rdfs:subClassOf", "limit": 2},
+            },
+            "multiple relation type query": {
+                "summary": "Query relations with given relation types",
+                "value": {"relation": ["rdfs:subClassOf", "bfo:0000050"], "limit": 2},
+            },
+            "increase path length of query": {
+                "summary": "Query a given fixed number of hops",
+                "value": {
+                    "source_curie": "bfo:0000002",
+                    "relation": "rdfs:subClassOf",
+                    "relation_max_hops": 2,
+                    "limit": 2,
+                },
+            },
+            "increase path length of query": {
+                "summary": "Query a variable number of hops",
+                "description": "Distinct is given as true since there might be multiple paths from the source to each given target.",
+                "value": {
+                    "source_curie": "bfo:0000002",
+                    "relation": "rdfs:subClassOf",
+                    "relation_max_hops": 0,
+                    "limit": 2,
+                    "distinct": True,
+                },
+            },
+        },
+    ),
+):
     """Get relations based on the query sent.
 
     The question *which hosts get immunized by the Brucella

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional, Union
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Path, Request
 from neo4j.graph import Relationship
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
@@ -55,22 +55,30 @@ class RelationQuery(BaseModel):
     )
 
 
-@api_blueprint.get("/entity/{curie}", response_model=Entity, tags=["entities"])
-def get_entity(curie: str, request: Request):
-    """Get information about an entity based on its compact URI (CURIE).
-
-    Parameters
-    ----------
-    curie :
-        A compact URI (CURIE) for an entity in the form of <prefix>:<local unique identifier>
-    """
-    # vo:0000001
+@api_blueprint.get(
+    "/entity/{curie}", response_model=Entity, response_model_exclude_unset=True, tags=["entities"]
+)
+def get_entity(
+    request: Request,
+    curie: str = Path(
+        ...,
+        description="A compact URI (CURIE) for an entity in the form of ``<prefix>:<local unique identifier>``",
+        example="ido:0000511",
+    ),
+):
+    """Get information about an entity based on its compact URI (CURIE)."""
     return request.app.state.client.get_entity(curie)
 
 
-@api_blueprint.get("/lexical", response_model=List[LexicalRow], tags=["entities"])
+@api_blueprint.get(
+    "/lexical",
+    response_model=List[Entity],
+    tags=["entities"],
+    response_model_include={"name", "synonyms", "description", "id"},
+    response_model_exclude_unset=True,
+)
 def get_lexical(request: Request):
-    """Get information about an entity."""
+    """Get lexical information (i.e., name, synonyms, and description) for all entities in the graph."""
     return request.app.state.client.get_lexical()
 
 

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -32,7 +32,9 @@ EntityType = Literal["class", "property", "individual"]
 class Entity(BaseModel):
     """An entity in the domain knowledge graph."""
 
-    id: str = Field(..., description="The CURIE of the entity", example="ido:0000511")
+    id: str = Field(
+        ..., title="Compact URI", description="The CURIE of the entity", example="ido:0000511"
+    )
     name: str = Field(..., description="The name of the entity", example="infected population")
     type: EntityType = Field(..., description="The type of the entity", example="class")
     obsolete: bool = Field(..., description="Is the entity marked obsolete?", example=False)
@@ -44,11 +46,13 @@ class Entity(BaseModel):
         default_factory=list, description="A list of string synonyms", example=[]
     )
     alts: List[str] = Field(
+        title="Alternative Identifiers",
         default_factory=list,
         example=[],
         description="A list of alternative identifiers, given as CURIE strings.",
     )
     xrefs: List[str] = Field(
+        title="Database Cross-references",
         default_factory=list,
         example=[],
         description="A list of database cross-references, given as CURIE strings.",

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -221,6 +221,7 @@ class Neo4jClient:
 
     def get_lexical(self) -> List[Entity]:
         """Get Lexical information for all entities."""
+        # FIXME the construction should not allow entities missing names
         query = f"MATCH (n) WHERE NOT n.obsolete and EXISTS(n.name) RETURN n"
         return [Entity(**n) for n, in self.query_tx(query) or []]
 
@@ -258,6 +259,7 @@ class Neo4jClient:
         r = self.query_nodes(cypher)
         if not r:
             return None
+        # FIXME the construction should not allow entities missing names
         return Entity(**r[0])
 
 

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -14,10 +14,13 @@ grounding_blueprint = APIRouter()
 
 
 class GroundRequest(BaseModel):
-    text: str = Field(..., description="The text to be grounded")
+    """A model representing the parameters to be passed to :func:`gilda.ground` for grounding."""
+
+    text: str = Field(..., description="The text to be grounded", example="infected population")
     context: Optional[str] = Field(description="Context around the text to be grounded")
-    organisms: Optional[List[str]] = None
-    namespaces: Optional[List[str]] = None
+    namespaces: Optional[List[str]] = Field(
+        description="A list of namespaces to filter groundings to.", example=["do", "mondo", "ido"]
+    )
 
 
 class GroundResult(BaseModel):
@@ -53,7 +56,6 @@ def ground(ground_request: GroundRequest, request: Request):
         request=request,
         text=ground_request.text,
         context=ground_request.context,
-        organisms=ground_request.organisms,
         namespaces=ground_request.namespaces,
     )
 
@@ -68,12 +70,9 @@ def _ground(
     request: Request,
     text: str,
     context: Optional[str] = None,
-    organisms: Optional[List[str]] = None,
     namespaces: Optional[List[str]] = None,
 ) -> GroundResults:
-    results = request.app.state.grounder.ground(
-        text, context=context, organisms=organisms, namespaces=namespaces
-    )
+    results = request.app.state.grounder.ground(text, context=context, namespaces=namespaces)
     return GroundResults(
         query=text,
         results=[GroundResult.from_scored_match(scored_match) for scored_match in results],

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -90,15 +90,24 @@ def ground(
     request: Request,
     ground_request: GroundRequest = Body(
         ...,
-        # examples={
-        #     "text only": {
-        #         "text": "infected population",
-        #     },
-        #     "filtered by namespace": {
-        #         "text": "infected population",
-        #         "namespaces": ["ido", "cido"],
-        #     },
-        # },
+        # See https://fastapi.tiangolo.com/tutorial/schema-extra-example/#body-with-multiple-examples
+        examples={
+            "simple": {
+                "summary": "An example with only text",
+                "description": "This example only includes a text query. Note that it is a capitalization variant of the actual IDO term, which uses lowercase.",
+                "value": {
+                    "text": "Infected Population",
+                },
+            },
+            "filtered": {
+                "summary": "An example with text and a namespace filter",
+                "description": "The namespaces field can be included to filter results based on terms coming from namespaces with the given prefixes",
+                "value": {
+                    "text": "infected population",
+                    "namespaces": ["ido", "cido"],
+                },
+            },
+        },
     ),
 ):
     """Ground text with Gilda."""
@@ -108,7 +117,13 @@ def ground(
 @grounding_blueprint.get("/ground/{text}", response_model=GroundResults, tags=["grounding"])
 def ground_get(
     request: Request,
-    text: str = Path(..., description="The text to be grounded", example="infected population"),
+    text: str = Path(
+        ...,
+        description="The text to be grounded. Warning: grounding does not work well for "
+        "substring matches, i.e., if searching only for 'infected'. In these "
+        "cases, using the search API is more appropriate.",
+        example="Infected Population",
+    ),
 ):
     """Ground text with Gilda."""
     return _ground(request=request, ground_request=GroundRequest(text=text))

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -19,7 +19,7 @@ class GroundRequest(BaseModel):
     """A model representing the parameters to be passed to :func:`gilda.ground` for grounding."""
 
     text: str = Field(..., description="The text to be grounded", example="Infected Population")
-    context: Optional[str] = Field(description="Context around the text to be grounded")
+    # context: Optional[str] = Field(description="Context around the text to be grounded")
     namespaces: Optional[List[str]] = Field(
         description="A list of namespaces to filter groundings to.", example=["do", "mondo", "ido"]
     )
@@ -136,7 +136,7 @@ def _ground(
 ) -> GroundResults:
     results = request.app.state.grounder.ground(
         ground_request.text,
-        context=ground_request.context,
+        # context=ground_request.context,
         namespaces=ground_request.namespaces,
     )
     return GroundResults(

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -80,10 +80,17 @@ class GroundResults(BaseModel):
     results: List[GroundResult] = Field(..., description="A list of grounding results")
 
 
+GROUNDING_RESPONSE_DESCRIPTION = (
+    "Successful grounding returns an object containing a copy of "
+    "the grounding request as well as a list of grounding results."
+)
+
+
 @grounding_blueprint.post(
     "/ground",
     response_model=GroundResults,
     response_model_exclude_unset=True,
+    response_description=GROUNDING_RESPONSE_DESCRIPTION,
     tags=["grounding"],
 )
 def ground(
@@ -114,7 +121,13 @@ def ground(
     return _ground(request=request, ground_request=ground_request)
 
 
-@grounding_blueprint.get("/ground/{text}", response_model=GroundResults, tags=["grounding"])
+@grounding_blueprint.get(
+    "/ground/{text}",
+    response_model=GroundResults,
+    response_model_exclude_unset=True,
+    response_description=GROUNDING_RESPONSE_DESCRIPTION,
+    tags=["grounding"],
+)
 def ground_get(
     request: Request,
     text: str = Path(

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -126,7 +126,7 @@ def ground_get(
     ),
 ):
     """Ground text with Gilda."""
-    return _ground(request=request, ground_request=GroundRequest(text=text))
+    return _ground(request=request, ground_request=GroundRequest(text=text, namespaces=None))
 
 
 def _ground(

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Body, Path, Request
 from gilda.grounder import ScoredMatch
 from pydantic import BaseModel, Field
 
@@ -12,11 +12,13 @@ __all__ = [
 
 grounding_blueprint = APIRouter()
 
+BR_BASE = "https://bioregistry.io"
+
 
 class GroundRequest(BaseModel):
     """A model representing the parameters to be passed to :func:`gilda.ground` for grounding."""
 
-    text: str = Field(..., description="The text to be grounded", example="infected population")
+    text: str = Field(..., description="The text to be grounded", example="Infected Population")
     context: Optional[str] = Field(description="Context around the text to be grounded")
     namespaces: Optional[List[str]] = Field(
         description="A list of namespaces to filter groundings to.", example=["do", "mondo", "ido"]
@@ -24,56 +26,105 @@ class GroundRequest(BaseModel):
 
 
 class GroundResult(BaseModel):
-    url: str
-    score: float
-    prefix: str
-    identifier: str
-    status: str
+    """The results returned from a grounding request."""
+
+    url: str = Field(
+        ...,
+        description="A URL that resolves the term to an external web service",
+        example=f"{BR_BASE}/ido:0000511",
+    )
+    score: float = Field(
+        ..., description="The matching score calculated by Gilda", ge=0.0, le=1.0, example=0.78
+    )
+    prefix: str = Field(
+        ...,
+        description="The prefix corresponding to the ontology/database from which the term comes",
+        example="ido",
+    )
+    identifier: str = Field(
+        ...,
+        description="The local unique identifier for the term in the ontology/database denoted by the prefix",
+        example="0000511",
+    )
+    curie: str = Field(
+        ...,
+        description="The compact URI that combines the prefix and local identifier.",
+        example="ido:0000511",
+    )
+    name: str = Field(
+        ..., description="The standard entity name for the term", example="infected population"
+    )
+    status: str = Field(..., description="The match status, e.g., name, synonym", example="name")
 
     @classmethod
     def from_scored_match(cls, scored_match: ScoredMatch) -> "GroundResult":
         identifier = scored_match.term.id
-        if identifier.startswith(scored_match.term.db):
-            identifier = identifier[len(scored_match.term.db) + 1 :]
+        prefix = scored_match.term.db
+        if identifier.startswith(prefix):
+            identifier = identifier[len(prefix) + 1 :]
         return cls(
-            url=scored_match.url,
-            score=scored_match.score,
-            prefix=scored_match.term.db,
+            url=f"{BR_BASE}/{prefix}:{identifier}",
+            score=round(scored_match.score, 2),
+            prefix=prefix,
             identifier=identifier,
+            curie=f"{prefix}:{identifier}",
+            name=scored_match.term.entry_name,
             status=scored_match.term.status,
         )
 
 
 class GroundResults(BaseModel):
-    query: str
-    results: List[GroundResult]
+    """A grouped set of results."""
+
+    request: GroundRequest = Field(..., description="A request for grounding")
+    results: List[GroundResult] = Field(..., description="A list of grounding results")
 
 
-@grounding_blueprint.post("/ground", response_model=GroundResults, tags=["grounding"])
-def ground(ground_request: GroundRequest, request: Request):
+@grounding_blueprint.post(
+    "/ground",
+    response_model=GroundResults,
+    response_model_exclude_unset=True,
+    tags=["grounding"],
+)
+def ground(
+    request: Request,
+    ground_request: GroundRequest = Body(
+        ...,
+        # examples={
+        #     "text only": {
+        #         "text": "infected population",
+        #     },
+        #     "filtered by namespace": {
+        #         "text": "infected population",
+        #         "namespaces": ["ido", "cido"],
+        #     },
+        # },
+    ),
+):
     """Ground text with Gilda."""
-    return _ground(
-        request=request,
-        text=ground_request.text,
-        context=ground_request.context,
-        namespaces=ground_request.namespaces,
-    )
+    return _ground(request=request, ground_request=ground_request)
 
 
 @grounding_blueprint.get("/ground/{text}", response_model=GroundResults, tags=["grounding"])
-def ground_get(text: str, request: Request):
+def ground_get(
+    request: Request,
+    text: str = Path(..., description="The text to be grounded", example="infected population"),
+):
     """Ground text with Gilda."""
-    return _ground(request=request, text=text)
+    return _ground(request=request, ground_request=GroundRequest(text=text))
 
 
 def _ground(
+    *,
     request: Request,
-    text: str,
-    context: Optional[str] = None,
-    namespaces: Optional[List[str]] = None,
+    ground_request: GroundRequest,
 ) -> GroundResults:
-    results = request.app.state.grounder.ground(text, context=context, namespaces=namespaces)
+    results = request.app.state.grounder.ground(
+        ground_request.text,
+        context=ground_request.context,
+        namespaces=ground_request.namespaces,
+    )
     return GroundResults(
-        query=text,
+        request=ground_request,
         results=[GroundResult.from_scored_match(scored_match) for scored_match in results],
     )

--- a/mira/modeling/ops.py
+++ b/mira/modeling/ops.py
@@ -3,8 +3,8 @@
 import itertools as itt
 from typing import Iterable, Optional, Set, Tuple, Type
 
-from ..metamodel import ControlledConversion, NaturalConversion, Template
 from . import TemplateModel
+from ..metamodel import ControlledConversion, NaturalConversion, Template
 
 __all__ = [
     "stratify",

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,9 @@ docs =
     m2r2
     pygraphviz
 
+[mypy]
+plugins = pydantic.mypy
+
 ##########################
 # Darglint Configuration #
 ##########################

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -1,12 +1,16 @@
 """Tests for the domain knowledge graph app."""
 
+import inspect
+import os
 import unittest
+
+import fastapi.params
+import pystow
 from fastapi.testclient import TestClient
 from gilda.grounder import Grounder
-from mira.dkg.utils import MiraState
 
-import pystow
-import os
+from mira.dkg.api import get_relations
+from mira.dkg.utils import MiraState
 
 MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
 
@@ -30,16 +34,31 @@ class TestDKG(unittest.TestCase):
         """Test grounding with a get request."""
         response = self.client.get("/api/ground/vaccine")
         self.assertEqual(200, response.status_code, msg=response.content)
-        self.assertTrue(any(
-            r["prefix"] == "vo" and r["identifier"] == "0000001"
-            for r in response.json()["results"]
-        ))
+        self.assertTrue(
+            any(
+                r["prefix"] == "vo" and r["identifier"] == "0000001"
+                for r in response.json()["results"]
+            )
+        )
 
     def test_grounding_post(self):
         """Test grounding with a post request."""
         response = self.client.post("/api/ground", json={"text": "vaccine"})
         self.assertEqual(200, response.status_code, msg=response.content)
-        self.assertTrue(any(
-            r["prefix"] == "vo" and r["identifier"] == "0000001"
-            for r in response.json()["results"]
-        ))
+        self.assertTrue(
+            any(
+                r["prefix"] == "vo" and r["identifier"] == "0000001"
+                for r in response.json()["results"]
+            )
+        )
+
+    def test_get_relations(self):
+        """Test getting relations."""
+        spec = inspect.signature(get_relations)
+        relation_query_default = spec.parameters["relation_query"].default
+        self.assertIsInstance(relation_query_default, fastapi.params.Body)
+
+        for key, data in relation_query_default.examples.items():
+            with self.subTest(key=key):
+                response = self.client.post("/api/relations", json=data["value"])
+                self.assertEqual(200, response.status_code, msg=response.content)

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -26,9 +26,18 @@ class TestDKG(unittest.TestCase):
         self.assertIsInstance(self.client.app.state, MiraState)
         self.assertIsInstance(self.client.app.state.grounder, Grounder)
 
-    def test_grounding(self):
-        """Test grounding."""
+    def test_grounding_get(self):
+        """Test grounding with a get request."""
         response = self.client.get("/api/ground/vaccine")
+        self.assertEqual(200, response.status_code, msg=response.content)
+        self.assertTrue(any(
+            r["prefix"] == "vo" and r["identifier"] == "0000001"
+            for r in response.json()["results"]
+        ))
+
+    def test_grounding_post(self):
+        """Test grounding with a post request."""
+        response = self.client.post("/api/ground", json={"text": "vaccine"})
         self.assertEqual(200, response.status_code, msg=response.content)
         self.assertTrue(any(
             r["prefix"] == "vo" and r["identifier"] == "0000001"

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,16 @@ commands =
         mira/modeling/ops.py \
         mira/modeling/viz.py \
         notebooks/dkg_api.ipynb \
-        tests/test_ops.py
+        tests/test_ops.py \
+        tests/test_dkg.py
     isort \
         mira/dkg \
         mira/examples \
         mira/modeling/ops.py \
         mira/modeling/viz.py \
         notebooks/dkg_api.ipynb \
-        tests/test_ops.py
+        tests/test_ops.py \
+        tests/test_dkg.py
 description = Apply automatic formatters
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -55,3 +55,11 @@ deps =
     flake8<5.0.0
 commands =
     flake8 mira/ tests/
+
+[testenv:mypy]
+deps =
+    mypy
+    pydantic
+skip_install = true
+commands = mypy --install-types --non-interactive --ignore-missing-imports mira/
+description = Run the mypy tool to check static typing on the project.


### PR DESCRIPTION
This PR does the following:

1. Improves documentation for models (adds titles, descriptions, examples)
2. Improves documentation for endpoints (adds better examples)
3. Reduces unnecessary return values with `response_model_exclude_unset`
4. Updates some potential bugs found with `mypy`
5. Simplifies the return types using the `Entity` model

I found with `MATCH (n) WHERE NOT EXISTS(n.name) RETURN n` that there are 7 nodes without labels, this shouldn't be allowed. In the mean time, I will have it filter out those nodes, but the DKG construction should ensure this doesn't happen 