### PR TITLE
Add additional properties to ASKEMO / the DKG

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -7,7 +7,7 @@ from neo4j.graph import Relationship
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
-from mira.dkg.client import Entity
+from mira.dkg.client import Entity, AskemEntity
 
 __all__ = [
     "api_blueprint",
@@ -56,7 +56,13 @@ class RelationQuery(BaseModel):
 
 
 @api_blueprint.get(
-    "/entity/{curie}", response_model=Entity, response_model_exclude_unset=True, tags=["entities"]
+    "/entity/{curie}",
+    # Note the order is important here - is greedy from left to right
+    response_model=Union[AskemEntity, Entity],
+    response_model_exclude_unset=True,
+    response_model_exclude_defaults=True,
+    response_model_exclude_none=True,
+    tags=["entities"],
 )
 def get_entity(
     request: Request,

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -249,7 +249,12 @@ def get_relations(
 
 
 @api_blueprint.get(
-    "/search", response_model=List[Entity], response_model_exclude_unset=True, tags=["grounding"]
+    "/search",
+    response_model=List[Union[AskemEntity, Entity]],
+    response_model_exclude_unset=True,
+    response_model_exclude_none=True,
+    response_model_exclude_defaults=True,
+    tags=["grounding"],
 )
 def search(
     request: Request,

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -28,8 +28,12 @@ class Term(BaseModel):
     type: EntityType
     obsolete: bool = Field(default=False)
     description: str
+    physical_min: float
+    physical_max: float
     suggested_data_type: str
     suggested_unit: str
+    typical_min: float
+    typical_max: float
     xrefs: List[Xref] = Field(default_factory=list)
     synonyms: List[Synonym] = Field(default_factory=list)
 

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -28,14 +28,14 @@ class Term(BaseModel):
     type: EntityType
     obsolete: bool = Field(default=False)
     description: str
+    xrefs: List[Xref] = Field(default_factory=list)
+    synonyms: List[Synonym] = Field(default_factory=list)
     physical_min: Optional[float] = None
     physical_max: Optional[float] = None
     suggested_data_type: Optional[str] = None
     suggested_unit: Optional[str] = None
     typical_min: Optional[float] = None
     typical_max: Optional[float] = None
-    xrefs: List[Xref] = Field(default_factory=list)
-    synonyms: List[Synonym] = Field(default_factory=list)
 
     @property
     def prefix(self) -> str:

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -54,7 +54,7 @@ def get_askemo_terms() -> Mapping[str, Term]:
 
 def write(ontology: Mapping[str, Term]) -> None:
     terms = [
-        term.dict(exclude_unset=True)
+        term.dict(exclude_unset=True, exclude_defaults=True, exclude_none=True)
         for _curie, term in sorted(ontology.items())
     ]
     ONTOLOGY_PATH.write_text(

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List, Mapping
+from typing import List, Mapping, Optional
 
 from pydantic import BaseModel, Field
 
@@ -28,12 +28,12 @@ class Term(BaseModel):
     type: EntityType
     obsolete: bool = Field(default=False)
     description: str
-    physical_min: float
-    physical_max: float
+    physical_min: Optional[float]
+    physical_max: Optional[float]
     suggested_data_type: str
     suggested_unit: str
-    typical_min: float
-    typical_max: float
+    typical_min: Optional[float]
+    typical_max: Optional[float]
     xrefs: List[Xref] = Field(default_factory=list)
     synonyms: List[Synonym] = Field(default_factory=list)
 

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -28,12 +28,12 @@ class Term(BaseModel):
     type: EntityType
     obsolete: bool = Field(default=False)
     description: str
-    physical_min: Optional[float]
-    physical_max: Optional[float]
-    suggested_data_type: str
-    suggested_unit: str
-    typical_min: Optional[float]
-    typical_max: Optional[float]
+    physical_min: Optional[float] = None
+    physical_max: Optional[float] = None
+    suggested_data_type: Optional[str] = None
+    suggested_unit: Optional[str] = None
+    typical_min: Optional[float] = None
+    typical_max: Optional[float] = None
     xrefs: List[Xref] = Field(default_factory=list)
     synonyms: List[Synonym] = Field(default_factory=list)
 

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -3,7 +3,7 @@
     "description": "The number of people who live in an area being modeled.",
     "id": "askemo:0000001",
     "name": "population",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "int",
     "suggested_unit": "person",
     "synonyms": [],
@@ -19,7 +19,7 @@
     "description": "The length of time that an infectious disease requires to double in incidence.",
     "id": "askemo:0000002",
     "name": "doubling time",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -40,7 +40,7 @@
     "description": "The length of time an infected individual needs to recover after being infected.",
     "id": "askemo:0000003",
     "name": "recovery time",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -60,7 +60,7 @@
     "description": "The length of time an infected individual is infectious after being infected.",
     "id": "askemo:0000004",
     "name": "infectious time",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -78,8 +78,8 @@
       }
     ],
     "type": "class",
-    "typical_min": 1,
-    "typical_max": 35,
+    "typical_max": 35.0,
+    "typical_min": 1.0,
     "xrefs": [
       {
         "id": "apollosv:00000140",
@@ -91,7 +91,7 @@
     "description": "The average number of contacts per person per time which result in an infection. Can be calculated as the transmissibility multiplied by the average number of people exposed.",
     "id": "askemo:0000005",
     "name": "effective contact rate",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "person / day",
     "synonyms": [
@@ -116,7 +116,7 @@
     "description": "Represents the average number of people who will be infected by any given infected person where all individuals are susceptible to infection. It is calculated as the ratio of the effective contact rate and then mean recovery time.",
     "id": "askemo:0000006",
     "name": "basic reproduction number",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "dimensionless",
     "synonyms": [
@@ -149,7 +149,7 @@
     "description": "Represents the average number of people who will be infected by any given infected person in a partially susceptible population. It is calculated by multiplying the basic reproduction number by the fraction of the population that is susceptible.",
     "id": "askemo:0000007",
     "name": "effective reproduction number",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "dimensionless",
     "synonyms": [
@@ -213,7 +213,7 @@
     "description": "The length of time after which an infected person shows symptoms of disease.",
     "id": "askemo:0000010",
     "name": "incubation time",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -246,7 +246,7 @@
     "description": "The rate at which an infected person develops symptoms of disease. Inverse of the incubation time.",
     "id": "askemo:0000011",
     "name": "progression rate",
-    "physical_min": 0,
+    "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "1 / day",
     "synonyms": [],

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -3,6 +3,7 @@
     "description": "The number of people who live in an area being modeled.",
     "id": "askemo:0000001",
     "name": "population",
+    "physical_min": 0,
     "suggested_data_type": "int",
     "suggested_unit": "person",
     "synonyms": [],
@@ -18,6 +19,7 @@
     "description": "The length of time that an infectious disease requires to double in incidence.",
     "id": "askemo:0000002",
     "name": "doubling time",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -38,6 +40,7 @@
     "description": "The length of time an infected individual needs to recover after being infected.",
     "id": "askemo:0000003",
     "name": "recovery time",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -57,6 +60,7 @@
     "description": "The length of time an infected individual is infectious after being infected.",
     "id": "askemo:0000004",
     "name": "infectious time",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -74,6 +78,8 @@
       }
     ],
     "type": "class",
+    "typical_min": 1,
+    "typical_max": 35,
     "xrefs": [
       {
         "id": "apollosv:00000140",
@@ -85,6 +91,7 @@
     "description": "The average number of contacts per person per time which result in an infection. Can be calculated as the transmissibility multiplied by the average number of people exposed.",
     "id": "askemo:0000005",
     "name": "effective contact rate",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "person / day",
     "synonyms": [
@@ -109,6 +116,7 @@
     "description": "Represents the average number of people who will be infected by any given infected person where all individuals are susceptible to infection. It is calculated as the ratio of the effective contact rate and then mean recovery time.",
     "id": "askemo:0000006",
     "name": "basic reproduction number",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "dimensionless",
     "synonyms": [
@@ -141,6 +149,7 @@
     "description": "Represents the average number of people who will be infected by any given infected person in a partially susceptible population. It is calculated by multiplying the basic reproduction number by the fraction of the population that is susceptible.",
     "id": "askemo:0000007",
     "name": "effective reproduction number",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "dimensionless",
     "synonyms": [
@@ -204,6 +213,7 @@
     "description": "The length of time after which an infected person shows symptoms of disease.",
     "id": "askemo:0000010",
     "name": "incubation time",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "day",
     "synonyms": [
@@ -236,6 +246,7 @@
     "description": "The rate at which an infected person develops symptoms of disease. Inverse of the incubation time.",
     "id": "askemo:0000011",
     "name": "progression rate",
+    "physical_min": 0,
     "suggested_data_type": "float",
     "suggested_unit": "1 / day",
     "synonyms": [],

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -6,7 +6,6 @@
     "physical_min": 0.0,
     "suggested_data_type": "int",
     "suggested_unit": "person",
-    "synonyms": [],
     "type": "class",
     "xrefs": [
       {
@@ -53,8 +52,7 @@
         "value": "recovery rate"
       }
     ],
-    "type": "class",
-    "xrefs": []
+    "type": "class"
   },
   {
     "description": "The length of time an infected individual is infectious after being infected.",
@@ -194,7 +192,6 @@
     "description": "The likelihood of a disease occurring due to a pathogen. Virulence is measured relative to a standard, such as another pathogen or host.",
     "id": "askemo:0000009",
     "name": "virulence",
-    "synonyms": [],
     "type": "class",
     "xrefs": [
       {
@@ -247,8 +244,6 @@
     "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "1 / day",
-    "synonyms": [],
-    "type": "class",
-    "xrefs": []
+    "type": "class"
   }
 ]

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -194,8 +194,6 @@
     "description": "The likelihood of a disease occurring due to a pathogen. Virulence is measured relative to a standard, such as another pathogen or host.",
     "id": "askemo:0000009",
     "name": "virulence",
-    "suggested_data_type": "",
-    "suggested_unit": "",
     "synonyms": [],
     "type": "class",
     "xrefs": [

--- a/mira/dkg/askemo/generate_site.py
+++ b/mira/dkg/askemo/generate_site.py
@@ -21,6 +21,14 @@ def _get_term(term: Term) -> pyobo.Term:
         properties["suggested_data_type"] = [term.suggested_data_type]
     if term.suggested_unit:
         properties["suggested_unit"] = [term.suggested_unit]
+    if term.physical_min:
+        properties["physical_min"] = [term.physical_min]
+    if term.physical_max:
+        properties["physical_max"] = [term.physical_max]
+    if term.typical_min:
+        properties["typical_min"] = [term.typical_min]
+    if term.typical_max:
+        properties["typical_max"] = [term.typical_max]
 
     rv = pyobo.Term(
         reference=pyobo.Reference.from_curie(term.id, name=term.name),

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -155,10 +155,20 @@ class Entity(BaseModel):
         data = self.dict()
         return AskemEntity(
             **data,
-            physical_min=self._get_single_property("physical_min", dtype=float),
-            physical_max=self._get_single_property("physical_max", dtype=float),
-            suggested_data_type=self._get_single_property("suggested_data_type"),
-            suggested_unit=self._get_single_property("suggested_unit"),
+            physical_min=self._get_single_property(
+                "physical_min", dtype=float,
+            ),
+            physical_max=self._get_single_property(
+                "physical_max", dtype=float,
+            ),
+            suggested_data_type=self._get_single_property(
+                "suggested_data_type", dtype=str,
+            ),
+            # TODO could later extend suggested_unit to have a
+            #  more sophistocated data model as well
+            suggested_unit=self._get_single_property(
+                "suggested_unit", dtype=str,
+            ),
             typical_min=self._get_single_property("typical_min", dtype=float),
             typical_max=self._get_single_property("typical_max", dtype=float),
         )
@@ -166,12 +176,13 @@ class Entity(BaseModel):
 class AskemEntity(Entity):
     """An extended entity with more ASKEM stuff loaded in."""
 
-    physical_min: Optional[float] = None
-    physical_max: Optional[float] = None
-    suggested_data_type: Optional[str] = None
-    suggested_unit: Optional[str] = None
-    typical_min: Optional[float] = None
-    typical_max: Optional[float] = None
+    # TODO @ben please write descriptions for these
+    physical_min: Optional[float] = Field(..., description="")
+    physical_max: Optional[float] = Field(..., description="")
+    suggested_data_type: Optional[str] = Field(..., description="")
+    suggested_unit: Optional[str] = Field(..., description="")
+    typical_min: Optional[float] = Field(..., description="")
+    typical_max: Optional[float] = Field(..., description="")
 
 
 class Neo4jClient:

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -177,12 +177,12 @@ class AskemEntity(Entity):
     """An extended entity with more ASKEM stuff loaded in."""
 
     # TODO @ben please write descriptions for these
-    physical_min: Optional[float] = Field(..., description="")
-    physical_max: Optional[float] = Field(..., description="")
-    suggested_data_type: Optional[str] = Field(..., description="")
-    suggested_unit: Optional[str] = Field(..., description="")
-    typical_min: Optional[float] = Field(..., description="")
-    typical_max: Optional[float] = Field(..., description="")
+    physical_min: Optional[float] = Field(description="")
+    physical_max: Optional[float] = Field(description="")
+    suggested_data_type: Optional[str] = Field(description="")
+    suggested_unit: Optional[str] = Field(description="")
+    typical_min: Optional[float] = Field(description="")
+    typical_max: Optional[float] = Field(description="")
 
 
 class Neo4jClient:

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -85,11 +85,12 @@ class Entity(BaseModel):
         key :
             The name of the property (either a URI, CURIE, or plain string)
         dtype :
-            The datatype to cast the property into
+            The datatype to cast the property into, if given. Can also be
+            any callable that takes one argument and returns something.
 
         Returns
         -------
-        A property value, if available
+        A property value, if available.
         """
         values = self.properties.get(key)
         if not values:
@@ -150,6 +151,9 @@ class Entity(BaseModel):
         return rv
 
     def as_askem_entity(self):
+        """Parse this term into an ASKEM Ontology-specific class."""
+        if self.prefix != "askemo":
+            raise ValueError(f"can only call as_askem_entity() on ASKEM ontology terms")
         if isinstance(self, AskemEntity):
             return self
         data = self.dict()

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -190,6 +190,19 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool):
         if term.suggested_data_type:
             property_predicates.append("suggested_data_type")
             property_values.append(term.suggested_data_type)
+        if term.physical_min is not None:
+            property_predicates.append("physical_min")
+            property_values.append(str(term.physical_min))
+        if term.physical_max is not None:
+            property_predicates.append("physical_max")
+            property_values.append(str(term.physical_max))
+        if term.typical_min is not None:
+            property_predicates.append("typical_min")
+            property_values.append(str(term.typical_min))
+        if term.typical_max is not None:
+            property_predicates.append("typical_max")
+            property_values.append(str(term.typical_max))
+
         nodes[term.id] = NodeInfo(
             curie=term.id,
             prefix=term.prefix,

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -93,3 +93,7 @@ class TestDKG(unittest.TestCase):
         )
         self.assertEqual("float", e.suggested_data_type)
         self.assertEqual("unitless", e.suggested_unit)
+
+        res = self.client.get("/api/entity/askemo:0000010")
+        e = Entity(**res.json())
+        self.assertEqual(0.0, e.physical_min)

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from gilda.grounder import Grounder
 
 from mira.dkg.api import get_relations
-from mira.dkg.client import Entity
+from mira.dkg.client import AskemEntity, Entity
 from mira.dkg.utils import MiraState
 
 MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
@@ -81,8 +81,13 @@ class TestDKG(unittest.TestCase):
 
     def test_entity(self):
         """Test getting entities."""
-        res = self.client.get("/api/entity/askemo:0000008")
+        res = self.client.get("/api/entity/ido:0000463")
         e = Entity(**res.json())
+        self.assertIsInstance(e, Entity)
+        self.assertFalse(hasattr(e, "physical_min"))
+
+        res = self.client.get("/api/entity/askemo:0000008")
+        e = AskemEntity(**res.json())
         self.assertLessEqual(1, len(e.synonyms))
         self.assertTrue(any(s.value == "infectivity" for s in e.synonyms))
         self.assertTrue(
@@ -95,5 +100,6 @@ class TestDKG(unittest.TestCase):
         self.assertEqual("unitless", e.suggested_unit)
 
         res = self.client.get("/api/entity/askemo:0000010")
-        e = Entity(**res.json())
+        e = AskemEntity(**res.json())
+        self.assertTrue(hasattr(e, "physical_min"))
         self.assertEqual(0.0, e.physical_min)

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -102,4 +102,5 @@ class TestDKG(unittest.TestCase):
         res = self.client.get("/api/entity/askemo:0000010")
         e = AskemEntity(**res.json())
         self.assertTrue(hasattr(e, "physical_min"))
+        self.assertIsInstance(e.physical_min, float)
         self.assertEqual(0.0, e.physical_min)

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,7 +1,7 @@
 """Tests for the ASKEM ontology."""
 
 import unittest
-from mira.dkg.askemo.api import get_askemo_terms, EQUIVALENCE_TYPES
+from mira.dkg.askemo.api import get_askemo_terms, EQUIVALENCE_TYPES, Term
 import bioregistry
 
 
@@ -16,6 +16,7 @@ class TestOntology(unittest.TestCase):
     def test_ontology(self):
         """Tests for the ontology."""
         for key, term in self.ontology.items():
+            self.assertIsInstance(term, Term)
             self.assertRegex(term.id, "^askemo:\\d{7}$")
             for synonym in term.synonyms or []:
                 self.assertIn(synonym.type, EQUIVALENCE_TYPES)
@@ -25,3 +26,5 @@ class TestOntology(unittest.TestCase):
                 norm_xref_prefix = self.manager.normalize_prefix(xref_prefix)
                 self.assertIsNotNone(norm_xref_prefix)
                 self.assertEqual(norm_xref_prefix, xref_prefix)
+        if term.physical_min:
+            self.assertIsInstance(term.physical_min, float)


### PR DESCRIPTION
This PR adds some physical limits on values of concepts in ASKEMO as well as one example of a (manually but empirically determined) typical min/max range for a value. Since the properties during constructing have to be strings, these are converted into strings and will thus appear as strings on the client side in this implementation.

On a related note, I would like to allow missing fields at the level of the JSON resource file. For instance instead of empty synonyms/xref dicts like (https://github.com/indralab/mira/blob/main/mira/dkg/askemo/askemo.json#L54), it would be good if those could be omitted. Similarly, in the current version of the JSON, I see empty string entries for cases where a suggested_unit and suggested_data_type is not defined (https://github.com/indralab/mira/blob/main/mira/dkg/askemo/askemo.json#L188-L189). I would again prefer if these could be left out of the JSON instead. However, in both these cases, I'm not entirely sure where, downstream, additional handling needs to be added for these cases.