### PR TITLE
Template diffs

### DIFF
--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -14,6 +14,7 @@ __all__ = [
     "GroupedControlledConversion",
     "TemplateModel",
     "TemplateModelDelta",
+    "RefinementClosure",
     "get_json_schema",
     "templates_equal",
     "assert_concept_context_refinement",

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -83,13 +83,16 @@ class Concept(BaseModel):
         """Get the priority prefix/identifier pair for this concept."""
         if config is None:
             config = DEFAULT_CONFIG
-        if not self.identifiers:
+        # fixme: Replace this hack to something more sustainable
+        identifiers = {k: v for k, v in self.identifiers.items()
+                       if k != "biomodel.species"}
+        if not identifiers:
             return "", self.name
         for prefix in config.prefix_priority:
-            identifier = self.identifiers.get(prefix)
+            identifier = identifiers.get(prefix)
             if identifier:
                 return prefix, identifier
-        return sorted(self.identifiers.items())[0]
+        return sorted(identifiers.items())[0]
 
     def get_curie_str(self, config: Optional[Config] = None) -> str:
         """Get the priority prefix/identifier as a CURIE string."""
@@ -184,8 +187,14 @@ class Concept(BaseModel):
         ):
             contextual_refinement = True
 
+        # fixme: Replace this hack to something more sustainable
+        self_identifiers = {k: v for k, v in self.identifiers.items()
+                            if k != "biomodel.species"}
+        other_identifiers = {k: v for k, v in other.identifiers.items()
+                             if k != "biomodel.species"}
+
         # Check if this concept is a child term to other?
-        if len(self.identifiers) > 0 and len(other.identifiers) > 0:
+        if len(self_identifiers) > 0 and len(other_identifiers) > 0:
             # Check if other is a parent of this concept
             this_curie = ":".join(self.get_curie())
             other_curie = ":".join(other.get_curie())

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -634,13 +634,13 @@ class TemplateModelDelta:
         source_tag: str,
         target: Template,
         target_tag: str,
-        edge_type: Literal["is_refinement", "is_equal"],
+        edge_type: Literal["refinement_of", "is_equal"],
     ):
         n1_id = self._add_node(source, tag=source_tag)
         n2_id = self._add_node(target, tag=target_tag)
 
-        if edge_type == "is_refinement":
-            # template1 is a refinement of template 2
+        if edge_type == "refinement_of":
+            # source is a refinement of target
             self.comparison_graph.add_edge(n1_id, n2_id, label=edge_type,
                                            color="green", weight=2)
         else:
@@ -698,7 +698,7 @@ class TemplateModelDelta:
                         source_tag=tag1,
                         target=templ2,
                         target_tag=tag2,
-                        edge_type="is_refinement",
+                        edge_type="refinement_of",
                     )
                 elif templ2.refinement_of(
                     templ1, refinement_func=self.refinement_func, with_context=True
@@ -708,7 +708,7 @@ class TemplateModelDelta:
                         source_tag=tag2,
                         target=templ1,
                         target_tag=tag1,
-                        edge_type="is_refinement",
+                        edge_type="refinement_of",
                     )
                 elif templ1.is_equal_to(templ2, with_context=True):
                     self._add_edge(

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -87,15 +87,20 @@ class Concept(BaseModel):
         """Get the priority prefix/identifier pair for this concept."""
         if config is None:
             config = DEFAULT_CONFIG
-        # fixme: Replace this hack to something more sustainable
         identifiers = {k: v for k, v in self.identifiers.items()
-                       if k != "biomodel.species"}
+                       if k not in config.prefix_exclusions}
+
+        # If ungrounded, return empty prefix and name
         if not identifiers:
             return "", self.name
+
+        # If there are identifiers get one from the priority list
         for prefix in config.prefix_priority:
             identifier = identifiers.get(prefix)
             if identifier:
                 return prefix, identifier
+
+        # Fallback to the identifiers outside the priority list
         return sorted(identifiers.items())[0]
 
     def get_curie_str(self, config: Optional[Config] = None) -> str:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -858,16 +858,20 @@ class TemplateModelDelta:
                     node_data["color"] = self.tag2_color
                     self.comparison_graph.add_node(node, **node_data)
 
+        def extend_data(d, color):
+            d["color"] = color
+            return d
+
         self.comparison_graph.add_edges_from(
             ((*u, self.tag1) if u in template_node_ids else u,
              (*v, self.tag1) if v in template_node_ids else v,
-             d)
+             extend_data(d, self.tag1_color))
             for u, v, d in self.templ1_graph.edges(data=True)
         )
         self.comparison_graph.add_edges_from(
             ((*u, self.tag2) if u in template_node_ids else u,
              (*v, self.tag2) if v in template_node_ids else v,
-             d)
+             extend_data(d, self.tag2_color))
             for u, v, d in self.templ2_graph.edges(data=True)
         )
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -600,9 +600,13 @@ class TemplateModelDelta:
             if field_name in ["type", "provenance"]:
                 continue
             field = getattr(template, field_name)
-            if not isinstance(field, Concept):
+            if isinstance(field, Concept):
+                curie = ':'.join(field.get_curie())
+            elif isinstance(field, list) and isinstance(field[0], Concept):
+                curie = '; '.join(':'.join(c.get_curie()) for c in field)
+            else:
                 logger.warning(f"Unhandled field type {type(field)}")
-            curie = ':'.join(field.get_curie())
+                continue  # ?
 
             # Add context like: '| {city: Boston | season: Winter }'
             context_list = []

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -107,6 +107,10 @@ class Concept(BaseModel):
         """Get the priority prefix/identifier as a CURIE string."""
         return ":".join(self.get_curie(config=config))
 
