### PR TITLE
Improve rate law processing

### DIFF
--- a/mira/sources/sbml.py
+++ b/mira/sources/sbml.py
@@ -216,8 +216,9 @@ def template_model_from_sbml_model(
     # Handle custom assignment rules in the model
     assignment_rules = {}
     for rule in sbml_model.rules:
-        assignment_rules[rule.id] = sympy.parse_expr(rule.formula,
-                                                     local_dict=all_locals)
+        rule_expr = parse_assignment_rule(rule.formula, all_locals)
+        if rule_expr:
+            assignment_rules[rule.id] = rule_expr
 
     for reaction in sbml_model.reactions:
         modifier_species = [species.species for species in reaction.modifiers]
@@ -343,6 +344,14 @@ def template_model_from_sbml_model(
     template_model = TemplateModel(templates=templates,
                                    parameters=all_parameters)
     return ParseResult(template_model=template_model)
+
+
+def parse_assignment_rule(rule, locals):
+    try:
+        expr = sympy.parse_expr(rule, local_dict=locals)
+        return expr
+    except SyntaxError:
+        return None
 
 
 def get_formula_str(ast_node):

--- a/mira/sources/sbml.py
+++ b/mira/sources/sbml.py
@@ -234,6 +234,8 @@ def template_model_from_sbml_model(
                                      local_dict=all_locals)
         # At this point we need to make sure we substitute the assignments
         rate_expr = rate_expr.subs(assignment_rules)
+        for comp in compartment_symbols:
+            rate_expr = rate_expr.subs(comp, all_parameters[comp])
 
         rate_law_variables = variables_from_sympy_expr(rate_expr)
 

--- a/tests/test_sbml.py
+++ b/tests/test_sbml.py
@@ -1,0 +1,13 @@
+from mira.sources.sbml import parse_assignment_rule
+
+
+def test_parse_expr():
+    expr = 'piecewise(Social_Distance_base * ' \
+           'Government_induced_isolation_factor_0, and(gt(time, ' \
+           'Time_government_action_0), lt(intermittent_time, ' \
+           'Time_government_action_0 - lockdown_duration * ' \
+           '(1 - timeFraction_lockdown_0))), Social_Distance_base)'
+    rule = parse_assignment_rule(expr, {})
+    # TODO: transform the piecewise/and/gt/lt functions to be valid
+    # in formulas so the expression can be parsed
+    assert rule is None


### PR DESCRIPTION
This PR improves rate law processing by skipping some non-canonical expressions that currently error, and substituting placeholder compartment parameters in rate laws. This latter change has the effect that rate laws are simplified, often to contain a simple mass-action expression.