### PR TITLE
Readonly sessions

### DIFF
--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, 
 import neo4j.graph
 import networkx
 import pystow
-from neo4j import GraphDatabase
+from neo4j import GraphDatabase, Transaction, unit_of_work
 from pydantic import BaseModel, Field
 from tqdm import tqdm
 from typing_extensions import Literal, TypeAlias
@@ -177,6 +177,7 @@ class Entity(BaseModel):
             typical_max=self._get_single_property("typical_max", dtype=float),
         )
 
+
 class AskemEntity(Entity):
     """An extended entity with more ASKEM stuff loaded in."""
 
@@ -257,10 +258,7 @@ class Neo4jClient:
             # As stated here, using a context manager allows for the
             # transaction to be rolled back when an exception is raised
             # https://neo4j.com/docs/api/python-driver/current/api.html#explicit-transactions
-
-            with session.begin_transaction() as tx:
-                res = tx.run(query)
-                values = res.values()
+            values = session.read_transaction(do_cypher_tx, query)
 
         return values
 
@@ -470,6 +468,22 @@ class Neo4jClient:
                 (node, desc) for desc in networkx.descendants(g, node)
             }
         return transitive_closure
+
+
+# Follows example here:
+# https://neo4j.com/docs/python-manual/current/session-api/#python-driver-simple-transaction-fn
+# and from the docstring of neo4j.Session.read_transaction
+@unit_of_work()
+def do_cypher_tx(
+        tx: Transaction,
+        query: str,
+        query_params: Optional[Dict] = None
+) -> List[List]:
+    result = tx.run(query, parameters=query_params)
+    values = []
+    for record in result:
+        values.append(record.values())
+    return values
 
 
 def similarity_score(query, entity: Entity) -> Tuple[float, float, float, float]:

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -480,10 +480,7 @@ def do_cypher_tx(
         query_params: Optional[Dict] = None
 ) -> List[List]:
     result = tx.run(query, parameters=query_params)
-    values = []
-    for record in result:
-        values.append(record.values())
-    return values
+    return [record.values() for record in result]
 
 
 def similarity_score(query, entity: Entity) -> Tuple[float, float, float, float]:


### PR DESCRIPTION
This PR updates how `Neo4jClient.query_tx` does its transaction calls: by using `Session.read_transaction` the queries are made to be read only. If a `CREATE ...` query is tried, a `neo4j.exceptions.ClientError` is raised.