+    def get_included_identifiers(self, config: Optional[Config] = None) -> Dict[str, str]:
+        config = DEFAULT_CONFIG if config is None else config
+        return {k: v for k, v in self.identifiers.items() if k not in config.prefix_exclusions}
+
     def get_key(self, config: Optional[Config] = None):
         return (
             self.get_curie(config=config),

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -583,9 +583,9 @@ class TemplateModelDelta:
     ):
         self.refinement_func = refinement_function
         self.template_model1 = template_model1
-        self.tag1 = tag1,
+        self.tag1 = tag1
         self.template_model2 = template_model2
-        self.tag2 = tag2,
+        self.tag2 = tag2
         self.comparison_graph = DiGraph()
         self.comparison_graph.graph["rankdir"] = "LR"  # transposed node tables
         self._assemble_comparison()

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -703,7 +703,7 @@ class TemplateModelDelta:
             or nx.get_edge_attributes(self.comparison_graph, "weight").values()
         )
         node_labels = nx_kwargs.pop("labels", None) or nx.get_node_attributes(
-            self.comparison_graph, "node_name"
+            self.comparison_graph, "type"
         )
         pos = nx_kwargs.pop("pos", None) or nx.circular_layout(
             self.comparison_graph, scale=nx_kwargs.get("scale", 1)

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -664,11 +664,9 @@ class TemplateModelDelta:
         # 1. Build lookup based on template type
         templates1 = _templates_by_type(self.template_model1.templates)
         templ1_keys = set(templates1.keys())
-        tag1 = "1"
 
         templates2 = _templates_by_type(self.template_model2.templates)
         templ2_keys = set(templates2.keys())
-        tag2 = "2"
 
         # 2. Compare templates:
 
@@ -676,11 +674,11 @@ class TemplateModelDelta:
         # TemplateModel, just add the nodes
         for type1 in templ1_keys.difference(templ2_keys):
             for templ1 in templates1[type1]:
-                self._add_node(templ1, tag=tag1)
+                self._add_node(templ1, tag=self.tag1)
 
         for type2 in templ2_keys.difference(templ1_keys):
             for templ2 in templates2[type2]:
-                self._add_node(templ2, tag=tag2)
+                self._add_node(templ2, tag=self.tag2)
 
         # For the types that exist in both TemplateModels, compare all
         # possible combinations of them
@@ -690,8 +688,8 @@ class TemplateModelDelta:
 
             # Iterate over all combinations for this type
             for templ1, templ2 in product(template_list1, template_list2):
-                self._add_node(templ1, tag=tag1)
-                self._add_node(templ2, tag=tag2)
+                self._add_node(templ1, tag=self.tag1)
+                self._add_node(templ2, tag=self.tag2)
 
                 # Check for refinement and equality
                 if templ1.refinement_of(
@@ -699,9 +697,9 @@ class TemplateModelDelta:
                 ):
                     self._add_edge(
                         source=templ1,
-                        source_tag=tag1,
+                        source_tag=self.tag1,
                         target=templ2,
-                        target_tag=tag2,
+                        target_tag=self.tag2,
                         edge_type="refinement_of",
                     )
                 elif templ2.refinement_of(
@@ -709,17 +707,17 @@ class TemplateModelDelta:
                 ):
                     self._add_edge(
                         source=templ2,
-                        source_tag=tag2,
+                        source_tag=self.tag2,
                         target=templ1,
-                        target_tag=tag1,
+                        target_tag=self.tag1,
                         edge_type="refinement_of",
                     )
                 elif templ1.is_equal_to(templ2, with_context=True):
                     self._add_edge(
                         source=templ1,
-                        source_tag=tag1,
+                        source_tag=self.tag1,
                         target=templ2,
-                        target_tag=tag2,
+                        target_tag=self.tag2,
                         edge_type="is_equal",
                     )
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -268,8 +268,8 @@ class Template(BaseModel):
             this_value = getattr(self, field_name)
 
             # Check refinement for any attribute that is a Concept; this is
-            # strict in the sense that unless every concept of this template is a
-            # refinement of the other, the Template as a whole cannot be
+            # strict in the sense that unless every concept of this template
+            # is a refinement of the other, the Template as a whole cannot be
             # considered a refinement
             if isinstance(this_value, Concept):
                 other_concept = getattr(other, field_name)
@@ -420,6 +420,7 @@ class GroupedControlledConversion(Template):
             "subject": self.subject,
             "outcome": self.outcome
         }
+
 
 class NaturalConversion(Template):
     """Specifies a process of natural conversion from subject to outcome"""

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -583,6 +583,7 @@ class TemplateModelDelta:
         self.template_model1 = template_model1
         self.template_model2 = template_model2
         self.comparison_graph = DiGraph()
+        self.comparison_graph.graph["rankdir"] = "LR"  # transposed node tables
         self._assemble_comparison()
 
     @staticmethod

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -603,6 +603,8 @@ class TemplateModelDelta:
             field = getattr(template, field_name)
             if isinstance(field, Concept):
                 curie = ":".join(field.get_curie())
+                if "biomodel.species:biomd" in curie.lower():
+                    curie = "-"
 
                 context_list = []
                 if field.context:
@@ -619,6 +621,8 @@ class TemplateModelDelta:
                 inner_cc_list = []
                 for sub_concept in field:
                     curie = ":".join(sub_concept.get_curie())
+                    if "biomodel.species:biomd" in curie.lower():
+                        curie = "-"
 
                     # NOTE: Skip context for now (doesn't fit)
                     # context_list = []

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -701,7 +701,7 @@ class TemplateModel(BaseModel):
             for role, concepts in template.get_concepts_by_role().items():
                 for concept in concepts if isinstance(concepts, list) else [concepts]:
                     concept_key = get_concept_graph_key(concept)
