### PR TITLE
Web client

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -247,4 +247,4 @@ def get_relations(
 )
 def search(request: Request, q: str = Query(..., example="infect"), limit: int = 25):
     """Get nodes based on a search to their name/synonyms."""
-    return request.app.state.client.search(q)
+    return request.app.state.client.search(q, limit=limit)

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -248,3 +248,7 @@ def get_relations(
 def search(request: Request, q: str = Query(..., example="infect"), limit: int = 25):
     """Get nodes based on a search to their name/synonyms."""
     return request.app.state.client.search(q)
+
+
+#: mapping from function name to route
+endpoints_mapping = {r.name: r for r in api_blueprint.routes}

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -248,7 +248,3 @@ def get_relations(
 def search(request: Request, q: str = Query(..., example="infect"), limit: int = 25):
     """Get nodes based on a search to their name/synonyms."""
     return request.app.state.client.search(q)
-
-
-#: mapping from function name to route
-endpoints_mapping = {r.name: r for r in api_blueprint.routes}

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -19,9 +19,15 @@ class GroundRequest(BaseModel):
     """A model representing the parameters to be passed to :func:`gilda.ground` for grounding."""
 
     text: str = Field(..., description="The text to be grounded", example="Infected Population")
-    # context: Optional[str] = Field(description="Context around the text to be grounded")
+    context: Optional[str] = Field(
+        None,
+        description="Context around the text to be grounded",
+        example="The infected population increased over the past month",
+    )
     namespaces: Optional[List[str]] = Field(
-        description="A list of namespaces to filter groundings to.", example=["do", "mondo", "ido"]
+        None,
+        description="A list of namespaces to filter groundings to.",
+        example=["do", "mondo", "ido"],
     )
 
 
@@ -113,6 +119,14 @@ def ground(
                     "text": "infected population",
                     "namespaces": ["ido", "cido"],
                 },
+                "context": {
+                    "summary": "An example with text and context",
+                    "description": "The context field can be included to provide context for the grounding mechanism to better disambiguate the term provided",
+                    "value": {
+                        "text": "infected population",
+                        "context": "The infected population increased the past month.",
+                    },
+                },
             },
         },
     ),
@@ -139,7 +153,7 @@ def ground_get(
     ),
 ):
     """Ground text with Gilda."""
