### PR TITLE
Generate DKG-ready triples from template models

### DIFF
--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -327,5 +327,11 @@
     "id": "askemo:0000016",
     "name": "equivalent distribution",
     "type": "property"
+  },
+  {
+    "description": "Two entities that appear in the same document (e.g., a model).",
+    "id": "askemo:0000017",
+    "name": "co-occurs with",
+    "type": "property"
   }
 ]

--- a/mira/dkg/constants.py
+++ b/mira/dkg/constants.py
@@ -1,0 +1,26 @@
+"""Constants for the DKG Build."""
+
+#: The used for the nodes files in the neo4j bulk import
+NODE_HEADER = (
+    "id:ID",
+    ":LABEL",
+    "name:string",
+    "synonyms:string[]",
+    "obsolete:boolean",
+    "type:string",
+    "description:string",
+    "xrefs:string[]",
+    "alts:string[]",
+    "version:string",
+)
+
+#: The used for the edges files in the neo4j bulk import
+EDGE_HEADER = (
+    ":START_ID",
+    ":END_ID",
+    ":TYPE",
+    "pred:string",
+    "source:string",
+    "graph:string",
+    "version:string",
+)

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -49,6 +49,7 @@ from mira.dkg.resources import SLIMS, get_ncbitaxon
 from mira.dkg.resources.extract_ncit import get_ncit_subset
 from mira.dkg.resources.probonto import get_probonto_terms
 from mira.dkg.units import get_unit_terms
+from mira.dkg.constants import EDGE_HEADER, NODE_HEADER
 from mira.dkg.utils import PREFIXES
 
 MODULE = pystow.module("mira")
@@ -136,32 +137,6 @@ class UseCasePaths:
         self.RDF_TTL_PATH = self.module.join(name="dkg.ttl.gz")
 
 