-                    if len([k for k in concept.identifiers if k != "biomodel.species"]):
+                    if len(concept.get_included_identifiers()):
                         label = concept.name
                     else:
                         label = f"{concept.name}\n(ungrounded)"
@@ -970,9 +970,10 @@ class TemplateModelDelta:
 
 
 def get_concept_graph_key(concept: Concept):
-    grounding_key = sorted(("identity", f"{k}:{v}")
-                           for k, v in concept.identifiers.items()
-                           if k != "biomodel.species")
+    grounding_key = sorted(
+        ("identity", f"{k}:{v}")
+        for k, v in concept.get_included_identifiers().items()
+    )
     context_key = sorted(concept.context.items())
     key = [concept.name] + grounding_key + context_key
     key = tuple(key) if len(key) > 1 else (key[0],)

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -702,15 +702,19 @@ class TemplateModelDelta:
             nx_kwargs.pop("width", None)
             or nx.get_edge_attributes(self.comparison_graph, "weight").values()
         )
-        with_labels = nx_kwargs.pop("with_labels", True)
-        pos = nx_kwargs.pop("pos", None) or nx.planar_layout(self.comparison_graph)
+        node_labels = nx_kwargs.pop("labels", None) or nx.get_node_attributes(
+            self.comparison_graph, "node_name"
+        )
+        pos = nx_kwargs.pop("pos", None) or nx.planar_layout(
+            self.comparison_graph, scale=nx_kwargs.get("scale", 1)
+        )
         nx.draw(
             G=self.comparison_graph,
             pos=pos,
             node_color=node_color,
             edge_color=edge_color,
             width=list(width),
-            with_labels=with_labels,
+            labels=node_labels,
             **nx_kwargs,
         )
         edge_labels = {

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -623,7 +623,7 @@ class TemplateModelDelta:
             type=template.type,
             template_key=template.get_key(),
             label=self._get_node_label(template, tag),
-            color="yellow" if tag == "1" else "pink",
+            color="orange" if tag == "1" else "pink",
             shape="record",
         )
         return node_id

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -274,7 +274,9 @@ class Template(BaseModel):
             if isinstance(this_value, Concept):
                 other_concept = getattr(other, field_name)
                 if not this_value.refinement_of(
-                    other_concept, refinement_func=refinement_func, with_context=with_context
+                    other_concept,
+                    refinement_func=refinement_func,
+                    with_context=with_context
                 ):
                     return False
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -578,10 +578,14 @@ class TemplateModelDelta:
         template_model1: TemplateModel,
         template_model2: TemplateModel,
         refinement_function: Callable[[str, str], bool],
+        tag1: str = "1",
+        tag2: str = "2"
     ):
         self.refinement_func = refinement_function
         self.template_model1 = template_model1
+        self.tag1 = tag1,
         self.template_model2 = template_model2
+        self.tag2 = tag2,
         self.comparison_graph = DiGraph()
         self.comparison_graph.graph["rankdir"] = "LR"  # transposed node tables
         self._assemble_comparison()

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -198,7 +198,8 @@ class Concept(BaseModel):
             ontological_refinement = False
 
         if with_context:
-            return ontological_refinement or contextual_refinement
+            return ontological_refinement or \
+                   self.is_equal_to(other) and contextual_refinement
         return ontological_refinement
 
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -724,14 +724,20 @@ class TemplateModelDelta:
         refinement_function: Callable[[str, str], bool],
         tag1: str = "1",
         tag2: str = "2",
+        tag1_color: str = "orange",
+        tag2_color: str = "blue",
+        merge_color: str = "red",
     ):
         self.refinement_func = refinement_function
         self.template_model1 = template_model1
         self.templ1_graph = template_model1.generate_model_graph()
         self.tag1 = tag1
+        self.tag1_color = tag1_color
         self.template_model2 = template_model2
         self.templ2_graph = template_model2.generate_model_graph()
         self.tag2 = tag2
+        self.tag2_color = tag2_color
+        self.merge_color = merge_color
         self.comparison_graph = DiGraph()
         self.comparison_graph.graph["rankdir"] = "LR"  # transposed node tables
         self._assemble_comparison()
@@ -744,7 +750,7 @@ class TemplateModelDelta:
             type=template.type,
             template_key=template.get_key(),
             label=template.type,
-            color="orange" if tag == self.tag1 else "blue",
+            color=self.tag1_color if tag == self.tag1 else self.tag2_color,
             shape="record",
         )
         return node_id
@@ -785,6 +791,7 @@ class TemplateModelDelta:
             else:
                 # Assumed to be a Concept node
                 node_id = node
+            node_data["color"] = self.tag1_color
             nodes_to_add.append((node_id, {"tags": {self.tag1}, **node_data}))
 
         self.comparison_graph.add_nodes_from(nodes_to_add)
@@ -798,17 +805,17 @@ class TemplateModelDelta:
                 node_id = (*node, self.tag2)
                 template_node_ids.add(node)
                 node_data["tags"] = {self.tag2}
-                node_data["color"] = "blue"
+                node_data["color"] = self.tag2_color
                 self.comparison_graph.add_node(node_id, **node_data)
             else:
                 if node in self.comparison_graph.nodes:
                     # If node already exists, add to tags and update color
                     self.comparison_graph.nodes[node]["tags"].add(self.tag2)
-                    self.comparison_graph.nodes[node]["color"] = "red"
+                    self.comparison_graph.nodes[node]["color"] = self.merge_color
                 else:
                     # If node doesn't exist, add it
                     node_data["tags"] = {self.tag2}
