### PR TITLE
Add units to DKG

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+WORKDIR /sw
+
+# Install and configure neo4j and python environment
+RUN apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates curl wget software-properties-common && \
+    curl -fsSL https://debian.neo4j.com/neotechnology.gpg.key | apt-key add - && \
+    add-apt-repository "deb https://debian.neo4j.com stable 4.4" && \
+    apt-get install -y neo4j && \
+    apt-get install -y git zip unzip bzip2 gcc graphviz graphviz-dev \
+        pkg-config python3 python3-pip && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
+ARG branch=main
+
+# Add graph content
+COPY nodes.tsv.gz /sw/nodes.tsv.gz
+COPY edges.tsv.gz /sw/edges.tsv.gz
+
+# Ingest graph content into neo4j
+RUN sed -i 's/#dbms.default_listen_address/dbms.default_listen_address/' /etc/neo4j/neo4j.conf && \
+    sed -i 's/#dbms.security.auth_enabled/dbms.security.auth_enabled/' /etc/neo4j/neo4j.conf && \
+    neo4j-admin import --delimiter='TAB' --skip-duplicate-nodes=true --skip-bad-relationships=true --nodes /sw/nodes.tsv.gz --relationships /sw/edges.tsv.gz
+
+# Python packages
+RUN python -m pip install git+https://github.com/indralab/mira.git@$branch#egg=mira[web,uvicorn] && \
+    python -m pip uninstall -y flask_bootstrap && \
+    python -m pip uninstall -y bootstrap_flask && \
+    python -m pip install bootstrap_flask
+
+COPY startup.sh startup.sh
+ENTRYPOINT ["/bin/bash", "/sw/startup.sh"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,11 +6,17 @@ This folder contains Docker build procedures for various aspects of MIRA.
 
 This folder implements a Docker build procedure for building a neo4j instance
 of MIRA's domain knowledge graph from a given node and edge dump. The node
-and edge dumps are assumed to be available as gzipped TSV files called
-`nodes.tsv.gz` and `edges.tsv.gz` in this folder. The build can be done as
+and edge dumps are pulled from S3.
 
 ```shell
 docker build --tag mira_dkg:latest .
+```
+
+If you want to test with local files, put `nodes.tsv.gz` and `edges.tsv.gz` in
+this folder and use:
+
+```shell
+docker build --file Dockerfile.local --tag mira_dkg:latest .
 ```
 
 Once the build finished, you can run the container locally as

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,13 +17,12 @@ this folder and use:
 
 ```shell
 docker build --file Dockerfile.local --tag mira_dkg:latest .
-docker run -p 8771:8771 -p 7687:7687 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
 ```
 
 Once the build finished, you can run the container locally as
 
 ```shell
-docker run -p 8771:8771 -p 7687:7687 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
+docker run -d -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
 ```
 
 This exposes a REST API at `http://localhost:8771`. Note that the `-d` flag

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,12 +17,13 @@ this folder and use:
 
 ```shell
 docker build --file Dockerfile.local --tag mira_dkg:latest .
+docker run -p 8771:8771 -p 7687:7687 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
 ```
 
 Once the build finished, you can run the container locally as
 
 ```shell
-docker run -d -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
+docker run -p 8771:8771 -p 7687:7687 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
 ```
 
 This exposes a REST API at `http://localhost:8771`. Note that the `-d` flag

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,8 @@ docker run -d -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
 ```
 
 This exposes a REST API at `http://localhost:8771`. Note that the `-d` flag
-runs the container in the background.
+runs the container in the background. If you want to expose Neo4j's bold, also
+add `-p 7687:7687`.
 
 ## MIRA Metaregistry
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ docker run -d -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
 ```
 
 This exposes a REST API at `http://localhost:8771`. Note that the `-d` flag
-runs the container in the background. If you want to expose Neo4j's bold, also
+runs the container in the background. If you want to expose Neo4j's bolt port, also
 add `-p 7687:7687`.
 
 ## MIRA Metaregistry

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -371,7 +371,7 @@ class Neo4jClient:
         labels = [x[0] for x in labels_result]
         counter_data = {}
         for label in labels:
-            res = self.query_tx(f"MATCH (n:{label}) RETURN count(*)")
+            res = self.query_tx(f"MATCH (n:`{label}`) RETURN count(*)")
             if res is not None:
                 counter_data[label] = res[0][0]
         return Counter(counter_data)

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -134,9 +134,9 @@ DEFAULT_VOCABS = [
 
 
 class NodeInfo(NamedTuple):
-    curie: str
-    prefix: str
-    label: str
+    curie: str  # the id used in neo4j
+    prefix: str  # the field used for neo4j labels. can contain semicolon-delimited
+    label: str  # the human-readable label
     synonyms: str
     deprecated: Literal["true", "false"]  # need this for neo4j
     type: EntityType
@@ -186,7 +186,9 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool):
                     edge_names[edge_node.curie] = edge_node.lbl.strip()
         EDGE_NAMES_PATH.write_text(json.dumps(edge_names, sort_keys=True, indent=2))
 
-    nodes: Dict[str, NamedTuple] = {}
+    # A mapping from CURIEs to node information tuples
+    nodes: Dict[str, NodeInfo] = {}
+    # A mapping from CURIEs to a set of source strings
     node_sources = defaultdict(set)
     unstandardized_nodes = []
     unstandardized_edges = []

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -16,18 +16,6 @@ Example command for local bulk import on mac with neo4j 4.x:
         --nodes ~/.data/mira/demo/import/nodes.tsv.gz \
         --relationships ~/.data/mira/demo/import/edges.tsv.gz
 
-On 5.x (/usr/local/Cellar/neo4j/5.1.0/libexec/conf/):
-
-.. code::
-
-    neo4j-admin database import full mira \
-        --delimiter='TAB' \
-        --overwrite-destination=true \
-        --skip-duplicate-nodes=true \
-        --skip-bad-relationships=true \
-        --nodes ~/.data/mira/demo/import/nodes.tsv.gz \
-        --relationships ~/.data/mira/demo/import/edges.tsv.gz
-
 Then, restart the neo4j service with homebrew ``brew services neo4j restart``
 """
 

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -244,10 +244,11 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool):
 
     click.secho("Units", fg="green", bold=True)
     for wikidata_id, label, description, xrefs in tqdm(get_unit_terms(), unit="unit"):
-        node_sources[term.id].add("wikidata")
-        nodes[term.id] = NodeInfo(
-            curie=f"wikidata:{wikidata_id}",
-            prefix="wikidata",
+        curie = f"wikidata:{wikidata_id}"
+        node_sources[curie].add("wikidata")
+        nodes[curie] = NodeInfo(
+            curie=curie,
+            prefix="wikidata;unit",
             label=label,
             synonyms="",
             deprecated="false",

--- a/mira/dkg/templates/home.html
+++ b/mira/dkg/templates/home.html
@@ -27,5 +27,13 @@
             to see grounding results such as <a href="/api/ground/vaccine">
             <code>/api/ground/vaccine</code></a>
         </p>
+        <h3>Summary</h3>
+        <div>
+            {% for item, count in node_counter.most_common() %}
+                <span class="badge bg-primary" style="margin-top: 2px;">
+                    {{ item }}: {{ "{:,}".format(count) }}
+                </span>
+            {% endfor %}
+        </div>
     </div>
 {% endblock %}

--- a/mira/dkg/ui.py
+++ b/mira/dkg/ui.py
@@ -1,8 +1,6 @@
 import random
 
-import flask
-from flask import Blueprint, Response, render_template, request
-from gilda.grounder import ScoredMatch
+from flask import Blueprint, render_template
 
 from .proxies import client, grounder
 
@@ -20,6 +18,7 @@ def home():
         number_terms=len(grounder.entries),
         example_key=key,
         example_term=grounder.entries[key][0].to_json(),
+        node_counter=client.get_node_counter(),
     )
 
 

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -43,7 +43,10 @@ def get_unit_terms():
     rv = []
     for record in records:
         xrefs = []
-        for prefix in ["umuc", "qudt"]:
+        for prefix in [
+            # "umuc",
+            "qudt",
+        ]:
             value = record.get(prefix)
             if value:
                 xrefs.append(f"{prefix}:{value['value']}")

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -1,0 +1,60 @@
+from textwrap import dedent
+from typing import List, Mapping, Any
+import logging
+import requests
+
+__all__ = [
+    "get_unit_terms",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Wikidata SPARQL endpoint. See https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service#Interfacing
+WIKIDATA_ENDPOINT = "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
+
+SPARQL = dedent("""\
+    SELECT ?item ?itemLabel ?itemDescription ?umuc ?uo ?qudt
+    WHERE 
+    {
+      ?item wdt:P7825 ?umuc .
+      OPTIONAL { ?item wdt:P8769 ?uo }
+      OPTIONAL { ?item wdt:P2968 ?qudt }
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". } # Helps get the label in your language, if not, then en language
+    }
+""")
+
+
+def query_wikidata(sparql: str) -> List[Mapping[str, Any]]:
+    """Query Wikidata's sparql service.
+
+    :param sparql: A SPARQL query string
+    :return: A list of bindings
+    """
+    logger.debug("running query: %s", sparql)
+    res = requests.get(WIKIDATA_ENDPOINT, params={"query": sparql, "format": "json"})
+    res.raise_for_status()
+    res_json = res.json()
+    return res_json["results"]["bindings"]
+
+
+def get_unit_terms():
+    """Get tuples for each unit."""
+    records = query_wikidata(SPARQL)
+    rv = []
+    for record in records:
+        xrefs = []
+        for prefix in ["umuc", "qudt"]:
+            value = record.get(prefix)
+            if value:
+                xrefs.append(f"{prefix}:{value['value']}")
+        try:
+            description = record["itemDescription"]["value"]
+        except KeyError:
+            description = ""
+        rv.append((
+            record["item"]["value"][len("http://www.wikidata.org/entity/"):],
+            record["itemLabel"]["value"],
+            description,
+            xrefs,
+        ))
+    return rv


### PR DESCRIPTION
This PR does the following:

1. Adds units in Wikidata that have mappings to UMUC/QUDT to the domain knowledge graph with dual labels (both `wikidata` as the prefix and also `unit` as the type)
2. Improves documentation of build workflow
3. Adds dockerfile appropriate for local testing and improved documentation on how to run locally with neo4j
4. Adds summary of node counts to homepage of DKG app