-    return _ground(request=request, ground_request=GroundRequest(text=text, namespaces=None))
+    return _ground(request=request, ground_request=GroundRequest(text=text))
 
 
 def _ground(
@@ -149,7 +163,7 @@ def _ground(
 ) -> GroundResults:
     results = request.app.state.grounder.ground(
         ground_request.text,
-        # context=ground_request.context,
+        context=ground_request.context,
         namespaces=ground_request.namespaces,
     )
     return GroundResults(

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -82,7 +82,7 @@ def get_relations_web(
         An instance of a RelationQuery BaseModel
     api_url :
         Use this parameter to specify the REST API base url or to override
-        the url set
+        the url set in the environment or the config
 
     Returns
     -------

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -94,7 +94,7 @@ def get_relations_web(
     )
     # fixme: the response can also be tuple, but it looks like the api code
     #  is not done yet over there
-    return [api.RelationResponse(r) for r in res_json]
+    return [api.RelationResponse(**r) for r in res_json]
 
 
 def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.Entity]:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -169,6 +169,16 @@ def ground_web(
         return grounding.GroundResults(**res_json)
 
 
+def search_web(
+    term: str, limit: int = 25, api_url: Optional[str] = None
+) -> Optional[List[api.Entity]]:
+    res_json = web_client(
+        endpoint="/search", method="get", query_json={"q": term, "limit": limit}, api_url=api_url
+    )
+    if res_json is not None:
+        return [api.Entity(**e) for e in res_json]
+
+
 def is_ontological_child(
     child_curie: str, parent_curie: str, api_url: Optional[str] = None
 ) -> bool:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Literal, Dict, Any, List
+from typing import Optional, Literal, Dict, Any, List, Union
 
 import pystow
 import requests
@@ -19,7 +19,7 @@ def web_client(
     method: Literal["get", "post"],
     query_json: Optional[Dict[str, Any]] = None,  # Required for post
     api_url: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """A wrapper for sending requests to the REST API and returning the
 
     Parameters

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -131,7 +131,7 @@ def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.En
         return api.Entity(**res_json)
 
 
-def get_lexical_web(api_url: Optional[str] = None) -> List[api.Entity]:
+def get_lexical_web(api_url: Optional[str] = None) -> List[Dict[str, Any]]:
     """Get lexical information for all entities in the graph
 
     A wrapper that calls the REST API's lexical endpoint.
@@ -147,8 +147,7 @@ def get_lexical_web(api_url: Optional[str] = None) -> List[api.Entity]:
     :
         A list of all entities in the graph.
     """
-    res_json = web_client(endpoint="/lexical", method="get", api_url=api_url)
-    return [api.Entity(**e) for e in res_json]
+    return web_client(endpoint="/lexical", method="get", api_url=api_url)
 
 
 def ground_web(

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -103,8 +103,9 @@ def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.En
         return api.Entity(**res_json)
 
 
-def get_lexical_web() -> List[api.Entity]:
-    pass
+def get_lexical_web(api_url: Optional[str] = None) -> List[api.Entity]:
+    res_json = web_client(endpoint="/lexical", method="get", api_url=api_url)
+    return [api.Entity(**e) for e in res_json]
 
 
 def is_ontological_child(child_curie: str, parent_curie: str) -> bool:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -10,6 +10,9 @@ from mira.dkg import api, grounding
 
 __all__ = [
     "get_relations_web",
+    "get_entity_web",
+    "get_lexical_web",
+    "ground_web",
     "is_ontological_child",
 ]
 

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -94,7 +94,21 @@ def get_relations_web(
     Returns
     -------
     :
-        If any relation exists, a list of RelationResponse models.
+        If any relation exists, a list of RelationResponse models or
+        FullRelationResponse models if a full query was requested.
+
+    Examples
+    --------
+    To populate the RelationQuery BaseModel, follow this example:
+
+    .. code-block:: python
+
+        from mira.dkg.api import RelationQuery
+        from mira.dkg.web_client import get_relations_web
+        relation_query = RelationQuery(target_curie="ncbitaxon:10090", relations="vo:0001243")
+        relations = get_relations_web(relations_model=relation_query)
+        print(relations[:5])
+
     """
     query_json = relations_model.dict(exclude_unset=True, exclude_defaults=True)
     res_json = web_client(
@@ -177,7 +191,7 @@ def ground_web(
     """
     query_json = {"text": text}
     if namespaces is not None:
-        query_json['namespaces'] = namespaces
+        query_json["namespaces"] = namespaces
     res_json = web_client(endpoint="/ground", method="post", query_json=query_json, api_url=api_url)
     if res_json is not None:
         return grounding.GroundResults(**res_json)

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -4,15 +4,15 @@ from typing import Optional, Literal, Dict, Any, List, Union
 import pystow
 import requests
 
-from mira.dkg.utils import DKG_REFINER_RELS
 from mira.dkg import api, grounding
-
+from mira.dkg.utils import DKG_REFINER_RELS
 
 __all__ = [
     "get_relations_web",
     "get_entity_web",
     "get_lexical_web",
     "ground_web",
+    "search_web",
     "is_ontological_child",
 ]
 

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -94,7 +94,8 @@ def get_relations_web(
     )
     # fixme: the response can also be tuple, but it looks like the api code
     #  is not done yet over there
-    return [api.RelationResponse(**r) for r in res_json]
+    if res_json is not None:
+        return [api.RelationResponse(**r) for r in res_json]
 
 
 def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.Entity]:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -72,7 +72,7 @@ def web_client(
 
 def get_relations_web(
     relations_model: api.RelationQuery,
-    api_url: str = None,
+    api_url: Optional[str] = None,
 ):
     """A wrapper that call the rest API's get_relations endpoint
 
@@ -97,7 +97,7 @@ def get_relations_web(
     return [api.RelationResponse(r) for r in res_json]
 
 
-def get_entity_web(curie: str, api_url: str) -> Optional[api.Entity]:
+def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.Entity]:
     res_json = web_client(endpoint=f"/entity/{curie}", method="get", api_url=api_url)
     if res_json is not None:
         return api.Entity(**res_json)

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Literal, Dict, Any
+from typing import Optional, Literal, Dict, Any, List
 
 import pystow
 import requests
@@ -95,6 +95,16 @@ def get_relations_web(
     # fixme: the response can also be tuple, but it looks like the api code
     #  is not done yet over there
     return [api.RelationResponse(r) for r in res_json]
+
+
+def get_entity_web(curie: str, api_url: str) -> Optional[api.Entity]:
+    res_json = web_client(endpoint=f"/entity/{curie}", method="get", api_url=api_url)
+    if res_json is not None:
+        return api.Entity(**res_json)
+
+
+def get_lexical_web() -> List[api.Entity]:
+    pass
 
 
 def is_ontological_child(child_curie: str, parent_curie: str) -> bool:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -231,4 +231,4 @@ def is_ontological_child(
         source_curie=child_curie, relations=DKG_REFINER_RELS, target_curie=parent_curie, limit=1
     )
     res = get_relations_web(relations_model=rel_model, api_url=api_url)
-    return len(res) > 0
+    return res is not None and len(res) > 0

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -151,7 +151,9 @@ def get_lexical_web(api_url: Optional[str] = None) -> List[Dict[str, Any]]:
 
 
 def ground_web(
-    grounding_model: grounding.GroundRequest, api_url: Optional[str] = None
+    text: str,
+    namespaces: Optional[List[str]] = None,
+    api_url: Optional[str] = None,
 ) -> Optional[grounding.GroundResults]:
     """Ground text with Gilda to an ontology identifier
 
@@ -159,8 +161,10 @@ def ground_web(
 
     Parameters
     ----------
-    grounding_model :
-        An instance of a GroundingRequest model.
+    text :
+        The text to be grounded.
+    namespaces :
+        A list of namespaces to filter groundings to. Optional. Example=["do", "mondo", "ido"]
     api_url
         Use this parameter to specify the REST API base url or to override
         the url set in the environment or the config.
@@ -171,7 +175,9 @@ def ground_web(
         If the query results in at least one grounding, a GroundResults
         model is returned with all the results.
     """
-    query_json = grounding_model.dict(exclude_unset=True, exclude_defaults=True)
+    query_json = {"text": text}
+    if namespaces is not None:
+        query_json['namespaces'] = namespaces
     res_json = web_client(endpoint="/ground", method="post", query_json=query_json, api_url=api_url)
     if res_json is not None:
         return grounding.GroundResults(**res_json)

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -173,6 +173,25 @@ def ground_web(
 def search_web(
     term: str, limit: int = 25, api_url: Optional[str] = None
 ) -> Optional[List[api.Entity]]:
+    """Get nodes based on a search to their name/synonyms
+
+    A wrapper that call the REST API's search endpoint
+
+    Parameters
+    ----------
+    term :
+        The term to search for
+    limit :
+        Limit the number of results to this number. Default: 25.
+    api_url :
+        Use this parameter to specify the REST API base url or to override
+        the url set in the environment or the config.
+
+    Returns
+    -------
+    :
+        A list of the matching entities.
+    """
     res_json = web_client(
         endpoint="/search", method="get", query_json={"q": term, "limit": limit}, api_url=api_url
     )

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -78,7 +78,7 @@ def web_client(
 def get_relations_web(
     relations_model: api.RelationQuery,
     api_url: Optional[str] = None,
-) -> List[api.RelationResponse]:
+) -> Union[List[api.RelationResponse], List[api.FullRelationResponse]]:
     """A wrapper that call the REST API's get_relations endpoint.
 
     Parameters
@@ -98,10 +98,11 @@ def get_relations_web(
     res_json = web_client(
         endpoint="/relations", method="post", query_json=query_json, api_url=api_url
     )
-    # fixme: the response can also be tuple, but it looks like the api code
-    #  is not done yet over there
     if res_json is not None:
-        return [api.RelationResponse(**r) for r in res_json]
+        if relations_model.full:
+            return [api.FullRelationResponse(**r) for r in res_json]
+        else:
+            return [api.RelationResponse(**r) for r in res_json]
 
 
 def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.Entity]:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -41,7 +41,7 @@ def web_client(
     -------
     :
         The data sent back from the endpoint as a json, unless the response
-        is empty.
+        is empty, in which case None is returned.
     """
     base_url = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
 
@@ -67,7 +67,7 @@ def web_client(
         kw = dict() if query_json is None else {"params": query_json}
         res = requests.get(endpoint_url, **kw)
     else:
-        raise ValueError("method must be one of 'get' and 'post'")
+        raise ValueError("Method must be one of 'get' and 'post'")
 
     res.raise_for_status()
 
@@ -79,7 +79,9 @@ def get_relations_web(
     relations_model: api.RelationQuery,
     api_url: Optional[str] = None,
 ) -> Union[List[api.RelationResponse], List[api.FullRelationResponse]]:
-    """A wrapper that call the REST API's get_relations endpoint.
+    """Get relations based on the query contained in the RelationQuery model
+
+    A wrapper that call the REST API's get_relations endpoint.
 
     Parameters
     ----------
@@ -106,7 +108,9 @@ def get_relations_web(
 
 
 def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.Entity]:
-    """A wrapper that calls the REST API's entity endpoint.
+    """Get information about an entity based on its compact URI (CURIE)
+
+    A wrapper that calls the REST API's entity endpoint.
 
     Parameters
     ----------
@@ -128,7 +132,9 @@ def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.En
 
 
 def get_lexical_web(api_url: Optional[str] = None) -> List[api.Entity]:
-    """A wrapper that calls the REST API's lexical endpoint.
+    """Get lexical information for all entities in the graph
+
+    A wrapper that calls the REST API's lexical endpoint.
 
     Parameters
     ----------
@@ -148,7 +154,9 @@ def get_lexical_web(api_url: Optional[str] = None) -> List[api.Entity]:
 def ground_web(
     grounding_model: grounding.GroundRequest, api_url: Optional[str] = None
 ) -> Optional[grounding.GroundResults]:
-    """A wrapper that calls the REST API's grounding POST endpoint
+    """Ground text with Gilda to an ontology identifier
+
+    A wrapper that calls the REST API's grounding POST endpoint
 
     Parameters
     ----------

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -5,7 +5,7 @@ import pystow
 import requests
 
 from mira.dkg.utils import DKG_REFINER_RELS
-from mira.dkg import api
+from mira.dkg import api, grounding
 
 
 __all__ = [
@@ -107,6 +107,15 @@ def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.En
 def get_lexical_web(api_url: Optional[str] = None) -> List[api.Entity]:
     res_json = web_client(endpoint="/lexical", method="get", api_url=api_url)
     return [api.Entity(**e) for e in res_json]
+
+
+def ground_web(
+    grounding_model: grounding.GroundRequest, api_url: Optional[str] = None
+) -> grounding.GroundResults:
+    query_json = grounding_model.dict(exclude_unset=True, exclude_defaults=True)
+    res_json = web_client(endpoint="/ground", method="post", query_json=query_json, api_url=api_url)
+    if res_json is not None:
+        return grounding.GroundResults(**res_json)
 
 
 def is_ontological_child(

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -89,7 +89,12 @@ def get_relations_web(
 
     """
     query_json = relations_model.dict(exclude_unset=True, exclude_defaults=True)
-    return web_client(query_json=query_json, method="post", endpoint="/relations", api_url=api_url)
+    res_json = web_client(
+        endpoint="/relations", method="post", query_json=query_json, api_url=api_url
+    )
+    # fixme: the response can also be tuple, but it looks like the api code
+    #  is not done yet over there
+    return [api.RelationResponse(r) for r in res_json]
 
 
 def is_ontological_child(child_curie: str, parent_curie: str) -> bool:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -108,7 +108,9 @@ def get_lexical_web(api_url: Optional[str] = None) -> List[api.Entity]:
     return [api.Entity(**e) for e in res_json]
 
 
-def is_ontological_child(child_curie: str, parent_curie: str) -> bool:
+def is_ontological_child(
+    child_curie: str, parent_curie: str, api_url: Optional[str] = None
+) -> bool:
     """Check if one curie is a child term of another curie
 
     Parameters
@@ -117,6 +119,9 @@ def is_ontological_child(child_curie: str, parent_curie: str) -> bool:
         The entity, identified by its CURIE that is assumed to be a child term
     parent_curie :
         The entity, identified by its CURIE that is assumed to be a parent term
+    api_url :
+        Use this parameter to specify the REST API base url or to override
+        the url set in the environment or the config
 
     Returns
     -------
@@ -127,5 +132,5 @@ def is_ontological_child(child_curie: str, parent_curie: str) -> bool:
     rel_model = api.RelationQuery(
         source_curie=child_curie, relations=DKG_REFINER_RELS, target_curie=parent_curie, limit=1
     )
-    res = get_relations_web(relations_model=rel_model)
+    res = get_relations_web(relations_model=rel_model, api_url=api_url)
     return len(res) > 0

--- a/notebooks/web_client.ipynb
+++ b/notebooks/web_client.ipynb
@@ -14,12 +14,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "outputs": [],
    "source": [
     "from mira.dkg.web_client import get_entity_web, ground_web, get_relations_web\n",
-    "from mira.dkg.api import RelationQuery\n",
-    "from mira.dkg.grounding import GroundRequest"
+    "from mira.dkg.api import RelationQuery"
    ],
    "metadata": {
     "collapsed": false,
@@ -31,7 +30,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "To ground an entity, create a `GroundRequest` model and use the `ground_web` function:"
+    "To ground an entity, provide `ground_web` with at least the text to be grounded:"
    ],
    "metadata": {
     "collapsed": false,
@@ -42,44 +41,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'mira.dkg.grounding.GroundResults'>\n"
+      "<class 'mira.dkg.grounding.GroundResults'>\n",
+      "request=GroundRequest(text='Infected Population', namespaces=None) results=[GroundResult(url='https://bioregistry.io/ido:0000511', score=0.76, prefix='ido', identifier='0000511', curie='ido:0000511', name='infected population', status='name')]\n"
      ]
     }
    ],
    "source": [
-    "ground_req_model = GroundRequest(text=\"Infected Population\")\n",
-    "ground_res = ground_web(grounding_model=ground_req_model)\n",
+    "ground_res = ground_web(text=\"Infected Population\")\n",
     "# ground_web returns a GroundResults model from mira.dkg.grounding\n",
-    "print(ground_res.__class__)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "GroundResults(request=GroundRequest(text='Infected Population', namespaces=None), results=[GroundResult(url='https://bioregistry.io/ido:0000511', score=0.76, prefix='ido', identifier='0000511', curie='ido:0000511', name='infected population', status='name')])"
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ground_res"
+    "print(ground_res.__class__)\n",
+    "print(ground_res)"
    ],
    "metadata": {
     "collapsed": false,
@@ -91,7 +68,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "To get more information about an entity, provide it's curie to the `get_entity_web` function:"
+    "To get more information about an entity, provide its curie to the `get_entity_web` function:"
    ],
    "metadata": {
     "collapsed": false,
@@ -102,13 +79,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "outputs": [
     {
      "data": {
       "text/plain": "Entity(id='ido:0000511', name='infected population', type='class', obsolete=False, description='An organism population whose members have an infection.', synonyms=[], alts=[], xrefs=[], labels=['ido'])"
      },
-     "execution_count": 14,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -138,13 +115,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "outputs": [
     {
      "data": {
-      "text/plain": "[RelationResponse(subject='vo:0000018', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000021', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000022', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000110', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000263', predicate='vo:0001243', object='ncbitaxon:10090')]"
+      "text/plain": "[RelationResponse(subject='vo:0005143', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0005154', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000018', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000021', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000022', predicate='vo:0001243', object='ncbitaxon:10090')]"
      },
-     "execution_count": 15,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/web_client.ipynb
+++ b/notebooks/web_client.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This notebook shows how to use the web client in the `web_client` module. The web client assumes the URL to the REST API is set either in the environment with `MIRA_REST_URL` or in the mira configuration file under `rest_url`. The REST API url can also be provided directly to the functions in the module using the optional `api_url` parameter that will override any other setting of the REST API url."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [],
+   "source": [
+    "from mira.dkg.web_client import get_entity_web, ground_web, get_relations_web\n",
+    "from mira.dkg.api import RelationQuery\n",
+    "from mira.dkg.grounding import GroundRequest"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To ground an entity, create a `GroundRequest` model and use the `ground_web` function:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'mira.dkg.grounding.GroundResults'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "ground_req_model = GroundRequest(text=\"Infected Population\")\n",
+    "ground_res = ground_web(grounding_model=ground_req_model)\n",
+    "# ground_web returns a GroundResults model from mira.dkg.grounding\n",
+    "print(ground_res.__class__)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "GroundResults(request=GroundRequest(text='Infected Population', namespaces=None), results=[GroundResult(url='https://bioregistry.io/ido:0000511', score=0.76, prefix='ido', identifier='0000511', curie='ido:0000511', name='infected population', status='name')])"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ground_res"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To get more information about an entity, provide it's curie to the `get_entity_web` function:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "Entity(id='ido:0000511', name='infected population', type='class', obsolete=False, description='An organism population whose members have an infection.', synonyms=[], alts=[], xrefs=[], labels=['ido'])"
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "entity = get_entity_web(curie=\"ido:0000511\")\n",
+    "entity"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To query for relations, use the `get_relations_web` function:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[RelationResponse(subject='vo:0000018', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000021', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000022', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000110', predicate='vo:0001243', object='ncbitaxon:10090'),\n RelationResponse(subject='vo:0000263', predicate='vo:0001243', object='ncbitaxon:10090')]"
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "relation_query = RelationQuery(target_curie=\"ncbitaxon:10090\", relations=\"vo:0001243\")\n",
+    "relations = get_relations_web(relations_model=relation_query)\n",
+    "relations[:5]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -4,7 +4,7 @@ from requests import HTTPError
 
 from mira.dkg.api import RelationQuery, RelationResponse, FullRelationResponse
 from mira.dkg.client import Entity
-from mira.dkg.grounding import GroundRequest, GroundResults
+from mira.dkg.grounding import GroundRequest, GroundResults, GroundResult
 from mira.dkg.web_client import *
 from mira.dkg.web_client import web_client
 
@@ -60,8 +60,10 @@ def test_get_entity():
 
 
 def test_ground():
-    res = ground_web(grounding_model=GroundRequest(text="Infected Population"))
+    res = ground_web(text="Infected Population")
     assert isinstance(res, GroundResults)
+    assert len(res.results) > 0
+    assert isinstance(res.results[0], GroundResult)
 
 
 # Skip this test

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -1,0 +1,74 @@
+import unittest
+
+from requests import HTTPError
+
+from mira.dkg.api import RelationQuery, RelationResponse, FullRelationResponse
+from mira.dkg.client import Entity
+from mira.dkg.grounding import GroundRequest, GroundResults
+from mira.dkg.web_client import *
+from mira.dkg.web_client import web_client
+
+
+# Test the failsafe mechanisms in web_client
+def test_web_client():
+    try:
+        web_client(endpoint="/relations", method="post", query_json=None)
+    except Exception as exc:
+        assert isinstance(exc, ValueError)
+        assert "POST request to endpoint /relations requires query data" in str(exc)
+    else:
+        raise AssertionError(f"Expected POST request ValueError")
+
+    # Bad method
+    try:
+        web_client(endpoint="/relations", method="put")
+    except Exception as exc:
+        assert isinstance(exc, ValueError)
+        assert "Method must be one of 'get' and 'post'" in str(exc)
+    else:
+        raise AssertionError(f"Expected bad method ValueError")
+
+    # Bad endpoint
+    try:
+        web_client(endpoint="/does_not_exist", method="get")
+    except Exception as exc:
+        assert isinstance(exc, HTTPError)
+        assert exc.response.status_code == 404
+
+
+def test_get_relations():
+    res = get_relations_web(relations_model=RelationQuery(source_type="vo", limit=2))
+    assert isinstance(res, list)
+    assert isinstance(res[0], RelationResponse)
+
+    res = get_relations_web(relations_model=RelationQuery(source_type="vo", limit=2, full=True))
+    assert isinstance(res, list)
+    assert isinstance(res[0], FullRelationResponse)
+
+
+def test_search():
+    res = search_web(term="infect")
+    assert isinstance(res, list)
+    assert len(res)
+    assert isinstance(res[0], Entity)
+
+
+def test_get_entity():
+    res = get_entity_web(curie="ido:0000511")
+    assert isinstance(res, Entity)
+    assert res.id == "ido:0000511"
+
+
+def test_ground():
+    res = ground_web(grounding_model=GroundRequest(text="Infected Population"))
+    assert isinstance(res, GroundResults)
+
+
+# Skip this test
+@unittest.skip("Takes memory and time to run, should be run locally")
+def test_lexical():
+    res = get_lexical_web()
+    assert res is not None
+    assert isinstance(res, list)
+    assert isinstance(res[0], dict)
+    assert {"id", "name"}.issubset(res[0].keys())


### PR DESCRIPTION
This PR extends the web client module to several new endpoints:
- `/api/ground`
- `/api/search`
- `/api/entity/{curie}`
- `/api/lexical`

An IPython Notebook showing simple example of how to use the different clients is added.
Tests for each client function are added.