### PR TITLE
Bilayer and BioModels model endpoints

### DIFF
--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -15,6 +15,7 @@ from mira.metamodel import NaturalConversion, Template, ControlledConversion
 from mira.metamodel.ops import stratify
 from mira.modeling import Model
 from mira.metamodel.templates import TemplateModel
+from mira.modeling.bilayer import BilayerModel
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
 from mira.sources.bilayer import template_model_from_bilayer
@@ -139,6 +140,15 @@ def bilayer_to_template_model(bilayer: Dict[str, Any]):
 
 
 # Input: TemplateModel, output: bilayer JSON
+@model_blueprint.post("/model_to_bilayer", response_model=Dict[str, Any])
+def template_model_to_bilayer(template_model: TemplateModel):
+    # todo:
+    #  - add openapi docs + docstrings
+    #  - Use model for bilayer to be used from above as response model
+    bilayer_model = BilayerModel(Model(template_model))
+    return bilayer_model.bilayer
+
+
 # Input: SBML string (XML), output: TemplateModel
 
 

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -120,7 +120,29 @@ class StratificationQuery(BaseModel):
         return ControlledConversion
 
 
-# Input: BioModels ID, output: TemplateModel
+@model_blueprint.post("/stratify", response_model=TemplateModel, tags=["modeling"])
+def model_stratification(
+    stratification_query: StratificationQuery = Body(
+        ...,
+        example={
+            "template_model": template_model_example,
+            "key": "city",
+            "strata": ["boston", "nyc"],
+        },
+    )
+):
+    """Stratify a model according to the specified stratification"""
+    template_model = stratify(
+        template_model=stratification_query.template_model,
+        key=stratification_query.key,
+        strata=stratification_query.strata,
+        structure=stratification_query.structure,
+        directed=stratification_query.directed,
+        conversion_cls=stratification_query.get_conversion_cls(),
+    )
+    return template_model
+
+
 @model_blueprint.get("/biomodel/{model_id}", response_model=TemplateModel, tags=["modeling"])
 def biomodel_id_to_model(model_id):
     # todo: add strings for opanapi docs
@@ -159,29 +181,6 @@ class XmlString(BaseModel):
 def sbml_xml_to_model(xml: XmlString):
     parse_res = template_model_from_sbml_string(xml.xml_string)
     return parse_res.template_model
