### PR TITLE
Fix api names

### DIFF
--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 
 from mira.metamodel import NaturalConversion, Template, ControlledConversion
 from mira.modeling import Model, TemplateModel
-#from mira.modeling.gromet_model import GrometModel
+# from mira.modeling.gromet_model import GrometModel
 from mira.modeling.ops import stratify
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
@@ -77,7 +77,7 @@ class PetriNetResponse(BaseModel):
     O: Outputs = Field(..., description="A list of outputs")  # Outputs
 
 
-@model_blueprint.post("/to_petrinet", response_model=PetriNetResponse)
+@model_blueprint.post("/to_petrinet", response_model=PetriNetResponse, tags=["model"])
 def model_to_petri(template_model: TemplateModel = Body(..., example=template_model_example)):
     """Create a PetriNet model from a TemplateModel"""
     model = Model(template_model)
@@ -101,7 +101,7 @@ def model_to_petri(template_model: TemplateModel = Body(..., example=template_mo
 #     )
 #
 #
-# @model_blueprint.post("/to_gromet", response_model=Dict[str, Any])
+# @model_blueprint.post("/to_gromet", response_model=Dict[str, Any], tags=["model"])
 # def model_to_gromet(
 #     data: ToGrometQuery = Body(
 #         ...,
@@ -150,7 +150,7 @@ class StratificationQuery(BaseModel):
         return ControlledConversion
 
 
-@model_blueprint.post("/stratify", response_model=TemplateModel)
+@model_blueprint.post("/stratify", response_model=TemplateModel, tags=["model"])
 def model_stratification(
     stratification_query: StratificationQuery = Body(
         ...,
@@ -211,6 +211,7 @@ def _graph_model(
     "/viz/to_dot_file",
     response_class=FileResponse,
     response_description="A successful response returns a grapviz dot file of the provided TemplateModel",
+    tags=["model"],
 )
 def model_to_viz_dot(
     bg_task: BackgroundTasks,
@@ -231,6 +232,7 @@ def model_to_viz_dot(
     response_class=FileResponse,
     response_description="A successful response returns a png image of the "
     "graph representation of the provided TemplateModel",
+    tags=["model"],
 )
 def model_to_graph_image(
     bg_task: BackgroundTasks,

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -77,7 +77,7 @@ class PetriNetResponse(BaseModel):
     O: Outputs = Field(..., description="A list of outputs")  # Outputs
 
 
-@model_blueprint.post("/to_petrinet", response_model=PetriNetResponse, tags=["model"])
+@model_blueprint.post("/to_petrinet", response_model=PetriNetResponse, tags=["modeling"])
 def model_to_petri(template_model: TemplateModel = Body(..., example=template_model_example)):
     """Create a PetriNet model from a TemplateModel"""
     model = Model(template_model)
@@ -101,7 +101,7 @@ def model_to_petri(template_model: TemplateModel = Body(..., example=template_mo
 #     )
 #
 #
-# @model_blueprint.post("/to_gromet", response_model=Dict[str, Any], tags=["model"])
+# @model_blueprint.post("/to_gromet", response_model=Dict[str, Any], tags=["modeling"])
 # def model_to_gromet(
 #     data: ToGrometQuery = Body(
 #         ...,
@@ -150,7 +150,7 @@ class StratificationQuery(BaseModel):
         return ControlledConversion
 
 
-@model_blueprint.post("/stratify", response_model=TemplateModel, tags=["model"])
+@model_blueprint.post("/stratify", response_model=TemplateModel, tags=["modeling"])
 def model_stratification(
     stratification_query: StratificationQuery = Body(
         ...,
@@ -211,7 +211,7 @@ def _graph_model(
     "/viz/to_dot_file",
     response_class=FileResponse,
     response_description="A successful response returns a grapviz dot file of the provided TemplateModel",
-    tags=["model"],
+    tags=["modeling"],
 )
 def model_to_viz_dot(
     bg_task: BackgroundTasks,
@@ -232,7 +232,7 @@ def model_to_viz_dot(
     response_class=FileResponse,
     response_description="A successful response returns a png image of the "
     "graph representation of the provided TemplateModel",
-    tags=["model"],
+    tags=["modeling"],
 )
 def model_to_graph_image(
     bg_task: BackgroundTasks,

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -28,6 +28,18 @@ tags_metadata = [
             "url": "https://github.com/indralab/gilda",
         },
     },
+    {
+        "name": "model",
+        "description": "Endpoints for model I/O",
+    },
+    {
+        "name": "entities",
+        "description": "Query entity data",
+    },
+    {
+        "name": "relations",
+        "description": "Query relation data",
+    }
 ]
 
 

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -24,7 +24,7 @@ tags_metadata = [
         "name": "grounding",
         "description": "Identify appropriate ontology/database terms for text.",
         "externalDocs": {
-            # "description": "Gilda is a Python package and REST service that grounds (i.e., finds appropriate identifiers in namespaces for) named entities in biomedical text.",
+            "description": "External documentation",
             "url": "https://github.com/indralab/gilda",
         },
     },

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -29,7 +29,7 @@ tags_metadata = [
         },
     },
     {
-        "name": "model",
+        "name": "modeling",
         "description": "Endpoints for model I/O",
     },
     {


### PR DESCRIPTION
This PR updates meta data for openapi tags:
- Add tag for the model endpoints, this replaces "default" with "model" in that section
- For the model, entities and relations endpoints, add a description of the endpoints

The new look of the api docs can be seen in the attached image:

![image](https://user-images.githubusercontent.com/4621351/191065856-42ccfba7-1e44-4a56-b931-d43d45d355d0.png)