-                    node_data["color"] = "blue"
+                    node_data["color"] = self.tag2_color
                     self.comparison_graph.add_node(node, **node_data)
 
         self.comparison_graph.add_edges_from(

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -661,6 +661,7 @@ class TemplateModelDelta:
         self.tag2 = tag2
         self.comparison_graph = DiGraph()
         self.comparison_graph.graph["rankdir"] = "LR"  # transposed node tables
+        self.shared_concept_nodes = defaultdict(set)
         self._assemble_comparison()
 
     @staticmethod
@@ -728,10 +729,17 @@ class TemplateModelDelta:
             for concept in concepts \
                     if isinstance(concepts, list) else [concepts]:
                 concept_key = self.get_concept_key(concept)
+                self.shared_concept_nodes[concept_key].add(tag)
+                if len(self.shared_concept_nodes[concept_key]) == 2:
+                    node_color = "red"
+                elif tag == self.tag1:
+                    node_color = "orange"
+                else:
+                    node_color = "blue"
                 self.comparison_graph.add_node(
                     concept_key,
                     label=concept.name,
-                    color="orange" if tag == self.tag1 else "blue"
+                    color=node_color
                 )
                 role_label = "controller" if role == "controllers" \
                     else role

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -606,11 +606,11 @@ class TemplateModelDelta:
 
         if edge_type == "is_refinement":
             # template1 is a refinement of template 2
-            self.comparison_graph.add_edge(n1, n2, type=edge_type, color="g", weight=2)
+            self.comparison_graph.add_edge(n1, n2, type=edge_type, color="green", weight=2)
         else:
             # is_equal: add edges both ways
-            self.comparison_graph.add_edge(n1, n2, type=edge_type, color="b", weight=2)
-            self.comparison_graph.add_edge(n2, n1, type=edge_type, color="b", weight=2)
+            self.comparison_graph.add_edge(n1, n2, type=edge_type, color="blue", weight=2)
+            self.comparison_graph.add_edge(n2, n1, type=edge_type, color="blue", weight=2)
 
     def _assemble_comparison(self):
         def _templates_by_type(templates: List[Template]) -> Mapping[str, List[Template]]:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -969,12 +969,9 @@ class TemplateModelDelta:
 
 
 def get_concept_graph_key(concept: Concept):
-    grounding_key = sorted(
-        ("identity", f"{k}:{v}")
-        for k, v in concept.get_included_identifiers().items()
-    )
+    grounding_key = ("identity", concept.get_curie_str())
     context_key = sorted(concept.context.items())
-    key = [concept.name] + grounding_key + context_key
+    key = [concept.name] + [grounding_key] + context_key
     key = tuple(key) if len(key) > 1 else (key[0],)
     return key
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -678,9 +678,13 @@ class TemplateModel(BaseModel):
             for role, concepts in template.get_concepts_by_role().items():
                 for concept in concepts if isinstance(concepts, list) else [concepts]:
                     concept_key = get_concept_graph_key(concept)
+                    if len([k for k in concept.identifiers if k != "biomodel.species"]):
+                        label = concept.name
+                    else:
+                        label = f"{concept.name}\n(ungrounded)"
                     graph.add_node(
                         concept_key,
-                        label=concept.name,
+                        label=label,
                         color="orange"
                     )
                     role_label = "controller" if role == "controllers" \

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -200,17 +200,13 @@ class Concept(BaseModel):
         ):
             contextual_refinement = True
 
-        # fixme: Replace this hack to something more sustainable
-        self_identifiers = {k: v for k, v in self.identifiers.items()
-                            if k != "biomodel.species"}
-        other_identifiers = {k: v for k, v in other.identifiers.items()
-                             if k != "biomodel.species"}
-
         # Check if this concept is a child term to other?
-        if len(self_identifiers) > 0 and len(other_identifiers) > 0:
+        this_prefix, this_id = self.get_curie()
+        other_prefix, other_id = other.get_curie()
+        if this_prefix and other_prefix:
             # Check if other is a parent of this concept
-            this_curie = ":".join(self.get_curie())
-            other_curie = ":".join(other.get_curie())
+            this_curie = f"{this_prefix}:{this_id}"
+            other_curie = f"{other_prefix}:{other_id}"
             ontological_refinement = refinement_func(this_curie, other_curie)
 
         # Any of them are ungrounded -> cannot know if there is a refinement

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -636,16 +636,19 @@ class TemplateModelDelta:
         target_tag: str,
         edge_type: Literal["is_refinement", "is_equal"],
     ):
-        n1 = self._add_node(source, tag=source_tag)
-        n2 = self._add_node(target, tag=target_tag)
+        n1_id = self._add_node(source, tag=source_tag)
+        n2_id = self._add_node(target, tag=target_tag)
 
         if edge_type == "is_refinement":
             # template1 is a refinement of template 2
-            self.comparison_graph.add_edge(n1, n2, type=edge_type, color="green", weight=2)
+            self.comparison_graph.add_edge(n1_id, n2_id, label=edge_type,
+                                           color="green", weight=2)
         else:
             # is_equal: add edges both ways
-            self.comparison_graph.add_edge(n1, n2, type=edge_type, color="blue", weight=2)
-            self.comparison_graph.add_edge(n2, n1, type=edge_type, color="blue", weight=2)
+            self.comparison_graph.add_edge(n1_id, n2_id, label=edge_type,
+                                           color="blue", weight=2)
+            self.comparison_graph.add_edge(n2_id, n1_id, label=edge_type,
+                                           color="blue", weight=2)
 
     def _assemble_comparison(self):
         def _templates_by_type(templates: List[Template]) -> Mapping[str, List[Template]]:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -705,7 +705,7 @@ class TemplateModelDelta:
         node_labels = nx_kwargs.pop("labels", None) or nx.get_node_attributes(
             self.comparison_graph, "node_name"
         )
