### PR TITLE
Improve metamodel module structure and docs

### DIFF
--- a/docs/source/metamodel.rst
+++ b/docs/source/metamodel.rst
@@ -4,9 +4,15 @@ Meta-model
    :members:
    :show-inheritance:
 
-Templates (:py:mod:`mira.metamodel.templates`)
-----------------------------------------------
+Operations (:py:mod:`mira.metamodel.ops`)
+-----------------------------------------
+.. automodule:: mira.metamodel.ops
+   :members:
+   :show-inheritance:
+
+Template utilities (:py:mod:`mira.metamodel.templates`)
+-------------------------------------------------------
 .. automodule:: mira.metamodel.templates
     :members:
-    :exclude-members: Concept, ControlledConversion, NaturalConversion, Provenance, Template
+    :exclude-members: Concept, ControlledConversion, NaturalConversion, Provenance, Template, NaturalDegradation, NaturalProduction, GroupedControlledConversion
     :show-inheritance:

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -13,10 +13,10 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from mira.metamodel import NaturalConversion, Template, ControlledConversion
+from mira.metamodel.ops import stratify
 from mira.modeling import Model
 from mira.metamodel.templates import TemplateModel
 # from mira.modeling.gromet_model import GrometModel
-from mira.modeling.ops import stratify
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
 

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -3,7 +3,7 @@
 import itertools as itt
 from typing import Iterable, Optional, Set, Tuple, Type
 
-from ..metamodel import *
+from .templates import *
 
 __all__ = [
     "stratify",

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -48,7 +48,7 @@
     },
     "ControlledConversion": {
       "title": "ControlledConversion",
-      "description": "Specifies a process of controlled conversion from subject to outcome,\ncontrolled by the controller",
+      "description": "Specifies a process of controlled conversion from subject to outcome,\ncontrolled by the controller.",
       "type": "object",
       "properties": {
         "type": {

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -282,7 +282,7 @@ class Provenance(BaseModel):
 
 class ControlledConversion(Template):
     """Specifies a process of controlled conversion from subject to outcome,
-    controlled by the controller"""
+    controlled by the controller."""
 
     type: Literal["ControlledConversion"] = Field("ControlledConversion", const=True)
     controller: Concept
@@ -366,6 +366,7 @@ class NaturalDegradation(Template):
     type: Literal["NaturalDegradation"] = Field("NaturalDegradation", const=True)
     subject: Concept
     provenance: List[Provenance] = Field(default_factory=list)
+
 
 def get_json_schema():
     """Get the JSON schema for MIRA."""
@@ -488,12 +489,6 @@ def assert_concept_context_refinement(refined_concept: Concept, other_concept: C
     return True
 
 
-def main():
-    """Generate the JSON schema file."""
-    schema = get_json_schema()
-    SCHEMA_PATH.write_text(json.dumps(schema, indent=2))
-
-
 # Needed for proper parsing by FastAPI
 SpecifiedTemplate = Annotated[
     Union[
@@ -512,6 +507,12 @@ class TemplateModel(BaseModel):
     def from_json(cls, data) -> "TemplateModel":
         templates = [Template.from_json(template) for template in data["templates"]]
         return cls(templates=templates)
+
+
+def main():
+    """Generate the JSON schema file."""
+    schema = get_json_schema()
+    SCHEMA_PATH.write_text(json.dumps(schema, indent=2))
 
 
 if __name__ == "__main__":

--- a/notebooks/biomodels.ipynb
+++ b/notebooks/biomodels.ipynb
@@ -287,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mira.modeling.ops import stratify"
+    "from mira.metamodel.ops import stratify"
    ]
   },
   {

--- a/notebooks/viz_strat_petri.ipynb
+++ b/notebooks/viz_strat_petri.ipynb
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mira.modeling.ops import stratify\n",
+    "from mira.metamodel.ops import stratify\n",
     "\n",
     "model_2_city = stratify(\n",
     "    template_model,\n",

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -11,10 +11,10 @@ from fastapi.testclient import TestClient
 
 from mira.dkg.model import model_blueprint#, ToGrometQuery
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion
-from mira.modeling import Model
+from mira.metamodel.ops import stratify
 from mira.metamodel.templates import TemplateModel
 # from mira.modeling.gromet_model import GrometModel
-from mira.modeling.ops import stratify
+from mira.modeling import Model
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -3,9 +3,7 @@
 import unittest
 
 from mira.examples.sir import cities, sir, sir_2_city
-from mira.metamodel import NaturalConversion
-from mira.metamodel.templates import TemplateModel
-from mira.modeling.ops import stratify
+from mira.metamodel.ops import stratify
 
 
 class TestOperations(unittest.TestCase):


### PR DESCRIPTION
This PR moves the `ops` module into `mira.metamodel` since it operates over a `TemplateModel` which is now also in the same module. It also updates the documentation structure to match the content of the module.