### PR TITLE
More docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,3 +13,7 @@ python:
       extra_requirements:
         - docs
         - ode
+        - dkg-client
+        - dkg-construct
+        - metaregistry
+        - web

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ MIRA builds on and generalizes prior work including:
 
 The most recent code and data can be installed directly from GitHub with:
 
-```python
+```shell
 python -m pip install git+https://github.com/indralab/mira.git
 ```
 
 To install in development mode, use the following:
 
-```python
+```shell
 git clone git+https://github.com/indralab/mira.git
 cd mira
 python -m pip install -e .

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ MIRA is a framework for representing systems using ontology-grounded **meta-mode
 * Generating an executable model from MIRA Templates and running simulation: [Notebook 2](https://github.com/indralab/mira/blob/main/notebooks/simulation.ipynb)
 * Stratifying and visualizing MIRA models, and exporting as Petri nets: [Notebook 3](https://github.com/indralab/mira/blob/main/notebooks/viz_strat_petri.ipynb)
 * Using the MIRA Domain Knowledge Graph REST API: [Notebook 4](https://github.com/indralab/mira/blob/main/notebooks/dkg_api.ipynb)
+* Using the Model REST API to perform various model operations: [Notebook 5](https://github.com/indralab/mira/blob/main/notebooks/model_api.ipynb)
+* Using the web client in python that connects to the REST API: [Notebook 6](https://github.com/indralab/mira/blob/main/notebooks/web_client.ipynb)
+
+[//]: # (Gromet Export fixme: uncomment when gromet works again)
 
 ## Related work
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@
 import os
 import re
 import sys
+import mock
 from datetime import date
 
 sys.path.insert(0, os.path.abspath("../.."))
@@ -236,3 +237,16 @@ autoclass_content = "both"
 # Don't sort alphabetically, explained at:
 # https://stackoverflow.com/questions/37209921/python-how-not-to-sort-sphinx-output-in-alphabetical-order
 autodoc_member_order = "bysource"
+
+MOCK_MODULES = [
+    "neo4j",
+    "neo4j.graph",
+    "bioontologies",
+    "bioontologies.obograph",
+    "bioregistry",
+    "bioregistry.app",
+    "bioregistry.app.impl",
+]
+
+for mod_name in MOCK_MODULES:
+    sys.modules[mod_name] = mock.Mock()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -241,11 +241,11 @@ autodoc_member_order = "bysource"
 MOCK_MODULES = [
     "neo4j",
     "neo4j.graph",
-    "bioontologies",
-    "bioontologies.obograph",
-    "bioregistry",
-    "bioregistry.app",
-    "bioregistry.app.impl",
+    #"bioontologies",
+    #"bioontologies.obograph",
+    #"bioregistry",
+    #"bioregistry.app",
+    #"bioregistry.app.impl",
 ]
 
 for mod_name in MOCK_MODULES:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,6 +67,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
+    "sphinxcontrib.autodoc_pydantic",
     "m2r2",
 ]
 

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -22,8 +22,8 @@ Constructing Registry (:py:mod:`mira.dkg.construct_registry`)
     :members:
     :show-inheritance:
 
-Configuarition Models (:py:mod:`mira.dkg.models`)
--------------------------------------------------
+Configuration Models (:py:mod:`mira.dkg.models`)
+------------------------------------------------
 .. automodule:: mira.dkg.models
     :members:
     :show-inheritance:

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -28,8 +28,8 @@ Configuration Models (:py:mod:`mira.dkg.models`)
     :members:
     :show-inheritance:
 
-App Utilities(:py:mod:`mira.dkg.utils`)
----------------------------------------
+App Utilities (:py:mod:`mira.dkg.utils`)
+----------------------------------------
 .. automodule:: mira.dkg.utils
     :members:
     :show-inheritance:

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -1,0 +1,41 @@
+Domain Knowledge Graph
+======================
+.. automodule:: mira.dkg
+    :members:
+    :show-inheritance:
+
+Client (:py:mod:`mira.dkg.client`)
+----------------------------------
+.. automodule:: mira.dkg.client
+    :members:
+    :show-inheritance:
+
+Construct (:py:mod:`mira.dkg.construct`)
+----------------------------------------
+.. automodule:: mira.dkg.construct
+    :members:
+    :show-inheritance:
+
+API (:py:mod:`mira.dkg.construct_registry`)
+-------------------------------------------
+.. automodule:: mira.dkg.construct_registry
+    :members:
+    :show-inheritance:
+
+API (:py:mod:`mira.dkg.models`)
+-------------------------------
+.. automodule:: mira.dkg.models
+    :members:
+    :show-inheritance:
+
+API (:py:mod:`mira.dkg.utils`)
+------------------------------
+.. automodule:: mira.dkg.utils
+    :members:
+    :show-inheritance:
+
+API (:py:mod:`mira.dkg.web_client`)
+-----------------------------------
+.. automodule:: mira.dkg.web_client
+    :members:
+    :show-inheritance:

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -16,26 +16,26 @@ Construct (:py:mod:`mira.dkg.construct`)
     :members:
     :show-inheritance:
 
-API (:py:mod:`mira.dkg.construct_registry`)
--------------------------------------------
+Constructing Registry (:py:mod:`mira.dkg.construct_registry`)
+-------------------------------------------------------------
 .. automodule:: mira.dkg.construct_registry
     :members:
     :show-inheritance:
 
-API (:py:mod:`mira.dkg.models`)
--------------------------------
+Configuarition Models (:py:mod:`mira.dkg.models`)
+-------------------------------------------------
 .. automodule:: mira.dkg.models
     :members:
     :show-inheritance:
 
-API (:py:mod:`mira.dkg.utils`)
-------------------------------
+App Utilities(:py:mod:`mira.dkg.utils`)
+---------------------------------------
 .. automodule:: mira.dkg.utils
     :members:
     :show-inheritance:
 
-API (:py:mod:`mira.dkg.web_client`)
------------------------------------
+Web Client (:py:mod:`mira.dkg.web_client`)
+------------------------------------------
 .. automodule:: mira.dkg.web_client
     :members:
     :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ Table of Contents
    metamodel
    modeling
    dkg
+   metaregistry
 
 Indices and Tables
 ------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,7 @@ Table of Contents
    overview
    metamodel
    modeling
+   dkg
 
 Indices and Tables
 ------------------

--- a/docs/source/metamodel.rst
+++ b/docs/source/metamodel.rst
@@ -1,4 +1,12 @@
 Meta-model
 ==========
+.. automodule:: mira.metamodel
+   :members:
+   :show-inheritance:
 
-.. automodapi:: mira.metamodel.templates
+Templates (:py:mod:`mira.metamodel.templates`)
+----------------------------------------------
+.. automodule:: mira.metamodel.templates
+    :members:
+    :exclude-members: Concept, ControlledConversion, NaturalConversion, Provenance, Template
+    :show-inheritance:

--- a/docs/source/metaregistry.rst
+++ b/docs/source/metaregistry.rst
@@ -1,0 +1,11 @@
+Metaregistry
+============
+.. automodule:: mira.dkg.metaregistry
+    :members:
+    :show-inheritance:
+
+Metaregistry Utils (:py:mod:`mira.dkg.metaregistry.utils`)
+----------------------------------------------------------
+.. automodule:: mira.dkg.metaregistry.utils
+    :members:
+    :show-inheritance:

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -39,7 +39,7 @@ NODES_PATH = DEMO_MODULE.join(name="nodes.tsv.gz")
 EDGES_PATH = DEMO_MODULE.join(name="edges.tsv.gz")
 METAREGISTRY_PATH = DEMO_MODULE.join(name="metaregistry.json")
 OBSOLETE = {"oboinowl:ObsoleteClass", "oboinowl:ObsoleteProperty"}
-EDGES_PATHS: dict[str, Path] = {
+EDGES_PATHS: Dict[str, Path] = {
     prefix: DEMO_MODULE.join("sources", name=f"edges_{prefix}.tsv") for prefix in PREFIXES
 }
 EDGE_HEADER = (

--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -21,6 +21,7 @@ class MiraState:
     grounder: Grounder
 
 
+#: A list of all prefixes used in MIRA
 PREFIXES = [
     # meta
     "oboinowl",

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -8,6 +8,7 @@ from mira.dkg import api, grounding
 from mira.dkg.utils import DKG_REFINER_RELS
 
 __all__ = [
+    "web_client",
     "get_relations_web",
     "get_entity_web",
     "get_lexical_web",

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -6,6 +6,7 @@
   "definitions": {
     "Concept": {
       "title": "Concept",
+      "description": "A concept is specified by its identifier(s), name, and - optionally -\nits context.",
       "type": "object",
       "properties": {
         "name": {
@@ -36,6 +37,7 @@
     },
     "Template": {
       "title": "Template",
+      "description": "The Template is a parent class for model processes",
       "type": "object",
       "properties": {}
     },
@@ -46,6 +48,7 @@
     },
     "NaturalConversion": {
       "title": "NaturalConversion",
+      "description": "Specifies a process of natural conversion from subject to outcome",
       "type": "object",
       "properties": {
         "type": {
@@ -78,6 +81,7 @@
     },
     "ControlledConversion": {
       "title": "ControlledConversion",
+      "description": "Specifies a process of controlled conversion from subject to outcome,\ncontrolled by the controller",
       "type": "object",
       "properties": {
         "type": {

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -3,7 +3,16 @@ Data models for metamodel templates.
 
 Regenerate the JSON schema by running ``python -m mira.metamodel.templates``.
 """
-__all__ = ["Concept", "Template", "Provenance", "ControlledConversion", "NaturalConversion"]
+__all__ = [
+    "Concept",
+    "Template",
+    "Provenance",
+    "ControlledConversion",
+    "NaturalConversion",
+    "get_json_schema",
+    "templates_equal",
+    "assert_concept_context_refinement",
+]
 
 import json
 import logging
@@ -22,6 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 class Config(BaseModel):
+    """Config determining how keys are generated"""
+
     prefix_priority: List[str]
 
 
@@ -33,6 +44,10 @@ DEFAULT_CONFIG = Config(
 
 
 class Concept(BaseModel):
+    """A concept is specified by its identifier(s), name, and - optionally -
+    its context.
+    """
+
     name: str = Field(..., description="The name of the concept.")
     identifiers: Mapping[str, str] = Field(
         default_factory=dict, description="A mapping of namespaces to identifiers."
@@ -161,6 +176,8 @@ class Concept(BaseModel):
 
 
 class Template(BaseModel):
+    """The Template is a parent class for model processes"""
+
     @classmethod
     def from_json(cls, data) -> "Template":
         template_type = data.pop("type")
@@ -252,6 +269,9 @@ class Provenance(BaseModel):
 
 
 class ControlledConversion(Template):
+    """Specifies a process of controlled conversion from subject to outcome,
+    controlled by the controller"""
+
     type: Literal["ControlledConversion"] = Field("ControlledConversion", const=True)
     controller: Concept
     subject: Concept
@@ -278,6 +298,8 @@ class ControlledConversion(Template):
 
 
 class NaturalConversion(Template):
+    """Specifies a process of natural conversion from subject to outcome"""
+
     type: Literal["NaturalConversion"] = Field("NaturalConversion", const=True)
     subject: Concept
     outcome: Concept

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -126,8 +126,7 @@ class Concept(BaseModel):
         refinement_func :
             A function that given a source/more detailed entity and a
             target/less detailed entity checks if they are in a child-parent and
-            returns a boolean. If not provided, the default
-            ``mira.dkg.web_client.is_ontological_child`` is used.
+            returns a boolean.
 
         Returns
         -------
@@ -169,6 +168,21 @@ class Template(BaseModel):
         return stmt_cls(**data)
 
     def is_equal_to(self, other: "Template", with_context: bool = False) -> bool:
+        """Check if this template is equal to another template
+
+        Parameters
+        ----------
+        other :
+            The other template to check for equality with this one with
+        with_context :
+            If True, the contexts are taken into account when checking for
+            equality. Default: False.
+
+        Returns
+        -------
+        :
+            True if the other Template is equal to this Template
+        """
         if not isinstance(other, Template):
             return False
         return templates_equal(self, other, with_context)
@@ -179,7 +193,26 @@ class Template(BaseModel):
         refinement_func: Callable[[str, str], bool],
         with_context: bool = False,
     ) -> bool:
-        """Check if this template is a more detailed version of another"""
+        """Check if this template is a more detailed version of another
+
+        Parameters
+        ----------
+        other :
+            The other template to compare with. Is assumed to be less
+            detailed than this template.
+        with_context :
+            If True, also consider the context of Templates' Concepts for the
+            refinement.
+        refinement_func :
+            A function that given a source/more detailed entity and a
+            target/less detailed entity checks if they are in a child-parent
+            relationship and returns a boolean.
+
+        Returns
+        -------
+        :
+            True if this Template is a refinement of the other Template.
+        """
         if not isinstance(other, Template):
             return False
 
@@ -226,6 +259,7 @@ class ControlledConversion(Template):
     provenance: List[Provenance] = Field(default_factory=list)
 
     def with_context(self, **context) -> "ControlledConversion":
+        """Return a copy of this template with context added"""
         return self.__class__(
             type=self.type,
             subject=self.subject.with_context(**context),
@@ -250,6 +284,7 @@ class NaturalConversion(Template):
     provenance: List[Provenance] = Field(default_factory=list)
 
     def with_context(self, **context) -> "NaturalConversion":
+        """Return a copy of this template with context added"""
         return self.__class__(
             type=self.type,
             subject=self.subject.with_context(**context),
@@ -282,6 +317,23 @@ def get_json_schema():
 
 
 def templates_equal(templ: Template, other_templ: Template, with_context: bool) -> bool:
+    """Check if two Template objects are equal
+
+    Parameters
+    ----------
+    templ :
+        A template to compare.
+    other_templ :
+        The other template to compare.
+    with_context :
+        If True, also check the contexts of the contained Concepts of the
+        Template.
+
+    Returns
+    -------
+    :
+        True if the two Template objects are equal.
+    """
     if templ.type != other_templ.type:
         return False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,8 @@ uvicorn =
 gunicorn =
     gunicorn
 docs =
+    bioregistry
+    bioontologies
     sphinx
     sphinx-rtd-theme
     sphinx-autodoc-typehints

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,8 @@ docs =
     autodoc-pydantic
     m2r2
     pygraphviz
+    wget
+; fixme: docs do not build completely without wget, yet it's not made available to the environment by the packages that need it
 
 [mypy]
 plugins = pydantic.mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,8 +72,8 @@ docs =
     autodoc-pydantic
     m2r2
     pygraphviz
+    mock
     wget
-; fixme: docs do not build completely without wget, yet it's not made available to the environment by the packages that need it
 
 [mypy]
 plugins = pydantic.mypy

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,10 @@ commands =
 extras =
     docs
     ode
+    dkg-client
+    dkg-construct
+    metaregistry
+    web
 commands =
     python -m sphinx -b {posargs:html} -d docs/build/doctrees docs/source docs/build/{posargs:html}
 


### PR DESCRIPTION
This PR substantially updates the documentation to bring it up to date with the current state of the repository.

Branch build: https://miramodel.readthedocs.io/en/more-docs/

Notable changes:
- [autodoc-pydantic](https://autodoc-pydantic.readthedocs.io/en/stable/users/installation.html) is activated and used, particularly in `mira.metamodel.templates`. For this to work, top level docstrings had to be added to the BaseModels in the module.
- Missing notebook links are added to README

Outstanding issues:
- [ ] Figure out why `wget` is not installed in the docs build environment when several submodule in `mira.dkg` are dependent on it
- [ ] Fix #42?
- [ ] Review added docstrings, especially in `mira.metamodel.templates`