### PR TITLE
Replace transition key with enumerated identifiers

### DIFF
--- a/mira/modeling/petri.py
+++ b/mira/modeling/petri.py
@@ -34,7 +34,7 @@ class PetriNetModel:
 
         for idx, transition in enumerate(model.transitions.values()):
             self.transitions.append(
-                {'tname': str(transition.key),
+                {'tname': f"t{idx + 1}",
                  'template_type': transition.template_type,
                  'parameter_name': sanitize_parameter_name(
                      str(transition.rate.key)),

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -23,6 +23,8 @@ def test_petri_net_assembly():
                   {"it": 2, "is": 2}]:
         assert entry in js['I']
 
+    transition_keys = {d['tname'] for d in js['T']}
+    assert {f't{ix+1}' for ix in range(len(js['T']))} == transition_keys
     for transition in js['T']:
         assert transition['template_type'] in {'ControlledConversion',
                                                'NaturalConversion'}


### PR DESCRIPTION
This PR replaces the transition key to simply be an enumerated key: `t1, ..., tn`. This simplifies the transitions' json representation to be more legible without losing the uniqueness.