-        pos = nx_kwargs.pop("pos", None) or nx.planar_layout(
+        pos = nx_kwargs.pop("pos", None) or nx.circular_layout(
             self.comparison_graph, scale=nx_kwargs.get("scale", 1)
         )
         nx.draw(

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -589,7 +589,10 @@ class TemplateModelDelta:
         node_id = (*template.get_key(), tag)
         node_name = f"{template.type} {tag}"
         self.comparison_graph.add_node(
-            node_id, type=template.type, node_name=node_name, color="yellow" if tag == "1" else "pink"
+            node_id,
+            type=template.type,
+            node_name=node_name,
+            color="yellow" if tag == "1" else "pink",
         )
         return node_id
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -681,49 +681,26 @@ class TemplateModelDelta:
                         edge_type="is_equal",
                     )
 
-    def draw_graph(self, **nx_kwargs):
-        """Draw a graph of the differences using nx.draw
+    def draw_graph(
+        self, path: str, prog: str = "dot", args: str = "", format: Optional[str] = None
+    ):
+        """Draw a pygraphviz graph of the differences using
 
         Parameters
         ----------
-        nx_kwargs :
-            Any key word arguments to provide to nx.draw
+        path :
+            The path to the output file
+        prog :
+            The graphviz layout program to use, such as "dot", "neato", etc.
+        format :
+            Set the file format explicitly
+        args :
+            Additional arguments to pass to the graphviz bash program as a
+            string. Example: "args="-Nshape=box -Edir=forward -Ecolor=red "
         """
         # draw graph
-        node_color = (
-            nx_kwargs.pop("node_color", None)
-            or nx.get_node_attributes(self.comparison_graph, "color").values()
-        )
-        edge_color = (
-            nx_kwargs.pop("edge_color", None)
-            or nx.get_edge_attributes(self.comparison_graph, "color").values()
-        )
-        width = (
-            nx_kwargs.pop("width", None)
-            or nx.get_edge_attributes(self.comparison_graph, "weight").values()
-        )
-        node_labels = nx_kwargs.pop("labels", None) or nx.get_node_attributes(
-            self.comparison_graph, "type"
-        )
-        pos = nx_kwargs.pop("pos", None) or nx.circular_layout(
-            self.comparison_graph, scale=nx_kwargs.get("scale", 1)
-        )
-        nx.draw(
-            G=self.comparison_graph,
-            pos=pos,
-            node_color=node_color,
-            edge_color=edge_color,
-            width=list(width),
-            labels=node_labels,
-            **nx_kwargs,
-        )
-        edge_labels = {
-            (u, v): data["type"]
-            for u, v, data in self.comparison_graph.edges(data=True)
-        }
-        nx.draw_networkx_edge_labels(
-            self.comparison_graph, pos=pos, edge_labels=edge_labels
-        )
+        agraph = nx.nx_agraph.to_agraph(self.comparison_graph)
+        agraph.draw(path, format=format, prog=prog, args=args)
 
     def graph_as_json(self) -> Dict:
         """Return the comparison graph json serializable node-link data"""

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -555,8 +555,25 @@ def templates_equal(templ: Template, other_templ: Template, with_context: bool) 
                 return False
 
         elif isinstance(value, list):
-            if not all(i1 == i2 for i1, i2 in zip(value, other_dict[key])):
+            # Assert that we have the same number of things in the list
+            if len(value) != len(other_dict[key]):
                 return False
+
+            elif len(value):
+                # Assumed to be same length
+                if isinstance(value[0], Concept):
+                    for this_conc, other_conc in zip(value, other_dict[key]):
+                        if not this_conc.is_equal_to(
+                                other_conc, with_context=with_context
+                        ):
+                            return False
+                else:
+                    raise NotImplementedError(
+                        f"No comparison implemented for type "
+                        f"List[{type(value[0])}] of Template"
+                    )
+            # Empty list
+
         else:
             raise NotImplementedError(
                 f"No comparison implemented for type {type(value)} for Template"

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -589,7 +589,7 @@ class TemplateModelDelta:
         node_id = (*template.get_key(), tag)
         node_name = f"{template.type} {tag}"
         self.comparison_graph.add_node(
-            node_id, node_name=node_name, color="yellow" if tag == "1" else "pink"
+            node_id, type=template.type, node_name=node_name, color="yellow" if tag == "1" else "pink"
         )
         return node_id
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -700,10 +700,17 @@ class TemplateModel(BaseModel):
             for role, concepts in template.get_concepts_by_role().items():
                 for concept in concepts if isinstance(concepts, list) else [concepts]:
                     concept_key = get_concept_graph_key(concept)
+                    context_str = "\n".join(
+                        f"{k}-{v}" for k, v in concept.context.items()
+                    )
+                    context_str = "\n" + context_str if context_str else ""
                     if len(concept.get_included_identifiers()):
-                        label = f"{concept.name}\n({concept.get_curie_str()})"
+                        label = (
+                            f"{concept.name}\n({concept.get_curie_str()})"
+                            f"{context_str}"
+                        )
                     else:
-                        label = f"{concept.name}\n(ungrounded)"
+                        label = f"{concept.name}\n(ungrounded){context_str}"
                     graph.add_node(
                         concept_key,
                         label=label,

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -658,7 +658,7 @@ class TemplateModelDelta:
             type=template.type,
             template_key=template.get_key(),
             label=self._get_node_label(template, tag),
-            color="orange" if tag == "1" else "pink",
+            color="orange" if tag == self.tag1 else "pink",
             shape="record",
         )
         return node_id

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -698,7 +698,7 @@ class TemplateModel(BaseModel):
                 for concept in concepts if isinstance(concepts, list) else [concepts]:
                     concept_key = get_concept_graph_key(concept)
                     if len(concept.get_included_identifiers()):
-                        label = concept.name
+                        label = f"{concept.name}\n({concept.get_curie_str()})"
                     else:
                         label = f"{concept.name}\n(ungrounded)"
                     graph.add_node(

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -217,7 +217,7 @@ class Concept(BaseModel):
 
         if with_context:
             return ontological_refinement or \
-                   self.is_equal_to(other) and contextual_refinement
+                   self.is_equal_to(other, with_context=False) and contextual_refinement
         return ontological_refinement
 
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -647,7 +647,7 @@ class TemplateModelDelta:
             if isinstance(field, Concept):
                 curie = ":".join(field.get_curie())
                 if "biomodel.species:biomd" in curie.lower():
-                    curie = "-"
+                    curie = None
 
                 context_list = []
                 if field.context:
@@ -656,8 +656,9 @@ class TemplateModelDelta:
 
                 # Add context like: '| {city: Boston | season: Winter }'
                 context = f" | {{{' | '.join(context_list)}}}" if context_list else ""
+                curie_str = f"({curie})" if curie else ""
                 cc_list.append(
-                    f"{{{field_name} | {field.name} ({curie}){context}}}"
+                    f"{{{field_name} | {field.name} {curie_str}{context}}}"
                 )
 
             elif isinstance(field, list) and isinstance(field[0], Concept):
@@ -665,7 +666,7 @@ class TemplateModelDelta:
                 for sub_concept in field:
                     curie = ":".join(sub_concept.get_curie())
                     if "biomodel.species:biomd" in curie.lower():
-                        curie = "-"
+                        curie = None
 
                     # NOTE: Skip context for now (doesn't fit)
                     # context_list = []
@@ -675,8 +676,9 @@ class TemplateModelDelta:
 
                     # Add context like: '| {city: Boston | season: Winter }'
                     # context = f" | {{{' | '.join(context_list)}}}" if context_list else ""
+                    curie_str = f"({curie})" if curie else ""
                     inner_cc_list.append(
-                        f"{sub_concept.name} ({curie})"
+                        f"{sub_concept.name} {curie_str}"
                     )
                 inner_str = ", ".join(inner_cc_list)
                 cc_list.append(

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -49,11 +49,15 @@ class Config(BaseModel):
     """Config determining how keys are generated"""
 
     prefix_priority: List[str]
+    prefix_exclusions: List[str]
 
 
 DEFAULT_CONFIG = Config(
     prefix_priority=[
         "ido",
+    ],
+    prefix_exclusions=[
+        "biomodels.species"
     ],
 )
 

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -51,9 +51,10 @@ class Model:
         self.make_model()
 
     def assemble_variable(self, concept):
-        grounding_key = sorted(("identity", f"{k}:{v}")
-                               for k, v in concept.identifiers.items()
-                               if k != "biomodel.species")
+        grounding_key = sorted(
+            ("identity", f"{k}:{v}")
+            for k, v in concept.get_included_identifiers().items()
+        )
         context_key = sorted(concept.context.items())
         key = [concept.name] + grounding_key + context_key
         key = tuple(key) if len(key) > 1 else key[0]

--- a/mira/sources/sbml.py
+++ b/mira/sources/sbml.py
@@ -303,7 +303,7 @@ def _extract_concepts(sbml_model, *, model_id: Optional[str] = None) -> Mapping[
             for element in annotation_tree.findall(IDENTIFIERS_XPATH, namespaces=PREFIX_MAP)
         )
         if model_id:
-            identifiers["biomodel.species"] = f"{model_id}:{species_id}"
+            identifiers["biomodels.species"] = f"{model_id}:{species_id}"
         concepts[species_id] = Concept(
             name=species_name or species_id,
             identifiers=identifiers,

--- a/scripts/biomodels_comparison.py
+++ b/scripts/biomodels_comparison.py
@@ -4,7 +4,7 @@ from running
 ``python -m mira.sources.biomodels``
 """
 import pickle
-from itertools import permutations
+from itertools import combinations
 from pathlib import Path
 from typing import List, Tuple, Optional, Set
 from tqdm import tqdm
@@ -48,7 +48,7 @@ def compare_models(
     refinement_closure = RefinementClosure(transitive_closure)
 
     comparisons = []
-    model_pairs = list(permutations(models, 2))
+    model_pairs = list(combinations(models, 2))
     for (id1, tm1), (id2, tm2) in tqdm(model_pairs,
                                        desc="Generating Template Deltas"):
         tmd = TemplateModelDelta(

--- a/scripts/biomodels_comparison.py
+++ b/scripts/biomodels_comparison.py
@@ -100,7 +100,7 @@ def main():
     graph_dir.mkdir(parents=True, exist_ok=True)
     compared_models = compare_models(models, graph_dir=graph_dir.as_posix(), transitive_closure=tc)
 
-    # Pickle the files
+    # Pickle the list of TemplateModelDelta objects with the model ids
     with output_folder.joinpath("model_diffs.pkl").open("wb") as fo:
         pickle.dump(obj=compared_models, file=fo)
 

--- a/scripts/biomodels_comparison.py
+++ b/scripts/biomodels_comparison.py
@@ -1,0 +1,86 @@
+"""Script to generate all pairwise comparisons of the BioModels generated
+from running
+
+``python -m mira.sources.biomodels``
+"""
+import pickle
+from itertools import permutations
+from pathlib import Path
+from typing import List, Tuple
+
+from tqdm import tqdm
+from mira.dkg.web_client import is_ontological_child
+from mira.sources.biomodels import BIOMODELS
+from mira.metamodel import model_from_json_file
+from mira.metamodel.templates import TemplateModelDelta, TemplateModel
+
+
+def compare_models(
+    models: List[Tuple[str, TemplateModel]],
+    graph_dir: str,
+) -> List[Tuple[str, str, TemplateModelDelta]]:
+    """Run pairwise comparisons of models
+
+    Parameters
+    ----------
+    models :
+        A list of tuples of model id/name and model as a TemplateModel
+    graph_dir :
+        A path to a directory
+
+    Returns
+    -------
+    :
+        A list of tuples of model id/name of model1, model id/name of model2
+        and the TemplateModelDelta for the two models.
+    """
+    comparisons = []
+    for (id1, tm1), (id2, tm2) in tqdm(permutations(models, 2), desc="Generating Template Deltas"):
+        tmd = TemplateModelDelta(template_model1=tm1, tag1=id1,
+                                 template_model2=tm2, tag2=id2,
+                                 refinement_function=is_ontological_child)
+        outpath = Path(graph_dir).joinpath(f"delta_{id1}_{id2}.png").as_posix()
+        tmd.draw_graph(path=outpath)
+        comparisons.append((id1, id2, tmd))
+
+    return comparisons
+
+
+def main():
+    # Setup
+    base_folder = BIOMODELS.module("models").base
+    output_folder = BIOMODELS.module("model_diffs").base
+
+    # Load model jsons
+    models = []
+    for path in base_folder.glob("*/*.json"):
+        # Check if file exsits
+        if not path.is_file():
+            print(f"No such file {path}")
+            continue
+
+        # Load model
+        template_model = model_from_json_file(path.as_posix())
+        model_id = path.name.split(".")[0]
+        models.append((model_id, template_model))
+
+    if len(models) <= 1:
+        print(
+            "2 or more models need to be loaded to compare them. Was "
+            "`python -m mira.sources.biomodels` run before this script?"
+        )
+        return
+
+    compared_models = compare_models(
+        models, graph_dir=output_folder.joinpath("graphs").as_posix()
+    )
+
+    # Pickle the files
+    with output_folder.joinpath("model_diffs.pkl").open("wb") as fo:
+        pickle.dump(obj=compared_models, file=fo)
+
+    print(f"Wrote models and graphs to {output_folder}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/biomodels_comparison.py
+++ b/scripts/biomodels_comparison.py
@@ -35,7 +35,8 @@ def compare_models(
         and the TemplateModelDelta for the two models.
     """
     comparisons = []
-    for (id1, tm1), (id2, tm2) in tqdm(permutations(models, 2), desc="Generating Template Deltas"):
+    model_pairs = list(permutations(models, 2))
+    for (id1, tm1), (id2, tm2) in tqdm(model_pairs, desc="Generating Template Deltas"):
         tmd = TemplateModelDelta(template_model1=tm1, tag1=id1,
                                  template_model2=tm2, tag2=id2,
                                  refinement_function=is_ontological_child)
@@ -71,9 +72,9 @@ def main():
         )
         return
 
-    compared_models = compare_models(
-        models, graph_dir=output_folder.joinpath("graphs").as_posix()
-    )
+    graph_dir = output_folder.joinpath("graphs")
+    graph_dir.mkdir(parents=True, exist_ok=True)
+    compared_models = compare_models(models, graph_dir=graph_dir.as_posix())
 
     # Pickle the files
     with output_folder.joinpath("model_diffs.pkl").open("wb") as fo:

--- a/scripts/biomodels_comparison.py
+++ b/scripts/biomodels_comparison.py
@@ -1,7 +1,7 @@
 """Script to generate all pairwise comparisons of the BioModels generated
 from running
 
-``python -m mira.sources.biomodels``
+``python -m mira.sources.biomodels path/to/transitive_closure_pickle.pkl``
 """
 import pickle
 from itertools import combinations
@@ -70,6 +70,8 @@ def compare_models(
 
 def cache_model_index(recreate: bool = False) -> Dict[str, TemplateModel]:
     if recreate or not MODEL_CACHE.is_file():
+        print("Creating model cache")
+
         # Load model jsons
         models = {}
         for path in BASE_FOLDER.glob("*/*.json"):
@@ -91,7 +93,7 @@ def cache_model_index(recreate: bool = False) -> Dict[str, TemplateModel]:
 
 def main():
     # Setup
-    model_lookup = cache_model_index()
+    model_lookup = cache_model_index(recreate=recreate_cache)
     models = [(model_id, model) for model_id, model in model_lookup.items()]
     output_folder = BIOMODELS.module("model_diffs").base
 
@@ -120,10 +122,17 @@ def main():
 
 
 if __name__ == "__main__":
-    import sys
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--transitive-closure-pickle", "-tc",
+                        help="Path to transitive closure pickle file")
+    parser.add_argument("--recreate", "-r", action="store_true",
+                        help="Force recreation of model cache")
+    args = parser.parse_args()
 
     # Get path to pickled transitive closure
-    tc_pickle_path = sys.argv[1] if len(sys.argv) > 1 else None
+    tc_pickle_path = args.transitive_closure_pickle
     if tc_pickle_path:
         print(f"Loading transitive closure from {tc_pickle_path}")
+    recreate_cache = args.recreate
     main()

--- a/scripts/biomodels_comparison.py
+++ b/scripts/biomodels_comparison.py
@@ -85,6 +85,8 @@ def cache_model_index(recreate: bool = False) -> Dict[str, TemplateModel]:
             template_model = model_from_json_file(path.as_posix())
             model_id = path.name.split(".")[0]
             models[model_id] = template_model
+        with MODEL_CACHE.open("wb") as wp:
+            pickle.dump(obj=models, file=wp)
     else:
         models = pickle.load(MODEL_CACHE.open("rb"))
 

--- a/scripts/generate_biomodels_groundings.py
+++ b/scripts/generate_biomodels_groundings.py
@@ -27,6 +27,8 @@ if __name__ == '__main__':
             model = model_from_json_file(model_file)
         except Exception as e:
             print('Could not process MIRA Template model from %s' % model_file)
+            continue
+
         for template in model.templates:
             concepts = template.get_concepts()
             for concept in concepts:

--- a/scripts/generate_biomodels_groundings.py
+++ b/scripts/generate_biomodels_groundings.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
             concepts = template.get_concepts()
             for concept in concepts:
                 for k, v in concept.identifiers.items():
-                    if k == 'biomodel.species':
+                    if k == 'biomodels.species':
                         continue
                     if not bioregistry.is_valid_identifier(k, v):
                         print(f'Invalid identifier in '

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,4 +1,5 @@
 from mira.metamodel import ControlledConversion, Concept, NaturalConversion
+from mira.metamodel.templates import Config
 from mira.dkg.web_client import is_ontological_child
 
 # Provide to tests that are not meant to test ontological refinements;
@@ -205,3 +206,38 @@ def test_provide_refinement_func():
         return False
 
     assert two_dim_region_gnd.refinement_of(spatial_region_gnd, refinement_func=refiner_func)
+
+
+def test_get_curie_default():
+    infected = Concept(
+        name="Infected",
+        identifiers={
+            "ido": "0000511",
+            "ncit": "C171133",
+            "biomodels.species": "BIOMD0000000970:Infected",
+        },
+    )
+    assert infected.get_curie() == ("ido", "0000511")
+
+    infected_biomodels = Concept(
+        name="Infected",
+        identifiers={
+            "biomodels.species": "BIOMD0000000970:Infected",
+        },
+    )
+    assert infected_biomodels.get_curie() == ("", "Infected")
+
+
+def test_get_curie_custom():
+    infected = Concept(
+        name="Infected",
+        identifiers={
+            "ido": "0000511",
+            "ncit": "C171133",
+            "biomodels.species": "BIOMD0000000970:Infected",
+        },
+    )
+
+    custom_config = Config(prefix_priority=["ncit"],
+                           prefix_exclusions=["biomodels.species", "ido"])
+    assert infected.get_curie(config=custom_config) == ("ncit", "C171133")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -120,6 +120,7 @@ def test_concept_refinement_grounding():
     one_dim_spat_gnd = Concept(
         name="one-dimensional spatial region", identifiers={"bfo": "0000026"}
     )
+    one_dim_spat_gnd_ctx = one_dim_spat_gnd.with_context(location="Stockholm")
     # test grounded
     assert one_dim_spat_gnd.refinement_of(
         spatial_region_gnd, refinement_func=is_ontological_child, with_context=False
@@ -133,16 +134,22 @@ def test_concept_refinement_grounding():
     assert not one_dim_spat_gnd.refinement_of(
         spatial_region, refinement_func=is_ontological_child, with_context=True
     )
+    assert one_dim_spat_gnd_ctx.refinement_of(
+        one_dim_spat_gnd, refinement_func=is_ontological_child, with_context=True
+    )
 
     # test ungrounded
     assert not spatial_region.refinement_of(
         one_dim_spat, refinement_func=is_ontological_child, with_context=False
     )
     spatial_region_ctx = spatial_region.with_context(location="Stockholm")
-    assert spatial_region_ctx.refinement_of(
+    # This one would be True if we consider names when ungrounded. Currently
+    # ungrounded are not considered equal by definition.
+    assert not spatial_region_ctx.refinement_of(
         spatial_region, refinement_func=is_ontological_child, with_context=True
     )
-    assert spatial_region_ctx.refinement_of(
+    #
+    assert not spatial_region_ctx.refinement_of(
         spatial_region_gnd, refinement_func=is_ontological_child, with_context=True
     )
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -143,12 +143,9 @@ def test_concept_refinement_grounding():
         one_dim_spat, refinement_func=is_ontological_child, with_context=False
     )
     spatial_region_ctx = spatial_region.with_context(location="Stockholm")
-    # This one would be True if we consider names when ungrounded. Currently
-    # ungrounded are not considered equal by definition.
     assert not spatial_region_ctx.refinement_of(
         spatial_region, refinement_func=is_ontological_child, with_context=True
     )
-    #
     assert not spatial_region_ctx.refinement_of(
         spatial_region_gnd, refinement_func=is_ontological_child, with_context=True
     )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -143,7 +143,7 @@ def test_concept_refinement_grounding():
         one_dim_spat, refinement_func=is_ontological_child, with_context=False
     )
     spatial_region_ctx = spatial_region.with_context(location="Stockholm")
-    assert not spatial_region_ctx.refinement_of(
+    assert spatial_region_ctx.refinement_of(
         spatial_region, refinement_func=is_ontological_child, with_context=True
     )
     assert not spatial_region_ctx.refinement_of(


### PR DESCRIPTION
This PR add the class `TemplateModelDelta` that serves to compare two `TemplateModel` objects and compare their graphical structure. This allows for determination of if e.g. two Concept objects are equal or refinements of each other.

Important updates in this PR, in no particular order:
- A prefix exclusion list is added to the key Config in order to allow to filter out certain prefixes
- `Concept.get_curie()` is updated to not yield a prefix, id pair where the prefix is in the prefix exclusion list
- Handle lists of concepts from `GroupedControlledConversion` in relation checks
- The `TemplateModel` can generate a graph that can be used to visualize it or for comparison with other template models, which is used in the `TemplateModelDelta` class
- A script that compares all Biomodels Models with each other is added
- Add tests for `Concept.get_curie`
- Add tests for `TemplateModelDelta`

**NOTE:** if inspecting the comparison between all biomodels models, remember to re-run `mira.sources.biomodels` to get the correct prefix - biomodel***s***.species instead of biomodel.species - for some of the extracted Concepts