### PR TITLE
TransactionError fix

### DIFF
--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -180,23 +180,29 @@ class Neo4jClient:
             return curie
         return name.lower().replace(" ", "_")
 
-    @property
-    def session(self) -> neo4j.Session:
-        if self._session is None:
-            sess = self.driver.session()
-            self._session = sess
-        return self._session
-
     def query_tx(self, query: str) -> Optional[TxResult]:
-        tx = self.session.begin_transaction()
-        try:
-            res = tx.run(query)
-        except Exception as e:
-            logger.error(e)
-            tx.close()
-            return None
-        values = res.values()
-        tx.close()
+        # See the Session Construction section and the Session section
+        # immediately following it at:
+        # https://neo4j.com/docs/api/python-driver/current/api.html#session-construction
+        #
+        #     Session creation is a lightweight operation and sessions are
+        #     not thread safe. Therefore a session should generally be
+        #     short-lived, and not span multiple threads.
+        #
+        # To avoid a new query potentially interfering with queries already
+        # in progress (or if a query has stalled or not closed properly for
+        # som reason), each transaction should be performed within its own
+
+        with self.driver.session() as session:
+
+            # As stated here, using a context manager allows for the
+            # transaction to be rolled back when an exception is raised
+            # https://neo4j.com/docs/api/python-driver/current/api.html#explicit-transactions
+
+            with session.begin_transaction() as tx:
+                res = tx.run(query)
+                values = res.values()
+
         return values
 
     def query_nodes(self, query: str) -> List[Node]:

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -169,6 +169,11 @@ class Neo4jClient:
         )
         self._session = None
 
+    def __del__(self):
+        # Safely shut down the driver as a Neo4jClient object is garbage collected
+        # https://neo4j.com/docs/api/python-driver/current/api.html#driver-object-lifetime
+        self.driver.close()
+
     @lru_cache(maxsize=100)
     def _get_relation_label(self, curie: str) -> str:
         """"""


### PR DESCRIPTION
This PR aims to solve a `TransactionError` raised by the Neo4j Driver. As I understand the issue, the Error is raised when different threads for requests from different clients to the web service come in and the Neo4jClient is trying to run transactions in the same session at the same time (transactions have to be run sequentially within the same session).

In this PR I have restructured `query_tx` so each transaction is run within a new session for each request, meaning different threads running transactions will have their own sessions.

A call to `Driver.close()` is added as well to `Neo4jClient.__del__`, so that the driver is properly closed when a `Neo4jClient` object is garbage collected.

This PR could fix half of #57.