### PR TITLE
Implement transitive closure for refinement checking

### DIFF
--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Tuple, Union
 
 import neo4j.graph
+import networkx
 import pystow
 from neo4j import GraphDatabase
 from pydantic import BaseModel, Field
@@ -288,6 +289,31 @@ class Neo4jClient:
             return None
         # FIXME the construction should not allow entities missing names
         return Entity(**r[0])
+
+    def get_transitive_closure(self, rels=None):
+        # Note: could not import this on top without circular import error
+        if not rels:
+            from mira.dkg.utils import DKG_REFINER_RELS
+            rels = DKG_REFINER_RELS
+        rel_type_str = '|'.join(rels)
+        cypher = f"""\
+            MATCH (n)-[:{rel_type_str}]->(m)
+            RETURN DISTINCT n, m
+        """
+        logger.info(f'Finding related nodes according to {rel_type_str}...')
+        r = self.query_tx(cypher)
+        if not r:
+            return None
+
+        logger.info('Building transitive closure...')
+        transitive_closure = set()
+        g = networkx.DiGraph()
+        g.add_edges_from([(n['id'], m['id']) for n, m in r])
+        for node in g:
+            transitive_closure |= {
+                (node, desc) for desc in networkx.descendants(g, node)
+            }
+        return transitive_closure
 
 
 def similarity_score(query, entity: Entity) -> Tuple[float, float, float, float]:

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -7,7 +7,7 @@ from collections import Counter
 from difflib import SequenceMatcher
 from functools import lru_cache
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
 import neo4j.graph
 import networkx
@@ -290,7 +290,27 @@ class Neo4jClient:
         # FIXME the construction should not allow entities missing names
         return Entity(**r[0])
 
-    def get_transitive_closure(self, rels=None):
+    def get_transitive_closure(self, rels: Optional[List[str]] = None) -> Set[Tuple[str, str]]:
+        """Return transitive closure with respect to one or more relations.
+
+        Transitive closure is constructed as a set of pairs of node IDs
+        ordered as (successor, descendant). Note that if rels are ones
+        that point towards taxonomical parents (e.g., subclassof, part_of),
+        then the pairs are interpreted as (taxonomical child, taxonomical
+        ancestor).
+
+        Parameters
+        ----------
+        rels :
+             One or more relation types to traverse. If not given,
+             the default DKG_REFINER_RELS are used capturing taxonomical
+             parenthood relationships.
+
+        Returns
+        -------
+        :
+            The set of pairs constituting the transitive closure.
+        """
         # Note: could not import this on top without circular import error
         if not rels:
             from mira.dkg.utils import DKG_REFINER_RELS

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -533,6 +533,23 @@ class TemplateModel(BaseModel):
         return cls(templates=templates)
 
 
+class RefinementClosure:
+    """A wrapper class for storing a transitive closure and exposing a
+    function to check for refinement relationship.
+
+    Typical usage would involve:
+    >>> from mira.dkg.client import Neo4jClient
+    >>> nc = Neo4jClient()
+    >>> rc = RefinementClosure(nc.get_transitive_closure())
+    >>> rc.is_ontological_child('doid:0080314', 'bfo:0000016')
+    """
+    def __init__(self, transitive_closure):
+        self.transitive_closure = transitive_closure
+
+    def is_ontological_child(self, child_curie: str, parent_curie: str) -> bool:
+        return (child_curie, parent_curie) in self.transitive_closure
+
+
 def main():
     """Generate the JSON schema file."""
     schema = get_json_schema()

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ tests =
     pygraphviz
 dkg-client =
     neo4j
+    networkx
     pystow
     tqdm
 dkg-construct =


### PR DESCRIPTION
This PR implements an approach to getting the transitive closure from the DKG. Interestingly, a direct Cypher query to get unbounded paths is much slower than getting all individual edges from the DKG first, and then using networkx in memory to get the transitive closure. It also adds a utility class in the `mira.metamodel.templates` module that wraps a transitive closure and exposes an `is_ontological_child` method for use in refinement finding functions.