### PR TITLE
Find and include implicit rate controllers in SBML models

### DIFF
--- a/mira/sources/sbml.py
+++ b/mira/sources/sbml.py
@@ -54,9 +54,20 @@ PROPERTIES_XPATH = f"rdf:RDF/rdf:Description/bqbiol:hasProperty/rdf:Bag/rdf:li"
 #: _protein-containing complex disassembly_ (GO:0043624)"
 IS_VERSION_XPATH = f"rdf:RDF/rdf:Description/bqbiol:hasProperty/rdf:Bag/rdf:li"
 
-converter = curies.Converter.from_reverse_prefix_map(
-    bioregistry.manager.get_reverse_prefix_map(include_prefixes=True)
-)
+
+class Converter:
+    def __init__(self):
+        self.converter = None
+
+    def parse_uri(self, uri):
+        if self.converter is None:
+            self.converter = curies.Converter.from_reverse_prefix_map(
+                bioregistry.manager.get_reverse_prefix_map(include_prefixes=True)
+            )
+        return self.converter.parse_uri(uri)
+
+
+converter = Converter()
 
 
 class ParseResult(BaseModel):
@@ -126,7 +137,7 @@ def template_model_from_sbml_model(
     templates: List[Template] = []
     # see docs on reactions
     # https://sbml.org/software/libsbml/5.18.0/docs/formatted/python-api/classlibsbml_1_1_reaction.html
-    all_species = {species.getSpecies() for species in sbml_model.species}
+    all_species = {species.id for species in sbml_model.species}
     for reaction in sbml_model.getListOfReactions():
         reaction_id = reaction.getId()
 

--- a/mira/sources/sbml.py
+++ b/mira/sources/sbml.py
@@ -258,13 +258,19 @@ def template_model_from_sbml_model(
 
 
 def variables_from_ast(ast_node):
+    """Recursively find variables appearing in a libSbml math formula."""
     variables_in_ast = set()
+    # We check for any children first
     for child_id in range(ast_node.getNumChildren()):
         child = ast_node.getChild(child_id)
+        # If the child has further children, we recursively add its variables
         if child.getNumChildren():
             variables_in_ast |= variables_from_ast(child)
+        # Otherwise we just add the "leaf" child variable
         else:
             variables_in_ast.add(child.getName())
+    # Now we add the node itself. Note that sometimes names are None which
+    # we can ignore.
     name = ast_node.getName()
     if name:
         variables_in_ast.add(name)


### PR DESCRIPTION
This PR addresses an issue in SBML model processing where species that are not explicitly listed as reaction modifiers but affect the rate of the reaction through the rate law were not considered. To find such implicit modifiers, I implemented an approach where we find model species that appear in the rate law and remove ones that are reactants and also ones that are known explicit modifiers. These implicit modifiers are then added to the overall list of modifiers and are taken into account when constructing MIRA Templates. Other minor changes:
- A new API function to read SBML directly from a file path
- Lazy loading for the curies converter which takes around 10 seconds to load.