### PR TITLE
More template keys

### DIFF
--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -440,7 +440,7 @@ class GroupedControlledConversion(Template):
             self.type,
             *tuple(
                 c.get_key(config=config)
-                for c in sorted(self.controllers, key=lambda c: c.get_curie())
+                for c in sorted(self.controllers, key=lambda c: c.get_key(config=config))
             ),
             self.subject.get_key(config=config),
             self.outcome.get_key(config=config),


### PR DESCRIPTION
This PR adds the `get_key` method to the Template models that were previously missing them. There is also an update to the return of `Concept.get_curie()`.

The `get_key` methods were quickly added based on how they look in the other ones. Specifically the `get_key` method for `GroupedControlledConversion` needs a closer look.