### PR TITLE
Generate node embeddings for DKG

### DIFF
--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -146,9 +146,14 @@ class NodeInfo(NamedTuple):
     is_flag=True,
     help="Add edges for xrefs to external ontology terms",
 )
-@click.option("--summaries", is_flag=True, help="Print summaries of nodes and edges while building")
+@click.option(
+    "--summaries",
+    is_flag=True,
+    help="Print summaries of nodes and edges while building",
+)
 @click.option("--do-upload", is_flag=True, help="Upload to S3 on completion")
-def main(add_xref_edges: bool, summaries: bool, do_upload: bool):
+@click.option("--refresh", is_flag=True, help="Refresh caches")
+def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
     """Generate the node and edge files."""
     if EDGE_NAMES_PATH.is_file():
         edge_names = json.loads(EDGE_NAMES_PATH.read_text())
@@ -271,7 +276,7 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool):
         edges = []
 
         _results_pickle_path = DEMO_MODULE.join("parsed", name=f"{prefix}.pkl")
-        if _results_pickle_path.is_file():
+        if _results_pickle_path.is_file() and not refresh:
             parse_results = pickle.loads(_results_pickle_path.read_bytes())
         else:
             if prefix in SLIMS:

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -42,8 +42,8 @@ from typing_extensions import Literal
 from mira.dkg.askemo import get_askemo_terms
 from mira.dkg.models import EntityType
 from mira.dkg.resources import SLIMS
-from mira.dkg.utils import PREFIXES
 from mira.dkg.units import get_unit_terms
+from mira.dkg.utils import PREFIXES
 
 MODULE = pystow.module("mira")
 DEMO_MODULE = MODULE.module("demo", "import")
@@ -58,6 +58,7 @@ EDGE_OBJ_COUNTER_PATH = DEMO_MODULE.join(name="count_predicate_object_prefix.tsv
 EDGE_COUNTER_PATH = DEMO_MODULE.join(name="count_predicate.tsv")
 NODES_PATH = DEMO_MODULE.join(name="nodes.tsv.gz")
 EDGES_PATH = DEMO_MODULE.join(name="edges.tsv.gz")
+EMBEDDINGS_PATH = DEMO_MODULE.join(name="embeddings.tsv.gz")
 METAREGISTRY_PATH = DEMO_MODULE.join(name="metaregistry.json")
 OBSOLETE = {"oboinowl:ObsoleteClass", "oboinowl:ObsoleteProperty"}
 EDGES_PATHS: Dict[str, Path] = {
@@ -596,6 +597,10 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool):
         edges_path=EDGES_PATH,
         upload=do_upload,
     )
+
+    from .construct_embeddings import _construct_embeddings
+
+    _construct_embeddings(upload=do_upload)
 
 
 def _write_counter(

--- a/mira/dkg/construct_embeddings.py
+++ b/mira/dkg/construct_embeddings.py
@@ -1,0 +1,44 @@
+"""Construct low-dimensional embeddings of entities in the MIRA DKG."""
+
+import gzip
+import os
+import shutil
+from tempfile import TemporaryDirectory
+
+import click
+from embiggen.embedders import SecondOrderLINEEnsmallen
+from ensmallen import Graph
+
+from mira.dkg.construct import EDGES_PATH, EMBEDDINGS_PATH, upload_s3
+
+
+def _construct_embeddings(upload: bool) -> None:
+    with TemporaryDirectory() as directory:
+        path = os.path.join(directory, EDGES_PATH.stem)
+        with gzip.open(EDGES_PATH, "rb") as f_in, open(path, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        graph = Graph.from_csv(
+            edge_path=path,
+            edge_list_separator="\t",
+            sources_column_number=0,
+            destinations_column_number=1,
+            edge_list_numeric_node_ids=False,
+            directed=True,
+            name="MIRA-DKG",
+        )
+    embedding = SecondOrderLINEEnsmallen(embedding_size=32).fit_transform(graph)
+    df = embedding.get_all_node_embedding()[0].sort_index()
+    df.index.name = "node"
+    df.to_csv(EMBEDDINGS_PATH, sep="\t")
+    if upload:
+        upload_s3(EMBEDDINGS_PATH)
+
+
+@click.command()
+@click.option("--upload", is_flag=True)
+def main(upload: bool):
+    _construct_embeddings(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/mira/dkg/resources/ncit_slim.json
+++ b/mira/dkg/resources/ncit_slim.json
@@ -84259,6 +84259,7 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/NCIT_C43877"
     } ],
+    "id" : "https://raw.githubusercontent.com/indralab/mira/main/mira/dkg/resources/ncit_slim.json",
     "meta" : {
       "subsets" : [ ],
       "xrefs" : [ ],

--- a/mira/dkg/summarize.py
+++ b/mira/dkg/summarize.py
@@ -14,7 +14,9 @@ def main(url: Optional[str], user: Optional[str], password: Optional[str]):
     """Summarize the contents of a neo4j instance."""
     client = Neo4jClient(url=url, user=user, password=password)
     c = client.get_node_counter()
-    click.echo(tabulate(c.most_common(), headers=["label", "count"], tablefmt="github"))
+    click.echo(
+        tabulate(c.most_common(), headers=["label", "count"], tablefmt="github")
+    )
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ dkg-construct =
     pystow
     tabulate
     tqdm
+dkg-embed =
+    grape
 metaregistry =
     bioregistry[web]
     more_click


### PR DESCRIPTION
This PR adds generation of node embeddings for entities in the DKG using the GRAPE library's implementation of Second Order LINE (a simple, fast method). It outputs the 32-dimensional embeddings in a gzipped TSV that also gets upload to S3 on construction. It takes about 30 seconds to run. Attached are the embeddings themselves:

[embeddings.tsv.gz](https://github.com/indralab/mira/files/10030393/embeddings.tsv.gz)

