### PR TITLE
Fix transition model assembly

### DIFF
--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -84,9 +84,9 @@ class Model:
                     produced = tuple()
 
                 consumed_key = tuple(s.key for s in consumed) \
-                    if len(consumed) > 1 else consumed[0].key
+                    if len(consumed) != 1 else consumed[0].key
                 produced_key = tuple(o.key for o in produced) \
-                    if len(produced) > 1 else produced[0].key
+                    if len(produced) != 1 else produced[0].key
                 tkey = get_transition_key((consumed_key, produced_key),
                                           template.type)
                 p = self.get_create_parameter(

--- a/tests/test_transition_model.py
+++ b/tests/test_transition_model.py
@@ -1,0 +1,14 @@
+from mira.metamodel import *
+from mira.modeling import Model
+
+
+def test_degradation_production():
+    template = NaturalDegradation(subject=Concept(name='x'))
+    tmodel = TemplateModel(templates=[template])
+    model = Model(tmodel)
+    assert len(model.variables) == 1
+
+    template2 = NaturalProduction(outcome=Concept(name='x'))
+    tmodel = TemplateModel(templates=[template, template2])
+    model = Model(tmodel)
+    assert len(model.variables) == 1


### PR DESCRIPTION
This PR fixes a bug related to variable key definition that I introduced in #44 and adds a regression test.