### PR TITLE
Update model generation pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   tests:

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -13,7 +13,8 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from mira.metamodel import NaturalConversion, Template, ControlledConversion
-from mira.modeling import Model, TemplateModel
+from mira.modeling import Model
+from mira.metamodel.templates import TemplateModel
 # from mira.modeling.gromet_model import GrometModel
 from mira.modeling.ops import stratify
 from mira.modeling.petri import PetriNetModel

--- a/mira/examples/nabi2021.py
+++ b/mira/examples/nabi2021.py
@@ -4,7 +4,7 @@ strategies <https://doi.org/10.1016/j.chaos.2021.110689>`_.
 """
 
 from mira.metamodel import Concept, GroupedControlledConversion, NaturalConversion
-from mira.modeling import TemplateModel
+from mira.metamodel.templates import TemplateModel
 
 __all__ = [
     "nabi2021",

--- a/mira/examples/sir.py
+++ b/mira/examples/sir.py
@@ -1,7 +1,7 @@
 """Examples of metamodel templates."""
 
 from ..metamodel import Concept, ControlledConversion, NaturalConversion
-from ..modeling import TemplateModel
+from ..metamodel.templates import TemplateModel
 
 __all__ = [
     "sir",

--- a/mira/metamodel/__init__.py
+++ b/mira/metamodel/__init__.py
@@ -1,3 +1,4 @@
+from .io import model_from_json_file
 from .templates import (
     Concept,
     ControlledConversion,
@@ -20,4 +21,5 @@ __all__ = [
     "NaturalProduction",
     "GroupedControlledConversion",
     "TemplateModel",
+    "model_from_json_file",
 ]

--- a/mira/metamodel/__init__.py
+++ b/mira/metamodel/__init__.py
@@ -7,6 +7,7 @@ from .templates import (
     NaturalProduction,
     Provenance,
     Template,
+    TemplateModel,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "NaturalDegradation",
     "NaturalProduction",
     "GroupedControlledConversion",
+    "TemplateModel",
 ]

--- a/mira/metamodel/io.py
+++ b/mira/metamodel/io.py
@@ -1,6 +1,19 @@
 import json
-from .templates import
+from .templates import TemplateModel
 
 
 def model_from_json_file(fname):
+    """Return a TemplateModel from a JSON file.
+
+    Parameters
+    ----------
+    fname : str or Path
+        A file path.
+
+    Returns
+    -------
+    TemplateModel
+        A TemplateModel deserialized from the JSON file.
+    """
     with open(fname, 'r') as fh:
+        return TemplateModel.from_json(json.load(fh))

--- a/mira/metamodel/io.py
+++ b/mira/metamodel/io.py
@@ -1,0 +1,6 @@
+import json
+from .templates import
+
+
+def model_from_json_file(fname):
+    with open(fname, 'r') as fh:

--- a/mira/metamodel/io.py
+++ b/mira/metamodel/io.py
@@ -1,3 +1,5 @@
+__all__ = ["model_from_json_file"]
+
 import json
 from .templates import TemplateModel
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -29,6 +29,12 @@ from typing import List, Mapping, Optional, Tuple, Literal, Callable, \
 import pydantic
 from pydantic import BaseModel, Field
 
+try:
+    from typing import Annotated  # py39+
+except ImportError:
+    from typing_extensions import Annotated
+
+
 HERE = Path(__file__).parent.resolve()
 SCHEMA_PATH = HERE.joinpath("schema.json")
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -23,8 +23,7 @@ import logging
 import sys
 from collections import ChainMap
 from pathlib import Path
-from typing import List, Mapping, Optional, Tuple, Literal, Callable, \
-    Annotated, Union
+from typing import List, Mapping, Optional, Tuple, Literal, Callable, Union
 
 import pydantic
 from pydantic import BaseModel, Field

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -7,10 +7,6 @@ from mira.metamodel import (
     GroupedControlledConversion,
 )
 
-try:
-    from typing import Annotated  # py39+
-except ImportError:
-    from typing_extensions import Annotated
 
 logger = logging.getLogger(__name__)
 

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -71,16 +71,16 @@ class Model:
                 if isinstance(template, (NaturalConversion, NaturalProduction)):
                     o = self.get_create_variable(
                         Variable(get_variable_key(template.outcome)))
-                    produced= (o,)
+                    produced = (o,)
                 else:
                     produced = tuple()
-                tkey = get_transition_key(
-                    (
-                        tuple(s.key for s in consumed),
-                        tuple(o.key for o in produced),
-                    ),
-                    template.type,
-                )
+
+                consumed_key = tuple(s.key for s in consumed) \
+                    if len(consumed) > 1 else consumed[0].key
+                produced_key = tuple(o.key for o in produced) \
+                    if len(produced) > 1 else produced[0].key
+                tkey = get_transition_key((consumed_key, produced_key),
+                                          template.type)
                 p = self.get_create_parameter(
                     Parameter(get_parameter_key(tkey, 'rate')))
                 self.get_create_transition(Transition(
@@ -100,7 +100,7 @@ class Model:
                     c = self.get_create_variable(
                         Variable(get_variable_key(template.controller)))
                     control = (c,)
-                    tkey = get_transition_key((s.key, o.key, (c.key,)), template.type)
+                    tkey = get_transition_key((s.key, o.key, c.key), template.type)
                 else:
                     control = tuple(
                         self.get_create_variable(Variable(get_variable_key(controller)))

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -32,11 +32,12 @@ class Parameter:
 
 
 def get_variable_key(concept):
-    return (
-        concept.name,
-        tuple(sorted(("identity", f"{k}:{v}") for k, v in concept.identifiers.items() if k != "biomodel.species")),
-        tuple(sorted(concept.context.items())),
-    )
+    grounding_key = sorted(("identity", f"{k}:{v}")
+                           for k, v in concept.identifiers.items()
+                           if k != "biomodel.species")
+    context_key = sorted(concept.context.items())
+    key = [concept.name] + grounding_key + context_key
+    return tuple(key) if len(key) > 1 else key[0]
 
 
 def get_transition_key(concept_keys, action):

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -1,12 +1,9 @@
-__all__ = ["TemplateModel", "Model", "Transition", "Variable", "Parameter"]
+__all__ = ["Model", "Transition", "Variable", "Parameter"]
 
 import logging
-from typing import List, Union
-
-from pydantic import BaseModel, Field
 
 from mira.metamodel import (
-    ControlledConversion, NaturalConversion, Template, NaturalProduction, NaturalDegradation,
+    ControlledConversion, NaturalConversion, NaturalProduction, NaturalDegradation,
     GroupedControlledConversion,
 )
 
@@ -16,25 +13,6 @@ except ImportError:
     from typing_extensions import Annotated
 
 logger = logging.getLogger(__name__)
-
-# Needed for proper parsing by FastAPI
-SpecifiedTemplate = Annotated[
-    Union[
-        NaturalConversion, ControlledConversion, NaturalDegradation, NaturalProduction, GroupedControlledConversion,
-    ],
-    Field(description="Any child class of a Template", discriminator="type"),
-]
-
-
-class TemplateModel(BaseModel):
-    templates: List[SpecifiedTemplate] = Field(
-        ..., description="A list of any child class of Templates"
-    )
-
-    @classmethod
-    def from_json(cls, data) -> "TemplateModel":
-        templates = [Template.from_json(template) for template in data["templates"]]
-        return cls(templates=templates)
 
 
 class Transition:

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -56,6 +56,7 @@ class Model:
                                if k != "biomodel.species")
         context_key = sorted(concept.context.items())
         key = [concept.name] + grounding_key + context_key
+        key = tuple(key) if len(key) > 1 else key[0]
         if key in self.variables:
             return self.variables[key]
 

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -20,24 +20,15 @@ class Transition:
         self.rate = rate
 
 
-# TODO is there a reason this can't contain the base concept from which it was derived?
 class Variable:
-    def __init__(self, key):
+    def __init__(self, key, data=None):
         self.key = key
+        self.data = data
 
 
 class Parameter:
     def __init__(self, key):
         self.key = key
-
-
-def get_variable_key(concept):
-    grounding_key = sorted(("identity", f"{k}:{v}")
-                           for k, v in concept.identifiers.items()
-                           if k != "biomodel.species")
-    context_key = sorted(concept.context.items())
-    key = [concept.name] + grounding_key + context_key
-    return tuple(key) if len(key) > 1 else key[0]
 
 
 def get_transition_key(concept_keys, action):
@@ -59,18 +50,34 @@ class Model:
         self.transitions = {}
         self.make_model()
 
+    def assemble_variable(self, concept):
+        grounding_key = sorted(("identity", f"{k}:{v}")
+                               for k, v in concept.identifiers.items()
+                               if k != "biomodel.species")
+        context_key = sorted(concept.context.items())
+        key = [concept.name] + grounding_key + context_key
+        if key in self.variables:
+            return self.variables[key]
+
+        data = {
+            'name': concept.name,
+            'identifiers': grounding_key,
+            'context': context_key
+        }
+        var = Variable(key, data)
+        self.variables[key] = var
+        return var
+
     def make_model(self):
         for template in self.template_model.templates:
             if isinstance(template, (NaturalConversion, NaturalProduction, NaturalDegradation)):
                 if isinstance(template, (NaturalConversion, NaturalDegradation)):
-                    s = self.get_create_variable(
-                        Variable(get_variable_key(template.subject)))
+                    s = self.assemble_variable(template.subject)
                     consumed = (s,)
                 else:
                     consumed = tuple()
                 if isinstance(template, (NaturalConversion, NaturalProduction)):
-                    o = self.get_create_variable(
-                        Variable(get_variable_key(template.outcome)))
+                    o = self.assemble_variable(template.outcome)
                     produced = (o,)
                 else:
                     produced = tuple()
@@ -91,22 +98,21 @@ class Model:
                     rate=p,
                 ))
             elif isinstance(template, (ControlledConversion, GroupedControlledConversion)):
-                s = self.get_create_variable(
-                    Variable(get_variable_key(template.subject)))
-                o = self.get_create_variable(
-                    Variable(get_variable_key(template.outcome)))
+                s = self.assemble_variable(template.subject)
+                o = self.assemble_variable(template.outcome)
 
                 if isinstance(template, ControlledConversion):
-                    c = self.get_create_variable(
-                        Variable(get_variable_key(template.controller)))
+                    c = self.assemble_variable(template.controller)
                     control = (c,)
                     tkey = get_transition_key((s.key, o.key, c.key), template.type)
                 else:
                     control = tuple(
-                        self.get_create_variable(Variable(get_variable_key(controller)))
+                        self.assemble_variable(controller)
                         for controller in template.controllers
                     )
-                    tkey = get_transition_key((s.key, o.key, tuple(c.key for c in control)), template.type)
+                    tkey = get_transition_key((s.key, o.key,
+                                               tuple(c.key for c in control)),
+                                              template.type)
 
                 p = self.get_create_parameter(
                     Parameter(get_parameter_key(tkey, 'rate')))
@@ -121,11 +127,6 @@ class Model:
                 if template.__class__ not in UNHANDLED_TYPES:
                     logger.warning("unhandled template type: %s", template.__class__)
                     UNHANDLED_TYPES.add(template.__class__)
-
-    def get_create_variable(self, variable):
-        if variable.key not in self.variables:
-            self.variables[variable.key] = variable
-        return self.variables[variable.key]
 
     def get_create_parameter(self, parameter):
         if parameter.key not in self.parameters:

--- a/mira/modeling/ops.py
+++ b/mira/modeling/ops.py
@@ -3,8 +3,8 @@
 import itertools as itt
 from typing import Iterable, Optional, Set, Tuple, Type
 
-from . import TemplateModel
-from ..metamodel import ControlledConversion, NaturalConversion, Template
+from ..metamodel import ControlledConversion, NaturalConversion, Template, \
+    TemplateModel
 
 __all__ = [
     "stratify",

--- a/mira/modeling/viz.py
+++ b/mira/modeling/viz.py
@@ -22,8 +22,10 @@ class GraphicalModel:
             strict=True,
             directed=True,
         )
-        for variable in model.variables:
-            name, identifiers, contexts = variable
+        for variable in model.variables.values():
+            identifiers = variable.data.get('identifiers')
+            contexts = variable.data.get('context')
+            name = variable.data.get('name', str(variable.key))
             if not identifiers and not contexts:
                 label = name
                 shape = "oval"
@@ -32,7 +34,7 @@ class GraphicalModel:
                 label = f"{{{name} | {cc}}}"
                 shape = "record"
             self.graph.add_node(
-                variable,
+                variable.key,
                 label=label,
                 shape=shape,
             )

--- a/mira/modeling/viz.py
+++ b/mira/modeling/viz.py
@@ -6,7 +6,8 @@ from typing import Optional, Union
 
 import pygraphviz as pgv
 
-from mira.modeling import Model, TemplateModel
+from mira.metamodel import TemplateModel
+from mira.modeling import Model
 
 __all__ = [
     "GraphicalModel",

--- a/mira/sources/sbml.py
+++ b/mira/sources/sbml.py
@@ -23,7 +23,7 @@ from mira.metamodel import (
     NaturalProduction,
     Template,
 )
-from mira.modeling import TemplateModel
+from mira.metamodel.templates import TemplateModel
 
 __all__ = [
     "ParseResult",

--- a/notebooks/gromet_export.ipynb
+++ b/notebooks/gromet_export.ipynb
@@ -2,25 +2,29 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Exporting a Mira Model to GroMEt\n",
     "\n",
     "First, create a simple SIR model template and make a Mira Model from it:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
-    "from mira.metamodel import ControlledConversion, Concept, NaturalConversion\n",
-    "from mira.modeling import TemplateModel, Model\n",
+    "from mira.metamodel import ControlledConversion, Concept, NaturalConversion, TemplateModel\n",
+    "from mira.modeling import Model\n",
     "\n",
     "infected = Concept(name=\"infected population\", identifiers={\"ido\": \"0000511\"})\n",
     "susceptible = Concept(name=\"susceptible population\", identifiers={\"ido\": \"0000514\"})\n",
@@ -34,29 +38,27 @@
     "template2 = NaturalConversion(subject=infected, outcome=immune)\n",
     "sir_model_templ = TemplateModel(templates=[template1, template2])\n",
     "sir_model = Model(sir_model_templ)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Next, we import and use the gromet model. The Gromet is initialized when creating the instance and is stored in `Gromet.gromet_model`:"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Next, we import and use the gromet model. The Gromet is initialized when creating the instance and is stored in `Gromet.gromet_model`:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from mira.modeling.gromet_model import GrometModel, model_to_gromet\n",
@@ -66,68 +68,58 @@
     "\n",
     "# or use the model_to_gromet helper function\n",
     "# sir_gromet = model_to_gromet(sir_model, name=\"my_sir_model\", model_name=\"PetriNet\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "The model can be saved to a file as a json exported GroMEt:"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "The model can be saved to a file as a json exported GroMEt:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from mira.modeling.gromet_model import model_to_gromet_json_file\n",
     "\n",
     "model_to_gromet_json_file(sir_model, name=\"my_sir_model\", model_name=\"PetriNet\", fname=\"my_sir_model.json\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Since the GroMEt is built up from Python dataclasses, it can be exported as a dict:"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Since the GroMEt is built up from Python dataclasses, it can be exported as a dict:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from dataclasses import asdict\n",
     "gromet_dict = asdict(sir_gromet)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
@@ -139,16 +131,16 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/notebooks/metamodel_intro.ipynb
+++ b/notebooks/metamodel_intro.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mira.modeling import TemplateModel"
+    "from mira.metamodel import TemplateModel"
    ]
   },
   {

--- a/notebooks/model_api.ipynb
+++ b/notebooks/model_api.ipynb
@@ -2,6 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Model REST API\n",
     "\n",
@@ -10,18 +15,16 @@
     "## Setup\n",
     "\n",
     "We will need `requests` to send requests to the model api."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -33,8 +36,7 @@
    ],
    "source": [
     "import requests\n",
-    "from mira.metamodel import Concept, ControlledConversion, NaturalConversion\n",
-    "from mira.modeling import TemplateModel\n",
+    "from mira.metamodel import Concept, ControlledConversion, NaturalConversion, TemplateModel\n",
     "\n",
     "# rest_url = \"http://127.0.0.1:8000\"  # Local service\n",
     "rest_url = \"http://34.230.33.149:8771\"\n",
@@ -52,27 +54,20 @@
     "sir_template_model = TemplateModel(templates=[controlled_conversion, natural_conversion])\n",
     "sir_template_model_dict = sir_template_model.dict()\n",
     "print(sir_template_model.json())"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## PetriNet\n",
     "\n",
     "The `/api/to_petrinet` endpoint returns a PetriNet model based on the `TemplateModel` provided:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -99,21 +94,25 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Model Stratification\n",
     "\n",
     "The `/api/stratify` endpoint can stratify a model. In this example, the stratification is along two cities, effectively creating a two-city SIR model from the original SIR model:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -126,31 +125,29 @@
    "source": [
     "res = requests.post(rest_url + \"/api/stratify\", json={\"template_model\": sir_template_model_dict, \"key\": \"city\", \"strata\": [\"Boston\", \"New York City\"]})\n",
     "print(res.json())"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Graphviz dot File\n",
     "\n",
     "The `/api/viz/to_dot_file` endpoint takes a `TemplateModel` and returns a graphviz dotfile of the provided model:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -206,36 +203,36 @@
    "source": [
     "res = requests.post(rest_url + \"/api/viz/to_dot_file\", json=sir_template_model_dict)\n",
     "print(res.text)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Graph image\n",
     "\n",
     "The `/api/viz/to_image` endpoint returns an image of the model as a graph structure."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAT8AAAGACAIAAABUWPJcAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deXxTZd43/iv72iZpmyZpmpaWVrpS2lLU0rJDkYIIKqNscisOt3M7Kj6OeN/OOD7DzDiOzqjj7Yyjr9/LEUfBcQbUUhSQFmkLSunC0gW60rRZmi5Zmz35/XEN5wnpQsCk6Qnf9x95JSfnXLnO8jnn5CzXoXi9XgQAICFquCsAALhFkF4AyArSCwBZ0cNdATABr9er1+sRQi6Xy2QyIYTsdvvY2Bj+lug4ntPpNJvNkxXL5XJZLNYNv2KxWFwu17djVFQUnQ6LyowDsyQ47Ha70Wg0Go16vd5gMIyNjVmtVpPJ5HA4DAaDzWYb/9FoNDqdToPBgBAym81OpxMhZDAYPB5PuMdmUkKhkEKhUKlUgUCAEOLz+UwmUygU4sBP/VEoFEZHR0dHRwsEAg6HE+5RiQQUOOY8IZfLNTIyMjw8PDw8TLwxGAxGoxG/EkHF72022/hCoqOjGQyGQCBgs9kcDicqKorBYIxfuBFCHA6HzWYjhPh8PoPBQONywmAw+Hw+UbJAIKBSJ/7XM8VXer1+stnt+5XVasWjQ6xT8Lcejweva4gtPLECIlZPTqdTr9fjPQU8+Ojo6PifYzAYOMY40gKBIPoagUAQe01MTAx+w2QyJ55Pt7fbMb02m02r1apUqsHBwYGBgaGhISKfOKs6nQ4vpgQ+nx8bGysQCHyXM6FQ6NcFfxQKhVwuF6cRIIQcDofFYtHr9cZriPUg0dF3nTgyMuI3/aOiomJiYuLi4uLi4ohIx8bGymQyqVQqkUgSEhJ4PF64RjBcIjO9ZrO5r69PqVRqtVqNRqNWq3FQBwcH1Wo1/kuJxcbGisVi39V8bGxsXFyc3+p/sr+LIERcLpffjs/w8PDQ0JDvSnZoaGhwcJBYgHk8nlwuj4+P9410fHy8QqFQKBQikSi8YxQK5E7v6Ohod3d3d3e3SqVSq9XEe41Gg8eLxWLFxMSIRKKEhASZTOb7KhKJkpKSoqKiwj0S4AcZHR3Fc1+lUo2OjuI3+FWlUhFrajabnZCQkJqaiheA1NRU/D45Odn3Lwm5kCO9ZrO583pdXV1qtdrtdiOEGAyGXC5XKBTJycmKa5KTk+VyeUxMTLjrDsKJ2Avr7+/v6+u7evUq8Z44VCGVSlNSUtKuR4olZ8al1+FwtLe3t7e345R2dHR0dnZqNBqEEI1GUygUxPQlUiqVSic7TgPAZLRabX9/v1KpvHr1and3N17eenp68IG6mJgYYklLT0/PyMjIzMycaX+tw5xet9t99erVlpaW1tZW4hWvFGUyWXZ2dqqPzMxMfB4SgNBRqVStra3dPtra2vDJdrxMZmVl4deCgoLwLpDTnV6LxdLU1FRfX9/Q0NDS0tLW1ma326lUampqak5OTlZWVm5ublZWVkZGBpwkADOE2+3u6uq6dOlSS0sLfr1y5YrT6aTT6WlpaTk5Ofn5+UVFRUVFRfj837QJeXqdTuelS5fOnj1bX19fX1/f0tLidrvFYvH8+fNzc3Ozs7PxagxO3wMScTqdly9fbmlpuXjxYktLS0NDg1KppFAo6enpRdfk5+eHeqkOSXotFkttbW11dfWpU6eamppsNltUVFRhYSExYrNmzQr6jwIQRhqNpv6ac+fODQ0N0en0nJycRYsWLVmyZPHixaE4DBa09NpstjNnzlRXV1dXV3///fdOpzMzM3PJkiV33nlnUVFRRkYGHFgCt4/u7u76+vqzZ89+++23zc3NXq83Ly9v6dKlS5cuXbRoUXR0dFB+5YemV6VSHTp06NChQ3V1dTabbfbs2UuvkclkQakiAKQ2Ojp66tSpqqqq6urqS5cu0Wi0+fPnr1+//v77709PT/8hJd9ient6eg4ePHjw4MHvvvuOx+OtWbPmnnvuWbp0aVJS0g+pDQCRTafTnTx58tixY1988YVOp8vNzd24ceP999+fm5t7C6XdXHp1Ot1HH3308ccfNzY2xsTErFu37v7771+5ciVc0wvATXG73TU1NQcPHjx06FB/f396evpDDz306KOP3twhIW9g6urqNm3axGQyBQLB448/fuzYMYfDEeCwIBCvvfYaniNyufyH9EMukTdGN8vj8Zw5c+a5556TyWRUKnXVqlUVFRUejyeQYW+c3iNHjixcuBAhdOedd37wwQcWi+UHVxh4vV6vyWRKS0srLy/37ZiXl3fD5TiQfsglWGM04SQlC6fTeejQodWrV1MolKysrA8//NDtdk89yFTHgZuampYtW7ZmzRqRSHTq1Knvvvtux44dcLXTLeDz+SUlJX4dvV6vx+OZyffiz2SRN0npdPp999331VdfXbhwoaio6LHHHsvPzz927NgUg0ycXqfT+dJLLy1YsMBut9fV1VVUVJSWloamzrevqKiorq6uI0eOhLsikSMyJmlOTs7f/va3ixcvpqSklJWVPfroo353OxMmSO/o6OiqVatef/31X//61zU1NcXFxSGuLQDAX0ZGxueff15ZWXn06NH58+d3dHRM0JPfnrTJZMrLy1MoFBcuXAjR/v1Nsdlsv/jFL+bMmcPhcEQi0dq1a7/44guXy+X1evfu3YtHYeHChbjnr776CneJjY0NpARsaGho9+7dqampTCZTLpcvX778gw8+GBsbw98ODg7+9Kc/TU5OZjAYcXFxGzZsaGpqwl/5HnE5e/bssmXL+Hw+h8NZsmRJbW2tXz8EGo3m9XoPHTpEdLFarURl8D/Atra2NWvWREdH+5Xm249vlykqOV4g1fabMrhBn9WrV1dVVQVeSIAzaPwYOZ3OAwcOrFixQiKRsNnsnJycN998k/gTeLOTdIqx8B2kp6dn06ZNAoEgJiamvLy8s7Nzsgk4zVQqVWFhoVQqvXr1qt9X/undsmWLRCLp7e2drrrdwM6dOwUCwbFjx8bGxjQazXPPPYcQqq6uJnrg8XjEwoEVFhb6LhxTl6BWq1NSUqRSaUVFhdFo1Gg0eJl74403vF6vSqVKTk6WSCSVlZUmk+nSpUuLFy9ms9mnT58mys/Ly+PxeHfffffp06fNZnN9ff3cuXOZTObJkyenqCS2fv368ekVCARLly6tra01mUwTlua3rAdSyfFuWG08ZSQSSUVFhcFguHz58saNGykUyvvvv/8Dx91vBo0fo4qKCoTQb3/7W9xK0Z/+9Ccqlfrcc8/5DhLgJA1kLPAg69evx2Nx/PhxDodTVFQ0xdSbZkajce7cufPnz/c7jnVdei9evEihUD7//PPprdtUUlJSiouLfbvccccdN5XeqUvYsWMHQujTTz/17WH16tU4vY888ghC6OOPPya+UqvVLBarsLCQ6JKXl4cQ8t3WXbhwASGUl5c3RSWxCdOLEDpz5swUpfkt64FUcrwbVhtPmf379xM92Gy2hIQEDoeDmy655XEPJL1Llizx7WHr1q0MBsNgMExRLOY3SQMZCzxIRUUF0c8DDzyAENLpdOPLD5e2tjYajfaPf/zDt+N16X3ttdcSExMDPNc0PZ544gmE0OOPP37mzBnf3V3CDReOqUvALTYajcYJfx23z+i70Hi93oKCAoSQUqnEH/H2x2/AhIQEhJBKpZqsktiE6WWz2X6zwK80v2U9kEqOd8NqTzhltm3bhhD68MMPf8i43zC94+G9Zd+9iQAnaSBjgQchwuz1enfv3o0QOn/+/BRVmn6rVq3asWOHb5frjlpptVqZTEahUNCM8c477+zbt6+7u3v58uXR0dGrV6/2/a/yA0uw2+0Gg4HNZk/YuhX+1uPxCAQCio/GxkaEkO9RhPF3dcbHxyOEBgcHb6qqWGxsrN8smKK0wCs53hTVnmzKSCQShBBu6uSGhdxgPCdnMBheeuml3NxckUiER+dnP/sZQohojz5AgY8FQgjnHMP3ls+0M09yuVyr1fp2uS69c+bMaW9vn6yd/rCgUCjbtm375ptv9Ho93qXfuHHjH//4R6IHKpXqcDh8B/FtMnLqElgslkAgsNlsE44yi8USCoV0Ot3pdI5fES5dupToc3h42Hv9Bad42cXLMa5D4KM8/vSAX2m3Vsnxpqj2ZFMGLz1SqTSQQvDHG86g8datW7d3797HH3/8ypUreDfkjTfeQAj5/lAgkzTwsZj5vF7v2bNnMzIyfDtel94HH3yQSqW+8sor01uxqQiFwvb2doQQg8FYuXLl559/TqFQKisriR5kMtnAwADxUaPR9PX1BV7Chg0bEEJ+Zwjz8/PxvtPGjRtdLlddXZ3vt6+++mpSUpLL5SK62Gy2+vp64uPFixdVKlVeXh5xlxWXyyWW4Dlz5rz33ntTjLLZbD5//vwUpfkJsJLjTV1tPGV8J7Xdbj9x4gSHwykrKwt83G84g/y43e66ujqpVPrUU0+JxWKcUqvV6tdbgJM0wLGY+T7++OO2trbHHnvsuq5+a+v333+fQqF89NFHQdhPDwaBQLB48eLz58/jJtRffvllhNCvf/1roocnn3wSIfT222+bTKbOzs5NmzbJ5XLfv1VTl4CPScpkssOHDxuNRqVS+cQTT0gkEnx0XqvVzp49OzU19ciRI3q9fnh4+N133+Vyub5HufBR4uXLl09x3HX16tUCgaCvr+/06dN0Or21tRV3n/B/L4/HKykp+e677yYrze9fYiCVHO+G1fY9Wms0Gomjte+9995NjfsNZ9D4MVq2bBlC6Pe//71OpxsbG6uqqsL3rh0/fvxmJ2kgYzF+LuzZswddfzQuvGpra7lc7u7du/26T3Cd8wsvvEChUH7zm9/c8DLLadDc3Lxr1y7cHl1MTMxdd931/vvv+x7U0ev1O3fulMlkHA6npKSkvr6+sLAQr5j27NkTSAlDQ0PPPPNMSkoKg8GQyWQPPfTQlStXiG+Hh4efffZZfLZQLBavWrXKdxnyXlvyWltby8rKoqKiOBzO4sWL/U6ctre3l5aW8ng8hULxzjvveK8/04gQ2rJli98Z1KVLl+IzqL6l+Z3qfPHFFwOs5HiBVNt3yggEgrKyshMnTtxsIVPPoAnHSKfT7dq1S6FQMBgMiUSyY8eOF154AfdAHEgPZJLecCzOnDkz/td9u8yES6Y//vhjNpt9//33jz/mOvFdCm+//TaTySwtLb18+XLoq0duJL1nICjVJum4k4VGo9m0aROFQtm9e/eEJ1wmvs75ySefPHv2rMlkysnJefLJJ/2OdAEAQspsNv/qV79KS0v77rvvjh49+sc//pFGo43vbdJ7jPLy8s6dO/fnP//50KFDKSkpTzzxRGdnZygrDABAGo3mxRdfTEpK+sMf/vDf//3fbW1tK1eunLTvG26+LRbLO++8M3v2bCqVWlZW9tlnn8F9+dhk/0JnuKBUm6TjPmN5PJ5vvvkGN4ARHx+/d+/eoaGhGw4VaMs4bre7oqLi/fffP3r0qEgkWr9+/caNG5cvXw4P1wPglnk8nrq6Otw+ztWrV4uLix9//PGHHnoowKambrpVOqVSuX///oMHD549ezYqKmrt2rUbN26855574K59AALkdDqrq6sPHjz4+eefa7XarKysjRs3PvTQQ9nZ2TdVzq23CNvf33/o0KGDBw/W1NQwmcxFixbhhmALCwsn/IcNwO3M6/W2trbidmGrq6v1en1hYeHGjRs3bNiQmZl5a2UGoTV2nU735Zdfnjhxorq6WqPRCASCRYsWLVu2bOnSpbm5udAIO7iddXR0VFdXV1VVnTx5UqvVCoXCRYsWLV++/N577/3hTxQJ8pNQWltbcV2//fbb4eHh2NjYIh/kurIUgFug1+uJR6KcPXtWpVLx+fzS0lK8Z5qfnx/EPdNQPYXM4/FcuHDh1KlT+PljHR0dXq9XoVDMnz+/qKhowYIFhYWF0/zANQBCwWKxNDc3E4nFjXIkJSXhLVZpaemCBQvodHoofnqangBqMpnOnz/fcE1raytCSCQSZWVlFRYW4scIzps3j8/nT0NlALhlLperr68PPzcQP2768uXLbrdbIBDk5OQUFhaWlJSUlpZOz25meJ6+rVarGxsbL126hJ+G2tbWZrPZqFRqSkoKfn5vTk4Ofmy5SCSa/uoBgJnN5q6urs7OztbWVr8n96anp+fk5OTk5GRnZxcUFKSkpEx/9cKTXj/46cb4Uah4GnV0dDidToRQbGxs2jhxcXHhrjKINEajsXMctVqNEKJSqbNmzcJBxQ+dniFPh58R6R3P5XL19vZ2dnbiNV9HR0dnZ2dPTw++pVMoFM6ePVuhUCQlJSUnJysUCvxeKpXCIW4wtcHBQaVSqVQq+/r6+vr68Juuri6dTocQotPpSUlJeCMxe/bstLS09PT01NTUmXlV0gxN74TcbrdSqcQrxe7ubjzdr169qtFo3G43Qgg36apQKHCk5XJ5QkJCfHx8QkKCRCIJ9YPMwQzhcDgGBwdVKpVWq9VoNAMDA1evXiUSa7PZcG9SqVRxDQ7q7Nmz8Y2E4a1/4MiU3sk4nU6VSqVUKnt7e5XX9Pb2qlSqkZERojeBQCCTyeLj4+VyeXx8vFQqxR+lUmlsbGxsbCyPxwvjWIAAWa3WkZGR4eHhwcFBjUYzODg4MDAwODioVqs1Go1Wqx0aGiJ6joqKSkxMTEpKwinFq3X8cWZuTm9KJKR3Cna73Xc1rFar8UdiZvs2ucJms2N9xMXFxV5PIBBER0dHR0dP2Iod+CHGxsaMRqPRaDQYDMMT0el0+I1v23T4mn68b0Wsjn0/RvYOV4Sn94aMRqNWqx0eHsarc8LQ0NDQ0BDxkdjdwigUilAoJMJMEIlEuCObzcavHA4nOjoat+qAP0ZFRYXo7F94eb1evV5vt9vHxsbMZrPD4dDr9Q6Hw2KxmM1mm81mNBpHR0eN1zMYDHq93mg0+jXBxWQy8RozJiYGvxGLxX4rU7x6Ddf4zgS3e3oDNDY2Njw8bDAYiMVOr9f7fsSIpdNms0325CiEEJVK9Qsz7oIQYjAY+KQ3/hYhxOPx8OFN3G4zUQifz5/wHxpRgh+r1eq3DsI8Ho9fVUdHRxFCbrfbaDQihHACfUswm824CUvfuOJzBBOKiopisVh47ea3vhMIBEKh0K9LbGws7N0EAtIbQjabzWq1mkwmh8NhMBjwR6PR6HA4jEYjDgNujdnlcuFWS3E/CCGLxYIPsBuNRnxMDocKw8mZ8EeJAf3QaLTo6OgJB/HbHYiOjqbRaHj/AiFEp9NxllgsFr6TjMvl4j+NIpEIryzwKkYkEjGZTB6Px+fzmUymUCgkBgGhAOmNWDqdLj4+vqqqaupWnQF5wdlRAMgK0gsAWUF6ASArSC8AZAXpBYCsIL0AkBWkFwCygvQCQFaQXgDICtILAFlBegEgK0gvAGQF6QWArCC9AJAVpBcAsoL0AkBWkF4AyArSCwBZQXoBICtILwBkBekFgKwgvQCQFaQXALKC9AJAVpBeAMgK0gsAWUF6ASArSC8AZAXpBYCsIL0AkBWkFwCygvQCQFbw9O2IsmDBgra2NuKjw+FgMBgUCgV/5PP5HR0dfD4/TLUDQUYPdwVAMK1evfrcuXO+a2SHw4HfUKnUZcuWQXQjCew5R5TNmzdPsTO1bdu26awMCDXYc440ubm5LS0t42crl8sdGhricDhhqRUIBdj2Rprt27fTaDS/jgwG44EHHoDoRhhIb6R56KGH3G63X0en07l58+aw1AeEDuw5R6Di4uLvv//e4/EQXYRCoU6no9PhIGVEgW1vBNq2bRtxlgghxGAwtm7dCtGNPLDtjUAjIyMSicTlchFd6urqiouLw1glEAqw7Y1AMTExy5cvJza2Mpns7rvvDm+VQChAeiPT1q1b8f9eJpO5Y8cO3x1pEDFgzzkyWSyWuLg4m82GELpw4UJubm64awSCD7a9kYnH461btw4hlJ6eDtGNVHAckty6ulBDw8RfzZq1BaHPCgoe+cc/Ju4hLQ0VFISuaiDkYM+Z3P78Z/Rf/zXZl3aEZAidQyh1wq+feAL9+c8hqxkIPdhzJj0GY7JvWAi9Nll0Jx8KkAakN7I9Fu4KgBCC9AJAVpBeAMgK0gsAWUF6ASArSC8AZAXpBYCsIL0AkBWkFwCygvQCQFaQXgDICtILAFlBegEgK0gvAGQF6QWArCC9AJAVpJf0xj32JIRDgRkF2rUit7Q0tHEjQgh5vZ6GhsfuuOP56OjMyXrWalFNDVq6FMXGIoSgUSvSg3atIkRTU1NBQcHUjb++8QZ69llUUIDOnUPQwHMEgD3nCPHtt9/GxMRkZ2dP0U9bG6JSUVMTmqyVSUAukN4IUVtbW1JSQqVONUObmhB+ruD/+T/IZpumioHQgfRGiIaGhgULFkzdz+XLCCHk9SKNBr399nTUCoQUpDcS6PX6q1evzps3b4p+VCpkMv37vduNXn4ZabXTUTcQOpDeSHDhwgWv1zt1eltbr/vodKK9e0NbKxBqkN5IcOnSpZiYGLlcPkU/ra3XtcDudKJ33/WPNCAXSG8kuHLlypw5c6buZ3xQqVT0/POhqhKYBpDeSNDZ2ZmWljZ1P+fPI6fzui5OJ6qsRN98E8KKgZCC9EaCzs7O2bNnT91PW9sEHWk09Mwz/z6NBEgH0kt6Ho+np6dn6vRqtchgmKC7243a2tBHH4WqbiCkIL2kp9PpHA6HQqGYop+pj07993+jsbEg1wpMA7hLgfQGBgYQQjc84EyhIK8X0ekIIeRyIYSQQIByc1FBAcrJQWNjiMudjtqCIIL0kh5Or0wmm6Kf1lbEYqE5c9D8+SgnB73yCvrP/0T/9/9OVxVBaEB6SU+tVgsEAh6PN0U/v/oVevttRFwEvW8fcjimo24gpCC9pDc0NCQWi6fuB9/QS4iLQ0NDIawSmB5w1Ir0DAaDQCC4qUFiY9HwcIiqA6YPpJf0biG9cXGQ3kgA6SU9g8EgFApvapDYWNhzjgSQXtLT6/Ww53x7gvSS3q3tOY+MIGjRjOwgvaR3C+nl85HTCSeNSA/SS3q3sOfMYiGEkN0ekvqAaQPpJb1bOGrFZCIE6SU/SC/p2Ww2Npt9U4PAtjcyQHpJz+PxTN0Q7Hg4vfC/l+wgveTm9Xq9Xu/Nphf2nCMDpJfcPB4PQujWtr2QXrKD9JIbpPd2Buklt1tLL+w5RwZIL7ndWnpxM3Q0WihqBKYPpJfc8ANcbza9uGlY38bZARnB3fnkhre9NptNpVIZjUaTyWQwGIqLi7lTtlIF6Y0MkF7y2b59e2trK86q2WxGCD3wwAPEtwKBYOhGt/9BeiMDpJd8FArFR5M0wUyj0crKyuj0G8xWfJ0GpJfs4H8v+ezatWuyP7per3ft2rU3LAG2vZEB0ks+SUlJq1evnnAD6/V6y8rKblgCpDcyQHpJ6cknn3ThJtWvN2/evPj4+BsOjtOLz/oC8oL0ktLq1auTk5P9OjKZzPXr1wcyOPzvjQyQXlKiUCg/+clP/HaeHQ5HeXl5IIOPjiIKBd3kLf1gxoH0ktWjjz5KoVB8u4hEooKCgkCGHRlBAgFca0V6kF6yiouL27RpE+Pa7i+Dwbj33nsDvOhqdBSJRKGsHJgWkF4S+8lPfuLEB6AQcrlca9asCXDA0VEUExOyaoHpAuklseLi4tzcXLy9pVKpq1atCnBASG9kgPSS25NPPkmhUCgUyoIFCwJvm25kBPacIwGkl9w2b97MZrO9Xm+A54ow2PZGBooXWtQPN71eb7VarVbr6OgoQshgMHg8HrvdPjY2hhDCHa1Wq81m83q9er0eD+VwOCwWC0Korq6upaXlgQceiImJQQjZbDar1Tr+V5hMJvGM3y++eF4m61iw4BBCiMPhEE1SRkVF0el0BoPB5/MRQgKBgEqlslgsfMeSUCikUCjR0dEcDofH4+FvQztpwJQgvUGDozV6jd97k8lktVqNRqPZbB4bGzObzUaj0Wq14gROITo6mkaj+UUIfyUSiRBCFoulqamppKQEd6TRaNHR0ePLsVgsDp9WJL1eCoXiRQgZjUa324074hUHkX+84pgCm83mcDgikYjD4XC5XPwQcC6XGxUVJRQKRSIRfvV9IxKJaHCqKkggvQGxWCyDg4NarVan0+l0Oq1WOzg4ODQ0hF+JiPoN5bvI8vl8DocTHR3N5/O5XC6fz/fdiOGlHyfTbwMYiP379z/88MPBHul/w5t9j8djMBgQQgaDYWxsDO8p4F0GvV6PuxgMBovFgldSeOWFX/FNyISoqChisshksri4OLFYHB8fL5FIxGKxWCyWSCQ3+3SI2xOk999sNptSqVSpVEqlcmBgYGBgoK+vT6PRqNXqoaEhvBOL8fl8iUQSHx8vFovj4uLi4+PHb17wR7+rKW5bBoNh/M7I6Ojo8PCwRqMZGhrCK0Tf1R+LxcLTVi6XJyYmJiQkJCUlyeVyuVyuUCgCX69FttsuvcPDwz09Pd3d3d3d3b29vTilKpWKuKOdyWQmJCQkJiYqFAqZTCaVSsXX4PccDie8oxCpHA4H3rXRaDTEPo5arSbWqsT/eYFAkJiYiFM9a9as1GukUml4R2GaRWx6PR5Pb29vZ2dn9/Xw7h+dTlcoFLNmzVIoFHghUCgUeNV+uy0BJDI8PKxSqfDalljt9vb29vb22u12hBCXy8UxTklJwW/S09NTU1MZEXpDRoSk1+Vy9fX1tbS0tLa2dnd3t7S0nD9/Hrcaw2azExISUq+XlZUFm9BIMjo62j1OT0+P1+ul0+lJSUlZWVnZ2dn4NSMjgzj8TmpkTa9Wq21sbGxsbDx//nxra2tHR4fD4aBSqcnJyZmZmXgOZWdnp6enx8CZzduV2Wy+cuVKe3t7S0tLe3t7a2trZ2eny+Wi0WgpKSlZWVlz584tKCgoKCgYf7slKZAmvUqlEse1qampsbFxYGAAIZScnJyfn5+VlZWVlZWZmZmRkTF1W4rgNudwODo6Otra2tra2vAO2pUrVzweT2xsbH5+fmFhYX5+fhaUHIQAACAASURBVEFBQVpaGimOOM7c9Lrd7ubm5pqampqamrq6Oq1WS6FQ0tLSCgoK8IQuKCiA7Sr4gcxmc3Nzc+M1bW1tLpdLIBAUFxeXlJQsWrSoqKiIhZ8cM/PMrPTabLazZ8+eOnWqtrb29OnTJpMpJiampKSktLS0qKgoPz9/wusQAAgWq9V64cKFc+fO1dbW1tTUDAwMsNnsoqKiRYsWlZSULFy4MCoqKtx1/H9mRHq1Wu3Ro0cPHz589OhRo9Eok8nwlCopKcnPz4fL8UC4qFSqurq62traurq6xsZGKpV61113rVu3bsWKFYWFheGuXfjS6/F4zpw5U1lZeeTIkfPnz/N4vBUrVqxZs2bVqlWzZs0KS5UAmIJWq62qqqqsrPz666+Hh4dTU1PLy8vLy8uXLFkSrl3rMKS3vb39wIEDH374YW9vb0pKysqVK9euXbty5UriWnkAZjKPx9PU1FRRUXH48OHGxkaBQLBu3brt27cvX758mo91TV96R0ZGcGjPnj2blJS0bdu2LVu2ZGZmTs+vAxAKSqXywIED+/btu3Tp0pw5c7Zv375t2zaFQjFNP+8NvUuXLj366KMsFovP52/fvv3EiRNut3safheAaXPu3LmnnnpKLBZTqdT169efOnVqGn40tOm9cOHCvffeS6FQMjMz33vvPZPJFNKf+yEOHDiQl5dH7L1fvHgx3DXyer3e/fv34/qwWKxw1yUgr732Gq6wXC4Pd13CwOFw/POf/1y4cCFCqLi4uLq6OqQ/F6r06nS6//iP/6BSqfn5+V9++aXH4wnRD/kymUxpaWnl5eU3O2BtbS2FQvnZz35mMpk6OzsTExNnSHqx5cuXkyW9WF5eXlDSe8szNOxOnz69cuVKhNA999zT1dUVol8JycmYf/3rX5mZmceOHfv4448bGhrWrVs3Pf/mvV6vx+Pxu5s0EJ999pnX63366af5fP7s2bOVSmVOTs4PrAyfzyfumAc3NOHkuuUZGnZ33333sWPHqqqq8LL0xhtveENwgCnITwD1er179ux5/fXXd+3a9eqrr07zxRVRUVFdXV23MKBSqUQIxcbGBrtG4Ae55Rk6QyxdurSxsfHVV199/vnn6+rq9u3bF9wreYO57fV6vbt27Xrrrbf27dv3l7/8hUTXRRFNwwAQXAwG4+c///k333xz8uTJe++9d8Imx25dEPfC//jHPzIYjMOHDwexzMAdOnSIGCmr1erXpaenZ9OmTQKBICYmpry8vLOzc/xQ2J133om/Ghwc/OlPf5qcnMxgMOLi4jZs2NDU1OT7i0NDQ7t3705NTWUymXK5fPny5R988MHY2Bhx5IZAo9GIoW5YbFtb2/r166Ojo7lcbklJSU1NzdT/e30PFJ09e3bZsmW4FZ4lS5bU1tZOWGEGgyEUClevXl1VVRV4IXv37sX9LFy4EHf56quvcJfY2FjfH/L73+t0Og8cOLBixQqJRMJms3Nyct58803ivMNkk2v8DL3hWAQyx8Olubk5Jibm8ccfD2KZQUuvWq1ms9m/+c1vglXgrcENo/rObNxl/fr1p0+fNpvNx48f53A4RUVFUw+lUqmSk5MlEkllZaXJZLp06dLixYvZbPbp06dxD2q1OiUlRSqVVlRUGI1GjUaDF278D8fr9fJ4PGIpD7zYjo4OoVAol8uPHTtmMpkuXLiALz674VGrvLw8Ho93991349Gsr6+fO3cuk8k8efKkb4UlEklFRYXBYLh8+fLGjRspFMr7778feCETjldhYeHU6a2oqEAI/fa3vx0ZGdHpdH/605+oVOpzzz3nO8iEk8s7btYEMhaBzPGwwCuXurq6YBUYtPS+8sor8fHxuNXSMJosvRUVFUSXBx54ACGk0+mmGOqRRx5BCH388cdEF7VazWKxCgsL8ccdO3YghD799FPfX1+9evXU6b1hsQ8++CBC6J///CfRw8DAAIvFCiS9CCHfzfiFCxcQQnl5eb4V3r9/P9GDzWZLSEjgcDgajSbAQiYcr0DSu2TJEt8etm7dymAwDAbDFMVifrMmkLEIZI6Hy1133bVt27ZglRa0/73Nzc2lpaUz9l6qoqIi4j2+FEalUk3R/+eff06lUteuXUt0kUql2dnZDQ0N/f39CCG8Hr3nnnt8h/rqq6+eeeaZH1Ls119/jRAqKysjekhISLjjjjsCGUcejzdv3jziY25ubkJCwvnz59VqNVFh30eEslis5cuXW63Wo0ePBljIrVm7dm11dbVvl7y8PKfT2dLScrNFBTgW6Obn+PRYuXJlc3NzsEoL2jFnCmVG3K40Gd8WRplMJkJoivMQdrsdN381YbukHR0dYrHYYDCw2eybul8skGJNJhObzfZrMzE+Pv7KlSs3LH/8k1Di4+NVKtXg4GBMTMyEFZZIJAghjUYTSCEymeyGdZiQwWD4wx/+cOjQof7+ft+GI31b6gwEnoCBjAW6yTlOUkHb9s6bN6+mpsZmswWrwDBisVhCoZBOpzudzvG7K0uXLmWxWAKBwGazmUymyQoZf4o7kGKjoqJsNhtukYswMjISSLWHh4f9VqCDg4MIofj4+MkqrNVqEUK+DfFNUQj+SKVSfVt1RwiNb8jaz7p16/bu3fv444/jhiy8Xu8bb7yBEPL9oUCuCAh8LGasY8eO5efnB6u0oKV3x44dJpPp9ddfD1aB4bVx40aXy1VXV+fb8dVXX01KSnK5XAihDRs2IISOHDni20N+fv7u3bvxey6XSyzlc+bMee+99wIpFu+K4/1nbGho6PLly4HU2Waz1dfXEx8vXryoUqny8vLwNhNXuLKykujBbrefOHGCw+H47qhPXQhCSCaT4WaJMI1G09fXN0Wt3G53XV2dVCrFlwHjlI4/cTLh5BovwLGYmf71r399//33//mf/xm0EoP1B9rr9b755pt0Ov2LL74IYpk3a7KjVr5d9uzZg64/NjO+H61WO3v27NTU1CNHjuj1+uHh4XfffZfL5RKHqfDBT5lMdvjwYaPRqFQqn3jiCYlEcvXqVdzD6tWrBQJBX1/f6dOn6XR6a2trIMV2dnbGxMQQx5xbWlrKysrwxnPqEc/LyxMIBMuXLw/kmLPRaCSO1r733nuBF+L1ep988kmE0Ntvv42vKt20aZNcLp/6qNWyZcsQQr///e91Ot3Y2FhVVVVSUhJC6Pjx40Q/E06u8bMmkLEIZI5Pv8bGRpFItGvXriCWGcz0ejyeXbt2MZnMv/3tb0EsNkB+Z263bNly5swZ3y4vvvii9/p9wvLy8vHne8+cOYMLHB4efvbZZ/F5RbFYvGrVKt+lzev1Dg0NPfPMMykpKQwGQyaTPfTQQ1euXCG+bW9vLy0t5fF4CoXinXfeIbrfsNjLly/fd999+DkpRUVFhw8fXr58Oa7bY489Ntno48C0traWlZVFRUVxOJzFixePP99LVFggEJSVlZ04ceJmC9Hr9Tt37pTJZBwOp6SkpL6+nmhlYs+ePX4nb/E01+l0u3btUigUDAZDIpHs2LHjhRdewD0QB9vHT67xM/SGYxHIHJ9sAoZUVVVVTEzMypUrfdcpP1yQ71LweDx79uyhUCg7d+7U6/XBLRxMISg3BgTr7gJAsNvtv/zlL2k02qZNm8bGxoJbeJDvUqBQKL/73e8OHjz45ZdfZmZm/v3vf4+8A30ABOj48ePz5s17/fXX33zzzU8//TToDwAIyT1G9913X1tb29q1a3fs2JGfn//5559DhsFtpaamZtmyZatWrUpPT7906RI+WBB8wd2U+2ltbb3//vupVOqcOXP++te/Go3GkP7c7WnCv5phKQTY7fbPPvvsrrvuQggtWrSopqYmpD83HS3jtLW17dy5k81m83i8bdu2HT9+HFrGARHm7NmzTz75ZFxcHJVK3bBhQxAvZp7C9F0gNTo6itvv+u677xITE7du3bply5YffhM8AGF09erV/fv379u3r62tLTMzc9u2bdu2bUtMTJyeXw/D5Y2XL1/ev3//Rx991N3dPWvWrFWrVq1YseKee+6BRyoDUsDP6PFtEXbTpk3btm1buHBhxLYI68fj8Zw9e7aysrKysrK5uZnD4Sxbtqy8vHzlypWzZ88OS5UAmIJara6qqjp8+PCxY8dGRkbS09Nxa+yLFi3C11FPvxlxa8Hg4ODXX39NPAlFKpXOnz+/pKRkxYoV8CQUEEb4SSjffPNNbW1tW1sbPAllKna7vb6+vqamBj85xmAwCIXChQsX4qeQFRQUjL8DBoAgslgs58+fJ55CptFoOBzOggUL8FPIiouLZ9T/u5mVXl9ut/vixYv4CaC1tbX4/tLU1FT87E8sLi4u3NUE5GYymfATobH29na32y0SifBD8EpLS+fPnx+uHeMbmrnp9aNSqRp94FYgk5KS/J6+zePxwl1TMHM5HI7Lly/jp2+3trY2Nzd3dnZ6PJ64uDjfrUJqamq4axoQ0qTXj06nwzFubm5ua2u7fPmyw+GgUCjJyckZGRnZ2dkZGRmZmZl33HGHWCwOd2VBeBgMho6ODhzU9vb2lpaWnp4el8tFo9FSU1OzsrLmzp2L44rveSIdsqbXj8vl6uvr6+7ubmlpaW1tbWlpuXDhAr6Hm81mJyQkpF4vMzMzuC3rgvAaHR3tnghCiMFgKBSKrKys7Oxs/Boxcz9C0jue1+vt6+vr7Oz0m524nQoajZaYmDhr1iyFQiGXy+VyuUKhSEhISExMlEqlcJR7ZtJqtSqVqr+/f2BgQKVS9fX1qVSqnp6eq1evOp1OhBCfz/dbTaelpaWmptJotHDXPSQiNr2T0ev1RJJ7e3v7+/v7+/tVKhVuXQUhRKfTpVJpUlJSQkKCXC4Xi8UymUwsFovFYolEEh8fD3+tQ8Rms+l0Oo1GMzg4qNPpBgcHtVqtWq1WKpU4rna7HfcZExOTkJCA51FycjKRVaL5ntvEbZfeydjtdpVKNTAwoFQqVSoVscQMDg5qNBrfhqa4XG58fLxUKo2Li8OpjomJEQqFIpFIJBL5vonUVf7NGh0dHR0d1ev1xCt+MzQ0pNVqdTodDq1va1UcDgevNyUSCU5pYmJiYmIi3ksK+q12JAXpDYjVah0aGlKr1XhRw5sF3TXE4ug3MaOjo4kw83g8LpcrFAo5HA5+w+VyORyOQCDAX0VFRUVFRdHpdDabjZdOkUgUptG9jtFodLvdDofDYrF4vV69Xm+xWKxWq9FoNJvNVqvVZDIZjUar1WqxWAwGg9VqNZvNvin1K1AgEODJEhMTI5VK8RqQeCORSCQSCezgBALSG0x6vd53qfV9NZvNY2Njer1+bGzMarX6ZmDqMjkcDpvNplKpuIlTHo9HnH5kMBgTXjwgFArHX3BrMBjG32VttVqJZkDdbjeujNlsdjqdTqfTr2nL8XzXO1wul8fjCQQC/GbCnRH8CocVggXSG34mkwlvr3DAxsbG7Ha7x+PBjT/jLLlcLrxjaTKZcOuTCCHcp19pRJ92u/3rr79euHAhvqaFy+WObyufTqcTbSNTKBR8KRvuk0aj4efI8fl8BoNB9CkSifDuw4StUoPpBOmNWDqdLj4+vqqqaunSpeGuCwgJ2IcBgKwgvQCQFaQXALKC9AJAVpBeAMgK0gsAWUF6ASArSC8AZAXpBYCsIL0AkBWkFwCygvQCQFaQXgDICtILAFlBegEgK0gvAGQF6QWArCC9AJAVpBcAsoL0AkBWkF4AyArSCwBZQXoBICtILwBkBekFgKwgvQCQFaQXALKC9AJAVpBeAMgK0gsAWUF6ASArergrAIKpqqrK4/Hg9/jh3Q0NDW63m+hh4cKFHA4nPJUDwQZP344oy5Ytq66unuxbiUQyMDBAo9Gms0ogdGDPOaI8/PDDVOrE85TBYDz00EMQ3UgC296IMjo6KpFInE7nhN9+//33CxYsmOYqgdCBbW9EEYlEZWVldPoEhzMUCkVRUdH0VwmEDqQ30mzZssX3MBXGYDB27NhBoVDCUiUQIrDnHGnGxsbi4uKsVqtf90uXLmVnZ4elSiBEYNsbabhc7oYNGxgMhm/HrKwsiG7kgfRGoM2bN/seuGIwGI888kgY6wNCBPacI5DL5YqPjx8dHcUfKRRKd3f3rFmzwlopEHyw7Y1AdDr9Rz/6EZPJRAhRKJQ777wTohuRIL2R6eGHH3Y4HAghGo22ffv2cFcHhATsOUcmj8cjl8s1Gg2NRlOr1WKxONw1AsEH297IRKVSt23bhhBasWIFRDdSwT1G5HbsGHr//Ym/0usfRui1kZEtDz44cQ9lZWjnztBVDYQcpJfcOjvRwYPo2k2BfvIRKqyvX19fP8F3VCqCTTLZwZ4z6U1519D/h1D0zQ8FyAHSG9nywl0BEEKQXgDICtILAFlBegEgK0gvAGQF6QWArCC9AJAVpBcAsoL0AkBWkF4AyArSCwBZQXoBICtILwBkBekFgKwgvQCQFaQXALKC9JLeJA8MDMlQYEaBNiXJrasLNTRM/JXJNPT003c8//yXGRklE/aQloYKCkJYNxBqkN6IpdPp4uPjq6qqli5dGu66gJCAPWcAyArSCwBZQXoBICtILwBkBekFgKwgvQCQFaQXALKC9AJAVpBeAMgK0gsAWUF6ASArSC8AZAXpBYCsIL0AkBWkFwCygvQCQFaQXgDICtILAFlBegEgK0gvAGQF6QWArCC9AJAVpBcAsoL0AkBWkF4AyArSCwBZQXoBICtILwBkBekFgKwgvQCQFaQXALKih7sCIJgOHTrkcrnwe6PRiBD69ttvh4aGiB7WrFnD4/HCUzkQbPD07YiyevXqo0ePTvZtQkKCUqmkUmGHK0LAjIwoDz/88GThZDKZW7duhehGEtj2RhSTyRQXF+dwOCb8tqmpad68edNcJRA6sCaOKFFRUWvXrmUwGOO/Sk1NhehGGEhvpNmyZQtx4IrAYDB27NgRjuqAEII950hjt9vj4uLMZrNf9ytXrqSnp4elSiBEYNsbaVgs1gMPPMBkMokuFApl3rx5EN3IA+mNQJs3b/Y9cEWj0R555JEw1geECOw5RyCPxyORSIiLNCgUilKplMvl4a0VCDrY9kYgKpW6efNmvPNMpVJLS0shuhEJ0huZHn74YbzzTKFQtm/fHu7qgJCAPefI5PV6k5OTlUolnU4fHBwUiUThrhEIPtj2RiZik3vPPfdAdCMVbHunj9vtNhqNZrPZarWaTCaj0Wi1Wi0Wi8FgGBsbs1qto6OjCCGj0eh2u+12+9jYGEJIr9d7vV6bzWa1WhFCuB+itPG/4nA4LBbL+O5sNpvD4YzvzuPxiNNL0dHRNBqNyWTi+5AEAgGVSiUGxGuB6OhoLpfL5XKFQiGHw8FvuFwuh8MRCAR8Pn/CK71AKEB6fxCj0ajT6UZHR0dHR/V6/eg149+bzWa73T5hIdHR0RwOh8fj4bTgANDp9KioKDRJoogBaTTa+AKJje3Pf/7zX/ziFywWC11bKYzvmVgdoOvXFF6vV6/XI4TGxsbsdrvH4zEYDLgfq9VKrGvGwzUXCoUikUgkEhFvfN/jNzExMXFxcYFOazAOpHdSDodDo9FoNBqdTqfT6QYHB7VarU6nGxoaIjr6BXL8Ykq8j4qK4nA40dHRfD6fw+FERUXhLnw+P3SjcPny5Tlz5oSufBxjvV6P9x0MBoPFYrFarUajkVh/jV+R+a5E6HS6WCyOi4uTSCQSiSQuLk4sFkulUrFYLBaL4+PjExISJtxlAAjSa7ValUrlwMBAf39/f3+/SqXq6+sbGBgYGBjQaDREb1wul1iq/Ba1+Ph4IqthHBESMRqNOMnDw8N4Pei7QsRrSZPJRPQfGxubkJCQlJQkl8vlcnlSUlJCQkJiYqJCocC7J7et2yW9Tqezr6+v+3q9vb0jIyO4BxaL5bdwJCYmymQyqVQaHx8P7VFMM5vNptPp8L5PX1+fSqXyXb3iIwIIoaioqFmzZqWmpqakpKRek5KSwmazw1v/6RGB6XW73b29va2tra2trZ2dnTioSqUS77AJhUJiZqekpOCUyuXy+Pj4cFccBGp0dHRgYECpVKpUqp6eHmJ1rNPpEEIUCiUhIQEnOS0tLSMjIysrKz09PfIOp5E+vU6ns7Ozs7W1ta2traWlpb29vb293WazIYQUCsUdd9yRer2YmJhwVxmEislk8tu96ujo6O3tdbvdDAZj9uzZ2dnZGRkZ+DUjI4Ps/6jJl16LxXL+/PnGxsampqbGxsaWlhan00mlUlNSUjIzM7OysojX2/xPEcBsNhtep+OVe2tra0dHB15m0tPTC3wIhcJwV/bmkCC9Vqu1vr7+3LlzOK6XL192u91CoRBP8fz8/KysrIyMjNvkrw744Yj9tebm5sbGxsbGRnyEMjU1lUjy3XffHR0dHe6a3sAMTa/ZbP7uu+9qa2vr6upqa2ttNptQKMzOzi68Jisri0KhhLuaIEKMjo62tLQ0XNPW1kalUufMmVNSUrJw4cIlS5YkJSWFu44TmEHpNZlMx48fP3ny5KlTpy5evOj1ejMyMkpLS0tKShYtWpScnBzuCoLbhVarraurO3XqVG1tbXNzs9vtvuOOO0pKSpYsWbJ69WqxWBzuCv5b+NN75cqVysrKysrKmpoat9udn59fWlqKQztzJhO4bZlMptOnT9fW1p46der77793Op1FRUXl5eXl5eX5+fnh3QEMT3q9Xm9dXd0///nPysrKzs7OmJiYVatWrV27tqysDC6dAzOWxWI5fvz4kSNHjhw5MjAwIJPJysvL77vvvrKyMjo9DI8lme709vb27tu376OPPurs7MzOzl63bt2aNWuKi4snvF4XgJnJ6/U2NzcfOXLk8OHD33//vUQi2bx58yOPPDJ37tzprMY0pddms3366ad/+9vfvv322/j4eDyqeXl50/DTAIRUT08P3iB1dXXNmzfvkUceeeSRR6bpsllviOl0updffjk+Ph63dVhRUeF0OkP9owBMM4/HU1NTs3PnTnyb5FNPPdXT0xPqHw1heo1G48svvxwdHR0bG/vzn/9co9GE7rfADPHaa6/hrYJcLg93XcLDaDS+8cYbs2bNYjKZ//Vf/6VSqUL3W6FK75dffqlQKPh8/p49ewwGQ4h+xY/JZEpLSysvL5+enwOTycvLC0p6yTtD3W73P/7xj5SUFC6X+7vf/c7lcoXiV4LfMo7ZbH744YfXr1+/cuXK3t7e3/3ud9N2zYrX6/V4PB6PZ3p+DgQRn88vKSnx60jeGUqlUh988MGWlpZnn332pZdeWrJkiUqlCvqvBPmolVqtXrVqlVar/eSTT1asWBHEkgGJzJs3b2hoqL+/P/BB+Hz+vHnzamtrQ1ercLl48eKDDz5oMBi+/vrr4B6pDea2d2RkZOnSpS6Xq6GhAaILAJabm3v27Nns7OwVK1a0tbUFs+gg7oXff//9SUlJarU6iGUG7tChQ8RI4WaZfLv09vZu2rSJz+fHxMRs3bp1ZGSkp6dn7dq1fD5fKpXu3LnTaDSOLyfwofbu3YsHWbhwIe7y1Vdf4S6xsbHjS+7p6dm0aZNAIIiJiSkvL+/s7PQdl8HBwZ/+9KfJyckMBiMuLm7Dhg1NTU2TjbjvgaKzZ88uW7YMN76zZMmS2tpa3z6HhoZ2796dmprKYDCEQuHq1aurqqoCLySQccT8/vc6nc4DBw6sWLFCIpGw2eycnJw333zT7Xb7/TSBRqNNOENvOBaBT+HpZ7FY7rrrrry8PLvdHqwyg5be77//HiF07NixYBV4a9avX+83s3GXjRs3njt3zmw279u3DyF0zz33rF+/vqmpyWQyvfvuuwih3bt3jy/nZofi8XjEko0VFhb6Ldm45PXr158+fdpsNh8/fpzD4RQVFRE9qFSq5ORkiURSWVlpMpkuXbq0ePFiNpt9+vTpKUY8Ly+Px+PdfffduNj6+vq5c+cymcyTJ0/iHtRqdUpKikQiqaioMBgMly9f3rhxI4VCef/99wMvJMBx9EtvRUUFQui3v/3tyMiITqf705/+RKVSn3vuuaknne/kImZoIGNxwykcLl1dXSwW64MPPghWgUFL7+7du3Nzc4NV2i2bLL2VlZVEl+zsbITQt99+S3RJSUmZM2fO+HJudqjA01tRUUF0eeCBBxBCOp0Of8RPDPv444+JHtRqNYvFKiwsnGLE8R8q3030hQsXEEJ5eXn4I35+7/79+4kebDYbbvONOJl3w0ICHMfx6V2yZIlvD1u3bmUwGL4nIwJMbyBjccMpHEY/+tGPysrKglVa0P739vT05ObmBqu0oJs/fz7xPiEhwa+LXC6f8JDgrQ0ViKKiIuK9QqFACBFFff7551Qqde3atUQPUqk0Ozu7oaFh6uNAPB5v3rx5xMfc3NyEhITz58+r1WqEEN6rLC8vJ3pgsVjLly+3Wq1Hjx4NsJBbs3bt2urqat8ueXl5TqezpaXlZosKcCzQlFM4jObOndvV1RWs0oKW3ri4OK1WG6zSgs73rBWVSqXRaFwul+hCo9EmPC1xa0MFQiAQEO9xY+i4KLvdbjAYPB6PQCCg+GhsbEQIdXR0TFHm+KYhcGNdg4ODuFg2m+3X3ohEIkEI+baeOUUhNz2S1xgMhpdeeik3N1ckEuHR+dnPfoYQIhqXC1DgY4Emn8LhpdVqg3jnXNDSu2zZslOnTimVymAVSEZUKtX3wbkIIdygeeBYLJZQKKTT6RNeT7p06dIphh0eHvZef/4PRw5fpioQCGw2m29LqwghvMKVSqWBFHLL47hu3bq9e/c+/vjjV65c8Xg8Xq/3jTfeQAj5/lAgt9oFPhYzk91u/+yzz5YvXx6sAoOW3vvvvz85OfnHP/7xTFjDhYtMJhsYGCA+4tZMb7aQjRs3ulyuuro6346vvvpqUlKSy+WaYkCbzVZfX098vHjxokqlysvLk8lkCKENGzYghCorNgNITQAACEJJREFUK4ke7Hb7iRMnOBxOWVlZgIXcwji63e66ujqpVPrUU0+JxWKcUvxUF19cLpdYKcyZM+e9996bsLQAx2JmeuGFFywWyxNPPBGsAoOWXiaT+fe//726unrXrl23bYBXrVqlUqn+93//12w2d3V1Pf3007fQ0Owrr7wye/bsRx999KuvvjIYDCMjI3/9619/9atfvf7661PfRCoQCP7nf/7nzJkzFovl3LlzW7duZTKZb731FlFsSkrKM888c/jwYZPJdOXKlc2bN6vV6rfeegvveQZSyC2MI41GW7JkiUajee2114aGhqxWa3V1NT5i76ugoODKlStKpfLMmTPd3d2lpaWTTZxAxmIG+sMf/vDWW2/95S9/wQdQgiNYh7+wr776is1ml5eXj4yMBLfkG/I914cQ2rJly5kzZ3y7vPjii75bFYTQK6+8UlNT49vll7/85a0Nheug1+t37twpk8k4HE5JSUl9fX1hYSHuZ8+ePeNL9l6/j0pc0Ds8PPzss8/iU5pisXjVqlXHjx+fevTxYd7W1taysjL8jJXFixePP9/7zDPPpKSkMBgMgUBQVlZ24sSJmy1k6nH0O3mLx1Gn0+3atUuhUDAYDIlEsmPHjhdeeAH3QBxIb29vLy0t5fF4CoXinXfemXCG3nAsAp/C08npdO7Zs4dCobz11lvBLTn4dynU1dXJ5fLk5OTDhw8HvXAwmaDcGBCsuwsAob6+Pj8/Pyoq6tNPPw164cG/S6G4uLipqam4uHjt2rX33XffLZwVACAC9Pf3//jHP77rrruEQmFDQ8OmTZuC/hMhefq2WCz+5JNPjh07dvXq1blz527ZsqW5uTkUPwTADNTb2/v000+np6cfO3bsgw8+OHHiRHp6ekh+Kehbc19ut/vAgQO4sZ8VK1Z8+umnvldBgaCY8K9mWAq5zblcrq+//nrTpk10Oj05Ofntt98O4iXNEwp5yzher9fj8Rw9erS8vJxOpwuFwh//+Me1tbX4vB8AEeDSpUvPP/98QkIChUIpLi7+5JNPpqf5p2ltU1Kj0XzyyScffvjhhQsX0tLSNm/evG7dusLCQngqAiCj9vb2w4cPHzhwoKGhYdasWdu2bdu+fXtaWtq0VSA87Tk3Nzd/+OGH//rXv5RKpUQiKS8vX7NmzcqVK2f+k2PAbc5ut3/77beHDx8+cuRIV1dXbGzs+vXrt2/fvmjRounfCIX5WQrnz58/cuRIZWXld999R6PRSktLV65cWVJSUlRUhK9NBSDs3G73xYsXa2pqTpw48c0331gslry8vDVr1qxdu/bOO+8MY1Pk4X8SCjY8PPz1119XVlaePHlSrVZzOJwFCxbg56EUFxfDszzBNLPb7fX19adOncLPwTMajSKRqLS0dM2aNWvWrME3LYXdTEmvr46ODuIZUB0dHTQabd68eQsWLMCPZszJyYHNMgg6t9t9+fJl/EBQ/MRZm80ml8uJ5+BlZ2dTqSE5w3rLZmJ6fanV6tra2tra2oaGhubmZovFwmQyc3JyiOeszp07l+xPQAdh4XK5WltbGxsbGxoaGhsbz58/j5eu3NzcwsLC4uLi0tLS1NTUcFdzKjM9vX5UKhXxkNUzZ84MDw8jhGQyWXZ2dlZWFn6dO3cuHP0CfpxOp1KpbGlpaW1txa+tra1Wq5XBYKSnpxPPhZ4/fz6JHuNOsvT68nq9nZ2dzc3NbW1tra2t7e3t7e3tdrsdIZSUlJSRkZGVlZWenj579uzU1NTk5GTY375NuN1upVLZ3d3d3d3d0dGBF4/e3l63202n02fPnp2dnY0Xj7lz52ZmZobl8X9BQeL0jud2u3t6elpbW9va2vA86+zsHB0dRQjRaLTExMTU682aNesW7uADM4der+/t7cVB7erqwm+uXr3qdDoRQnw+Py0tDQc1MzMzMzMzPT09klbiEZXeCdlsNpVK1X09vNeEEGIymbGxsQkJCampqTKZLCEhAb+mpqYmJSWRd60cSUZHR1UqlVqt7u7uxm/wa1dXF9Gsh0gkSh0nJSUlsi8Eivz0TsjlcimVyt7e3v7+/v7+fpVK1dfXp1KpBgYGcNOECCEajSaRSMRisUwmE4vFYrFYIpHEx8eLxeL4+HipVCoWi0n0H2lmcjqdOp1Op9Op1Wr8RqvVDg4O6nS6wcFBjUaj1WqJNjfi4uISEhIUCoVcLpfL5fhNcnLyrFmzWCxWeEckLG7T9E7B4XCo1WqcarVardVqtVotXrA0Go1Op/NtSy0qKkosFotEIpFIJBQKfd/4fcSNm4dxvKaN3W63WCyjo6Ojo6N6vX7CN/h1eHh4ZGSEGJDFYuE1I15p4vWmRCJJSkpKSEhITEyEdaUfSO9Ns1gsvpHW6XQTLpp6vd7tdvsNKxKJOBwOh8MRCoVcLpfL5UZHR+NgR0VFRUVF0el0DofDZrMpFApu3pHL5bJYLBqNhg+k8/l8BoOBS2OxWL5tXGLEgH5MJtP4ZrHsdjuxMvJ4PAaDASFkNpudTqfL5cKNv+EBHQ6HxWLxer16vX5sbMxqtRoMBrPZbLVaTSaTyWSyWq1msxk3iDl+rH3XaMR6LSYmRiqVxsXFicViqVTq2wokCASkN4SMRiMRZovFMjY2hhf9sbExg8GAu+BFf2xszGKx4EXfYrE4HA632200GsM9BgghxOPxmEwmsfrA6x28AuLxeBwOJzo6Gjejw+fzBQIBfuMb1HCPQcSC9M50eEvodDrNZjNCyGg0Ept0/JVf/3gjOb4cNps9ftedSqX6bvFw0vDG3+8rMANBegEgq5l13SYAIHCQXgDICtILAFn9//juO+dJsNQ7AAAAAElFTkSuQmCC\n",
-      "text/plain": "<IPython.core.display.Image object>"
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
      },
      "execution_count": 19,
      "metadata": {},
@@ -249,23 +246,16 @@
     "\n",
     "from IPython.display import Image\n",
     "Image(filename=\"./graph.png\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": []
   }
  ],
  "metadata": {
@@ -277,16 +267,16 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/notebooks/simulation.ipynb
+++ b/notebooks/simulation.ipynb
@@ -23,7 +23,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from mira.metamodel import *\n",
-    "from mira.modeling import TemplateModel, Model\n",
+    "from mira.modeling import Model\n",
     "from mira.modeling.ode import OdeModel, simulate_ode_model"
    ]
   },

--- a/notebooks/viz_strat_petri.ipynb
+++ b/notebooks/viz_strat_petri.ipynb
@@ -27,8 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mira.metamodel import ControlledConversion, NaturalConversion, Concept, Template\n",
-    "from mira.modeling import TemplateModel\n",
+    "from mira.metamodel import ControlledConversion, NaturalConversion, Concept, Template, TemplateModel\n",
     "\n",
     "infected = Concept(name='infected population', identifiers={'ido': '0000511'})\n",
     "susceptible = Concept(name='susceptible population', identifiers={'ido': '0000514'})\n",

--- a/tests/test_gromet.py
+++ b/tests/test_gromet.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from dataclasses import asdict
 from mira.modeling.gromet_model import GrometModel, model_to_gromet_json_file, model_to_gromet
 from mira.metamodel import ControlledConversion, Concept, NaturalConversion
-from mira.modeling import Model, TemplateModel
+from mira.modeling import Model
+from mira.metamodel.templates import TemplateModel
 
 
 def _get_sir_model_templ():

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -11,7 +11,8 @@ from fastapi.testclient import TestClient
 
 from mira.dkg.model import model_blueprint#, ToGrometQuery
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion
-from mira.modeling import TemplateModel, Model
+from mira.modeling import Model
+from mira.metamodel.templates import TemplateModel
 # from mira.modeling.gromet_model import GrometModel
 from mira.modeling.ops import stratify
 from mira.modeling.petri import PetriNetModel

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -4,7 +4,7 @@ import unittest
 
 from mira.examples.sir import cities, sir, sir_2_city
 from mira.metamodel import NaturalConversion
-from mira.modeling import TemplateModel
+from mira.metamodel.templates import TemplateModel
 from mira.modeling.ops import stratify
 
 


### PR DESCRIPTION
This PR makes the following changes:
- Moves `TemplateModel` into the `metamodel` module where it is a more logical fit and updates dependent code
- Makes `Variable` assembly more sophisticated when making transition `Models` so that structured data independent of the key can be propagated.
- Changes Github Actions to run on push so pushed branches are tested independent of PRs. This is also useful if non-public tests exist that don't work with PRs.
- Adds a function to get TemplateModels from JSON files directly