-
-
-@model_blueprint.post("/stratify", response_model=TemplateModel, tags=["modeling"])
-def model_stratification(
-    stratification_query: StratificationQuery = Body(
-        ...,
-        example={
-            "template_model": template_model_example,
-            "key": "city",
-            "strata": ["boston", "nyc"],
-        },
-    )
-):
-    """Stratify a model according to the specified stratification"""
-    template_model = stratify(
-        template_model=stratification_query.template_model,
-        key=stratification_query.key,
-        strata=stratification_query.strata,
-        structure=stratification_query.structure,
-        directed=stratification_query.directed,
-        conversion_cls=stratification_query.get_conversion_cls(),
-    )
-    return template_model
 
 
 # GraphicalModel endpoints

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -145,8 +145,18 @@ def model_stratification(
     return template_model
 
 
-@model_blueprint.get("/biomodel/{model_id}", response_model=TemplateModel,
-                     tags=["modeling"], status_code=200)
+@model_blueprint.get(
+    "/biomodel/{model_id}",
+    response_model=TemplateModel,
+    tags=["modeling"],
+    status_code=200,
+    responses={
+        400: {
+            "description": "Bad Request. When the model id doesn't match a "
+                           "model, a bad request status will be returned."
+        }
+    },
+)
 def biomodel_id_to_model(
     response: Response,
     model_id: str = FastPath(

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -150,6 +150,15 @@ def template_model_to_bilayer(template_model: TemplateModel):
 
 
 # Input: SBML string (XML), output: TemplateModel
+class XmlString(BaseModel):
+    # todo: better description
+    xml_string: str = Field(..., description="An SBML model as an XML string")
+
+
+@model_blueprint.post("/sbml_xml_to_model", response_model=TemplateModel)
+def sbml_xml_to_model(xml: XmlString):
+    parse_res = template_model_from_sbml_string(xml.xml_string)
+    return parse_res.template_model
 
 
 @model_blueprint.post("/stratify", response_model=TemplateModel, tags=["modeling"])

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -121,7 +121,7 @@ class StratificationQuery(BaseModel):
 
 
 # Input: BioModels ID, output: TemplateModel
-@model_blueprint.get("/biomodel/{model_id}", response_model=TemplateModel)
+@model_blueprint.get("/biomodel/{model_id}", response_model=TemplateModel, tags=["modeling"])
 def biomodel_id_to_model(model_id):
     # todo: add strings for opanapi docs
     xml_string = get_sbml_model(model_id=model_id)
@@ -130,7 +130,7 @@ def biomodel_id_to_model(model_id):
 
 
 # Input: bilayer JSON, output: TemplateModel
-@model_blueprint.post("/bilayer_to_model", response_model=TemplateModel)
+@model_blueprint.post("/bilayer_to_model", response_model=TemplateModel, tags=["modeling"])
 def bilayer_to_template_model(bilayer: Dict[str, Any]):
     # todo:
     #  - add openapi docs
@@ -140,7 +140,7 @@ def bilayer_to_template_model(bilayer: Dict[str, Any]):
 
 
 # Input: TemplateModel, output: bilayer JSON
-@model_blueprint.post("/model_to_bilayer", response_model=Dict[str, Any])
+@model_blueprint.post("/model_to_bilayer", response_model=Dict[str, Any], tags=["modeling"])
 def template_model_to_bilayer(template_model: TemplateModel):
     # todo:
     #  - add openapi docs + docstrings
@@ -155,7 +155,7 @@ class XmlString(BaseModel):
     xml_string: str = Field(..., description="An SBML model as an XML string")
 
 
-@model_blueprint.post("/sbml_xml_to_model", response_model=TemplateModel)
+@model_blueprint.post("/sbml_xml_to_model", response_model=TemplateModel, tags=["modeling"])
 def sbml_xml_to_model(xml: XmlString):
     parse_res = template_model_from_sbml_string(xml.xml_string)
     return parse_res.template_model

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Literal, Set, Type, Union, Any
 
 import pystow
 from fastapi import APIRouter, BackgroundTasks, Body, Path as FastPath, \
-    status, Response
+    HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
@@ -158,7 +158,6 @@ def model_stratification(
     },
 )
 def biomodels_id_to_model(
-    response: Response,
     model_id: str = FastPath(
         ...,
         description="The BioModels model ID to get the template model for.",
@@ -169,8 +168,7 @@ def biomodels_id_to_model(
     try:
         xml_string = get_sbml_model(model_id=model_id)
     except FileNotFoundError:
-        response.status_code = status.HTTP_400_BAD_REQUEST
-        return
+        raise HTTPException(status_code=400, detail="Bad model id")
     parse_res = template_model_from_sbml_string(xml_string, model_id=model_id)
     return parse_res.template_model
 

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -146,7 +146,7 @@ def model_stratification(
 
 
 @model_blueprint.get(
-    "/biomodel/{model_id}",
+    "/biomodels/{model_id}",
     response_model=TemplateModel,
     tags=["modeling"],
     status_code=200,
@@ -157,15 +157,15 @@ def model_stratification(
         }
     },
 )
-def biomodel_id_to_model(
+def biomodels_id_to_model(
     response: Response,
     model_id: str = FastPath(
         ...,
-        description="The biomodel model ID to get the template model for.",
+        description="The BioModels model ID to get the template model for.",
         example="BIOMD0000000956",
     ),
 ):
-    """Get a biomodel base template model by providing its model id"""
+    """Get a BioModels base template model by providing its model id"""
     try:
         xml_string = get_sbml_model(model_id=model_id)
     except FileNotFoundError:
@@ -210,7 +210,7 @@ class XmlString(BaseModel):
 def sbml_xml_to_model(
     xml: XmlString = Body(..., description="An XML string to turn into a template model")
 ):
-    """Turn SBML biomodel XML into a template model"""
+    """Turn SBML XML into a template model"""
     parse_res = template_model_from_sbml_string(xml.xml_string)
     return parse_res.template_model
 

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -4,7 +4,7 @@ This submodule serves as an API for modeling
 """
 import uuid
 from pathlib import Path
-from typing import List, Dict, Literal, Set, Type, Union
+from typing import List, Dict, Literal, Set, Type, Union, Any
 
 import pystow
 from fastapi import APIRouter, BackgroundTasks, Body
@@ -17,6 +17,7 @@ from mira.modeling import Model
 from mira.metamodel.templates import TemplateModel
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
+from mira.sources.bilayer import template_model_from_bilayer
 from mira.sources.sbml import template_model_from_sbml_string
 from mira.sources.biomodels import get_sbml_model
 
@@ -128,6 +129,15 @@ def biomodel_id_to_model(model_id):
 
 
 # Input: bilayer JSON, output: TemplateModel
+@model_blueprint.post("/bilayer_to_model", response_model=TemplateModel)
+def bilayer_to_template_model(bilayer: Dict[str, Any]):
+    # todo:
+    #  - add openapi docs
+    #  - Create model for 'bilayer' or at least add an example, e.g. the
+    #    test bilayer in tests.test_bilayer.sir_bilayer
+    return template_model_from_bilayer(bilayer_json=bilayer)
+
+
 # Input: TemplateModel, output: bilayer JSON
 # Input: SBML string (XML), output: TemplateModel
 

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -17,6 +17,8 @@ from mira.modeling import Model
 from mira.metamodel.templates import TemplateModel
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
+from mira.sources.sbml import template_model_from_sbml_string
+from mira.sources.biomodels import get_sbml_model
 
 __all__ = [
     "model_blueprint",
@@ -114,6 +116,20 @@ class StratificationQuery(BaseModel):
         if self.conversion_cls == "natural_conversion":
             return NaturalConversion
         return ControlledConversion
+
+
+# Input: BioModels ID, output: TemplateModel
+@model_blueprint.get("/biomodel/{model_id}", response_model=TemplateModel)
+def biomodel_id_to_model(model_id):
+    # todo: add strings for opanapi docs
+    xml_string = get_sbml_model(model_id=model_id)
+    parse_res = template_model_from_sbml_string(xml_string, model_id=model_id)
+    return parse_res.template_model
+
+
+# Input: bilayer JSON, output: TemplateModel
+# Input: TemplateModel, output: bilayer JSON
+# Input: SBML string (XML), output: TemplateModel
 
 
 @model_blueprint.post("/stratify", response_model=TemplateModel, tags=["modeling"])

--- a/mira/examples/sir.py
+++ b/mira/examples/sir.py
@@ -1,4 +1,4 @@
-"""Examples of metamodel templates."""
+"""Examples of metamodel templates and other model structures"""
 
 from ..metamodel import Concept, ControlledConversion, NaturalConversion
 from ..metamodel.templates import TemplateModel
@@ -6,6 +6,7 @@ from ..metamodel.templates import TemplateModel
 __all__ = [
     "sir",
     "sir_2_city",
+    "sir_bilayer",
 ]
 
 # SIR Model
@@ -58,3 +59,20 @@ sir_2_city = TemplateModel(
         recovered_boston_to_nyc,
     ],
 )
+
+sir_bilayer = \
+    {"Wa": [{"influx": 1, "infusion": 2},
+            {"influx": 2, "infusion": 3}],
+     "Win": [{"arg": 1, "call": 1},
+             {"arg": 2, "call": 1},
+             {"arg": 2, "call": 2}],
+     "Box": [{"parameter": "beta"},
+             {"parameter": "gamma"}],
+     "Qin": [{"variable": "S"},
+             {"variable": "I"},
+             {"variable": "R"}],
+     "Qout": [{"tanvar": "S'"},
+              {"tanvar": "I'"},
+              {"tanvar": "R'"}],
+     "Wn": [{"efflux": 1, "effusion": 1},
+            {"efflux": 2, "effusion": 2}]}

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -134,6 +134,11 @@ class Concept(BaseModel):
             if self.name.lower() != self.name.lower():
                 return False
 
+        # Here we know that we have
+        # len(self.identifiers) > 0 XOR len(other.identifiers) > 0
+        else:
+            return False
+
         return True
 
     def refinement_of(

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -129,9 +129,10 @@ class Concept(BaseModel):
                 return False
             else:
                 pass
-        # If either or both are ungrounded -> can't know -> False
-        else:
-            return False
+        # If both are ungrounded use name equality as fallback
+        elif len(self.identifiers) == 0 and len(other.identifiers) == 0:
+            if self.name.lower() != self.name.lower():
+                return False
 
         return True
 

--- a/mira/sources/biomodels.py
+++ b/mira/sources/biomodels.py
@@ -86,6 +86,8 @@ def get_sbml_model(model_id: str) -> str:
     """
     url = f'{DOWNLOAD_URL}?models={model_id}'
     res = requests.get(url)
+    if res.status_code == 404:
+        raise FileNotFoundError(f'No such file on source server: {model_id}')
     z = zipfile.ZipFile(io.BytesIO(res.content))
     return z.open(f'{model_id}.xml').read().decode('utf-8')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,9 @@ web =
     pystow
     tabulate
     pygraphviz
+    python-libsbml
+    lxml
+    bioregistry
 uvicorn =
     uvicorn
 gunicorn =

--- a/tests/test_bilayer.py
+++ b/tests/test_bilayer.py
@@ -1,26 +1,9 @@
+from mira.examples.sir import sir_bilayer
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion, \
     TemplateModel
 from mira.modeling import Model
 from mira.modeling.bilayer import BilayerModel
 from mira.sources.bilayer import template_model_from_bilayer
-
-
-sir_bilayer = \
-    {"Wa": [{"influx": 1, "infusion": 2},
-            {"influx": 2, "infusion": 3}],
-     "Win": [{"arg": 1, "call": 1},
-             {"arg": 2, "call": 1},
-             {"arg": 2, "call": 2}],
-     "Box": [{"parameter": "beta"},
-             {"parameter": "gamma"}],
-     "Qin": [{"variable": "S"},
-             {"variable": "I"},
-             {"variable": "R"}],
-     "Qout": [{"tanvar": "S'"},
-              {"tanvar": "I'"},
-              {"tanvar": "R'"}],
-     "Wn": [{"efflux": 1, "effusion": 1},
-            {"efflux": 2, "effusion": 2}]}
 
 
 def test_process_bilayer():

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -160,3 +160,11 @@ class TestModelApi(unittest.TestCase):
         with open(tmpf, 'rb') as fi:
             file_str = fi.read()
         self.assertEqual(file_str, response.content)
+
+    def test_biomodels_id_to_template_model(self):
+        model_id = "BIOMD0000000982"
+        response = self.client.get(f"/api/biomodel/{model_id}")
+        self.assertEqual(200, response.status_code)
+
+        # Try to make a template model from the json
+        tm = TemplateModel.from_json(response.json())

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -167,7 +167,7 @@ class TestModelApi(unittest.TestCase):
 
     def test_biomodels_id_to_template_model(self):
         model_id = "BIOMD0000000956"
-        response = self.client.get(f"/api/biomodel/{model_id}")
+        response = self.client.get(f"/api/biomodels/{model_id}")
         self.assertEqual(200, response.status_code)
 
         # Try to make a template model from the json
@@ -179,7 +179,7 @@ class TestModelApi(unittest.TestCase):
         self.assertEqual(sorted_json_str(tm.dict()), sorted_json_str(local.dict()))
 
     def test_biomodels_id_bad_request(self):
-        response = self.client.get(f"/api/biomodel/not_a_model")
+        response = self.client.get(f"/api/biomodels/not_a_model")
         self.assertEqual(400, response.status_code)
 
     def test_bilayer_json_to_template_model(self):

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -176,7 +176,7 @@ class TestModelApi(unittest.TestCase):
         # Test against locally made template model
 
     def test_bilayer_json_to_template_model(self):
-        from tests.test_bilayer import sir_bilayer
+        from mira.examples.sir import sir_bilayer
 
         response = self.client.post("/api/bilayer_to_model", json=sir_bilayer)
         self.assertEqual(response.status_code, 200)
@@ -189,7 +189,7 @@ class TestModelApi(unittest.TestCase):
         assert all(t1.is_equal_to(t2) for t1, t2 in zip(sorted1, sorted2))
 
     def test_template_model_to_bilayer_json(self):
-        from tests.test_bilayer import sir_bilayer
+        from mira.examples.sir import sir_bilayer
 
         tm = template_model_from_bilayer(bilayer_json=sir_bilayer)
         bj = BilayerModel(Model(tm)).bilayer

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -178,6 +178,10 @@ class TestModelApi(unittest.TestCase):
         local = template_model_from_sbml_string(xml_string, model_id=model_id).template_model
         self.assertEqual(sorted_json_str(tm.dict()), sorted_json_str(local.dict()))
 
+    def test_biomodels_id_bad_request(self):
+        response = self.client.get(f"/api/biomodel/not_a_model")
+        self.assertEqual(400, response.status_code)
+
     def test_bilayer_json_to_template_model(self):
         from mira.examples.sir import sir_bilayer
 

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -181,3 +181,15 @@ class TestModelApi(unittest.TestCase):
         sorted1 = sorted(tm.templates, key=lambda t: t.get_key())
         sorted2 = sorted(tm2.templates, key=lambda t: t.get_key())
         assert all(t1.is_equal_to(t2) for t1, t2 in zip(sorted1, sorted2))
+
+    def test_template_model_to_bilayer_json(self):
+        from tests.test_bilayer import sir_bilayer
+
+        tm = template_model_from_bilayer(bilayer_json=sir_bilayer)
+        bj = BilayerModel(Model(tm)).bilayer
+
+        response = self.client.post("/api/model_to_bilayer", json=tm.dict())
+        self.assertEqual(response.status_code, 200)
+        bj_res = response.json()
+
+        self.assertEqual(sorted_json_str(bj), sorted_json_str(bj_res))

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -174,6 +174,9 @@ class TestModelApi(unittest.TestCase):
         tm = TemplateModel.from_json(response.json())
 
         # Test against locally made template model
+        xml_string = get_sbml_model(model_id=model_id)
+        local = template_model_from_sbml_string(xml_string, model_id=model_id).template_model
+        self.assertEqual(sorted_json_str(tm.dict()), sorted_json_str(local.dict()))
 
     def test_bilayer_json_to_template_model(self):
         from mira.examples.sir import sir_bilayer

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -27,12 +27,14 @@ def test_templates_equal():
     )
     c1_gnd_ctx = c1_gnd.with_context(location="Stockholm")
     c2_ctx = c2.with_context(location="Stockholm")
-    assert not c1.is_equal_to(c2, with_context=False)
+    # Name equivalence is the fallback when both are ungrounded
+    assert c1.is_equal_to(c2, with_context=False)
     assert c1_gnd.is_equal_to(c1_gnd, with_context=False)
     assert c1_gnd.is_equal_to(c1_gnd_ctx, with_context=False)
     assert not c1_gnd.is_equal_to(c1_gnd_ctx, with_context=True)
     assert not c1.is_equal_to(c2_ctx, with_context=True)
-    assert not c1.is_equal_to(c2_ctx, with_context=False)
+    # Name equivalence is the fallback when both are ungrounded
+    assert c1.is_equal_to(c2_ctx, with_context=False)
 
 
 def test_concepts_equal():

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -40,10 +40,14 @@ def test_concepts_equal():
     c1_w_ctx = c1.with_context(location="Berlin")
     c2 = Concept(name="infected population", identifiers={"ido": "0000511"})
     c2_w_ctx = c2.with_context(location="Stockholm")
+    c3 = Concept(name="infected population", context={"location": "Stockholm"})
+    c4 = Concept(name="infected population", context={"location": "Berlin"})
 
     assert c1.is_equal_to(c2)
     assert not c1_w_ctx.is_equal_to(c2_w_ctx, with_context=True)
     assert c1_w_ctx.is_equal_to(c2_w_ctx, with_context=False)
+    assert c3.is_equal_to(c4, with_context=False)
+    assert not c3.is_equal_to(c4, with_context=True)
 
 
 def test_template_type_inequality_is_equal():


### PR DESCRIPTION
This PR adds four new endpoint to the model api:
- `/biomodel/{model_id}` returns a TemplateModel json from the biomodel identified with the id. If a bad model id is provided, a bad request status is returned
- `/bilayer_to_model` returns a TemplateModel json from the provided bilayer json
- `/model_to_bilayer` does the opposite of the previous one
- `/sbml_xml_to_model` returns a TemplateModel from a SBML XML string

Tests are added for the new endpoints in `test_model_api.py`