### PR TITLE
Update search

### DIFF
--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -264,9 +264,10 @@ class Neo4jClient:
                 apoc.text.distance(apoc.text.clean(n.name), "{query_lower}") as label_dist, 
                 min([syn IN COALESCE(n.synonyms, []) | apoc.text.distance(apoc.text.clean(syn),\
                     "{query_lower}")]) AS min_syn_dist,
+                NOT apoc.text.clean(n.name) CONTAINS "{query_lower}" as cnt,
                 n AS node
             RETURN node
-            ORDER BY label_dist, min_syn_dist
+            ORDER BY cnt, label_dist, min_syn_dist
             SKIP {offset}
             LIMIT {limit}
         """

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -258,10 +258,13 @@ class Neo4jClient:
             f"""\
             MATCH (n)
             WHERE
-                replace(replace(toLower(n.name), '-', ''), '_', '') CONTAINS '{query_lower}'
-                OR any(
-                    synonym IN n.synonyms 
-                    WHERE replace(replace(toLower(synonym), '-', ''), '_', '') CONTAINS '{query_lower}'
+                n.type = 'class'
+                AND (
+                    replace(replace(toLower(n.name), '-', ''), '_', '') CONTAINS '{query_lower}'
+                    OR any(
+                        synonym IN n.synonyms 
+                        WHERE replace(replace(toLower(synonym), '-', ''), '_', '') CONTAINS '{query_lower}'
+                    )
                 )
             RETURN n
             LIMIT {max(limit, 50)}

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -253,6 +253,9 @@ class Neo4jClient:
 
     def search(self, query: str, limit: int = 25) -> List[Entity]:
         """Search nodes for a given name or synonym substring."""
+        if len(query) < 3:
+            # Don't search super short query strings
+            return []
         query_lower = query.lower().replace("-", "").replace("_", "")
         cypher = dedent(
             f"""\

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -267,7 +267,6 @@ class Neo4jClient:
                     )
                 )
             RETURN n
-            LIMIT {max(limit, 50)}
         """
         )
         entities = [Entity(**n) for n in self.query_nodes(cypher)]


### PR DESCRIPTION
This PR demos one way we can make search pagination working by sticking the similarity logic inside the query. This might be problematic since it does make the query slower, but I think it's still good enough for autocomplete.

A few other things:

1. Using the `apoc.text.distance` vs `apoc.text.jaroWinklerDistance` (the second one biases towards the query text showing up at the front)
2. How to incorporate the pre-defined entity list? it could also be formatted in to the cypher query and added as an additional field
3. This is different in a few ways than the `similarity_score()` function, so will that be okay or should we try and fully-reimplement that?
4. A much simpler way to implement pagination would be to keep what was there and just use the list index for pagination. is there a lot to be gained from this more complicated solution? or should we revert to that?