-EDGE_HEADER = (
-    ":START_ID",
-    ":END_ID",
-    ":TYPE",
-    "pred:string",
-    "source:string",
-    "graph:string",
-    "version:string",
-)
-NODE_HEADER = (
-    "id:ID",
-    ":LABEL",
-    "name:string",
-    "synonyms:string[]",
-    "obsolete:boolean",
-    "type:string",
-    "description:string",
-    "xrefs:string[]",
-    "alts:string[]",
-    "version:string",
-    "property_predicates:string[]",
-    "property_values:string[]",
-    "xref_types:string[]",
-    "synonym_types:string[]",
-    "sources:string[]",  # the resources the node appears in
-)
 LABELS = {
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": "is defined by",
     "rdf:type": "type",

--- a/mira/modeling/triples.py
+++ b/mira/modeling/triples.py
@@ -1,0 +1,155 @@
+"""Generate knowledge-graph-ready triples from template models."""
+
+import csv
+import itertools as itt
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple, Union
+
+from pydantic import BaseModel
+
+from mira.dkg.constants import EDGE_HEADER
+from mira.metamodel import (
+    ControlledConversion,
+    GroupedControlledConversion,
+    NaturalConversion,
+    NaturalDegradation,
+    NaturalProduction,
+    Template,
+    TemplateModel,
+)
+from mira.metamodel.templates import Config
+
+if TYPE_CHECKING:
+    import pandas
+
+__all__ = [
+    "TriplesGenerator",
+]
+
+RELATED_TO_CURIE = "ro:0002323"
+
+RELATIONS = {
+    RELATED_TO_CURIE: "mereotopologically related to",  # FIXME new relation?
+}
+
+
+class Triple(BaseModel):
+    """Represents a triple of 3 CURIEs."""
+
+    sub: str
+    pred: str
+    obj: str
+
+    def as_tuple(self) -> Tuple[str, str, str]:
+        return self.sub, self.pred, self.obj
+
+
+class TriplesGenerator:
+    """Generates triples from a templated model to include in the DKG."""
+
+    def __init__(
+        self,
+        model: TemplateModel,
+        config: Optional[Config] = None,
+        skip_prefixes: Optional[Iterable[str]] = None,
+    ):
+        """
+        Parameters
+        ----------
+        model:
+            A template model
+        config:
+            Configuration for creating canonical CURIEs
+        skip_prefixes:
+            A list, set, or iterable of strings representing
+            prefixes that should be skipped.
+        """
+        self.model = model
+        self.triples = {}
+        self.skip_prefixes = {""}
+        if skip_prefixes:
+            self.skip_prefixes.update(skip_prefixes)
+        for template in model.templates:
+            for triple in self.iter_triples(template, config=config):
+                if triple.sub == triple.obj:
+                    continue
+                self.triples[triple.as_tuple()] = triple
+
+    def to_dataframe(self) -> "pandas.DataFrame":
+        """Get all triples as a pandas dataframe."""
+        import pandas
+
+        columns = ["subject", "predicate", "object"]
+        df = pandas.DataFrame(
+            [t.as_tuple() for t in self.triples.values()],
+            columns=columns,
+        )
+        df = df.drop_duplicates()
+        df = df[df["subject"] != df["object"]]
+        df = df.sort_values(columns)
+        return df
+
+    def write_neo4j_bulk(self, path: Union[str, Path]) -> None:
+        """Write a file that can be bulk imported in neo4j."""
+        with open(path, "w") as file:
+            writer = csv.writer(file, delimiter="\t")
+            writer.writerow(EDGE_HEADER)
+            writer.writerows(
+                (
+                    triple.sub,
+                    triple.obj,
+                    RELATIONS[triple.pred],
+                    triple.pred,
+                    "template",  # TODO add extra metadata to models?
+                    "template",
+                    "",
+                )
+                for _, triple in sorted(self.triples.items())
+            )
+
+    def iter_triples(
+        self, template: Template, config: Optional[Config] = None
+    ) -> Iterable[Triple]:
+        """Iterate triples from a template."""
+        if isinstance(
+            template, (ControlledConversion, GroupedControlledConversion)
+        ):
+            if isinstance(template, ControlledConversion):
+                controllers = [template.controller]
+            else:
+                controllers = template.controllers
+            for controller in controllers:
+                for a, b in itt.combinations(
+                    (template.subject, template.outcome, controller), 2
+                ):
+                    sub_prefix, sub_id = a.get_curie(config=config)
+                    obj_prefix, obj_id = b.get_curie(config=config)
+                    if (
+                        sub_prefix in self.skip_prefixes
+                        or obj_prefix in self.skip_prefixes
+                    ):
+                        continue
+                    yield Triple(
+                        sub=f"{sub_prefix}:{sub_id}",
+                        pred=RELATED_TO_CURIE,
+                        obj=f"{obj_prefix}:{obj_id}",
+                    )
+        elif isinstance(template, NaturalConversion):
+            sub_prefix, sub_id = template.subject.get_curie(config=config)
+            obj_prefix, obj_id = template.outcome.get_curie(config=config)
+            if (
+                sub_prefix in self.skip_prefixes
+                or obj_prefix in self.skip_prefixes
+            ):
+                return
+            yield Triple(
+                sub=f"{sub_prefix}:{sub_id}",
+                pred=RELATED_TO_CURIE,
+                obj=f"{obj_prefix}:{obj_id}",
+            )
+        elif isinstance(template, NaturalProduction):
+            pass  # No triples
+        elif isinstance(template, NaturalDegradation):
+            pass  # No triples
+        else:
+            raise TypeError

--- a/tests/test_generators/__init__.py
+++ b/tests/test_generators/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for generators."""

--- a/tests/test_generators/test_triples_generator.py
+++ b/tests/test_generators/test_triples_generator.py
@@ -1,0 +1,31 @@
+"""Tests for the triples generator."""
+
+import unittest
+
+from mira.examples.sir import sir
+from mira.modeling.triples import TriplesGenerator, RELATED_TO_CURIE
+
+
+class TestTriplesGenerator(unittest.TestCase):
+    """Test the triples generator."""
+
+    def test_sir(self):
+        """This test makes sure there are connections
+        between the three grounded IDO terms in the SIR model.
+        """
+        generator = TriplesGenerator(sir)
+        self.assertEqual(
+            {
+                (
+                    "ido:0000511",
+                    RELATED_TO_CURIE,
+                    "ido:0000592",
+                ),
+                (
+                    "ido:0000514",
+                    RELATED_TO_CURIE,
+                    "ido:0000511",
+                ),
+            },
+            set(generator.triples),
+        )

--- a/tests/test_generators/test_triples_generator.py
+++ b/tests/test_generators/test_triples_generator.py
@@ -3,7 +3,7 @@
 import unittest
 
 from mira.examples.sir import sir
-from mira.modeling.triples import TriplesGenerator, RELATED_TO_CURIE
+from mira.modeling.triples import TriplesGenerator, CO_OCCURS
 
 
 class TestTriplesGenerator(unittest.TestCase):
@@ -14,18 +14,21 @@ class TestTriplesGenerator(unittest.TestCase):
         between the three grounded IDO terms in the SIR model.
         """
         generator = TriplesGenerator(sir)
+        expected = {
+            (
+                "ido:0000511",
+                CO_OCCURS,
+                "ido:0000592",
+            ),
+            (
+                "ido:0000514",
+                CO_OCCURS,
+                "ido:0000511",
+            ),
+        }
+        expected.update({(o, p, s) for s, p, o in expected})
+
         self.assertEqual(
-            {
-                (
-                    "ido:0000511",
-                    RELATED_TO_CURIE,
-                    "ido:0000592",
-                ),
-                (
-                    "ido:0000514",
-                    RELATED_TO_CURIE,
-                    "ido:0000511",
-                ),
-            },
+            expected,
             set(generator.triples),
         )


### PR DESCRIPTION
This PR adds functionality to create triples from template models that represent connections between entities in the models. These lack mechanistic/causal specificity, but are rather meant to supplement a domain knowledge graph with model-derived information. For example, with the SIR model:

```python
from mira.examples.sir import sir
from mira.modeling.triples import TriplesGenerator

generator = TriplesGenerator(sir)
df = generator.to_dataframe()
```

Gives the following dataframe representing the connections between susceptible/infected and also infected/recovered

| subject     | predicate   | object      |
|:------------|:------------|:------------|
| ido:0000511 | askemo:0000017  | ido:0000592 |
| ido:0000514 | askemo:0000017  | ido:0000511 |

It also has an alternate output to help build up Neo4j bulk edge import TSV files, but it's not quite clear what the workflow would be to incorporate these edges so I didn't add any of this to the DKG code.
