### PR TITLE
Add symbol synonyms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ import.report
 scratch/
 .DS_Store
 docs/_site
+docker/edges.tsv.gz
+docker/nodes.tsv.gz

--- a/docs/ontology/0000002/index.html
+++ b/docs/ontology/0000002/index.html
@@ -55,10 +55,8 @@
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                    </dt>
-                    <dd>
-                            doubling rate (<span class="muted">RELATED</span>)
-                    </dd>
+                        Related                    </dt>
+                    <dd>doubling rate</dd>
                 
                 
                 

--- a/docs/ontology/0000003/index.html
+++ b/docs/ontology/0000003/index.html
@@ -55,13 +55,8 @@
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                    </dt>
-                    <dd>
-                            <ul>
-                                    <li>mean recovery time (<span class="muted">EXACT</span>)</li>
-                                    <li>recovery rate (<span class="muted">RELATED</span>)</li>
-                            </ul>
-                    </dd>
+                        Exact                    </dt>
+                    <dd>mean recovery time</dd>
                 
                 
                 

--- a/docs/ontology/0000004/index.html
+++ b/docs/ontology/0000004/index.html
@@ -55,14 +55,16 @@
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                    </dt>
-                    <dd>
-                            <ul>
-                                    <li>contagious time (<span class="muted">EXACT</span>)</li>
-                                    <li>infectious days (<span class="muted">NARROW</span>)</li>
-                                    <li>infectious period (<span class="muted">EXACT</span>)</li>
-                            </ul>
-                    </dd>
+                        Exact                    </dt>
+                    <dd>contagious time</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Narrow                    </dt>
+                    <dd>infectious days</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Exact                    </dt>
+                    <dd>infectious period</dd>
                 
                 
                 

--- a/docs/ontology/0000005/index.html
+++ b/docs/ontology/0000005/index.html
@@ -54,41 +54,21 @@
 
                 
                     <dt>
-                        Synonyms
-                    </dt>
-                    <dd>
-                        <table class="table table-sm table-hover table-responsive">
-                            <thead>
-                            <tr>
-                                <th scope="col">Synonym</th>
-                                <th scope="col">Specificity</th>
-                                <th scope="col">Type</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td>transmission coefficient</td>
-                                    <td>EXACT</td>
-                                    <td></td>
-                                </tr>
-                                <tr>
-                                    <td>transmission rate</td>
-                                    <td>EXACT</td>
-                                    <td></td>
-                                </tr>
-                                <tr>
-                                    <td>\beta</td>
-                                    <td>RELATED</td>
-                                    <td>Symbol LaTeX</td>
-                                </tr>
-                                <tr>
-                                    <td>β</td>
-                                    <td>RELATED</td>
-                                    <td>Symbol Text</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </dd>
+                        <span class="badge badge-primary">Synonym</span>
+                        Exact                    </dt>
+                    <dd>transmission coefficient</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Exact                    </dt>
+                    <dd>transmission rate</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\beta</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol Text)                    </dt>
+                    <dd>β</dd>
                 
                 
                 

--- a/docs/ontology/0000005/index.html
+++ b/docs/ontology/0000005/index.html
@@ -54,13 +54,40 @@
 
                 
                     <dt>
-                        <span class="badge badge-primary">Synonym</span>
+                        Synonyms
                     </dt>
                     <dd>
-                            <ul>
-                                    <li>transmission coefficient (<span class="muted">EXACT</span>)</li>
-                                    <li>transmission rate (<span class="muted">EXACT</span>)</li>
-                            </ul>
+                        <table class="table table-sm table-hover table-responsive">
+                            <thead>
+                            <tr>
+                                <th scope="col">Synonym</th>
+                                <th scope="col">Specificity</th>
+                                <th scope="col">Type</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>transmission coefficient</td>
+                                    <td>EXACT</td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td>transmission rate</td>
+                                    <td>EXACT</td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td>\beta</td>
+                                    <td>RELATED</td>
+                                    <td>Symbol LaTeX</td>
+                                </tr>
+                                <tr>
+                                    <td>β</td>
+                                    <td>RELATED</td>
+                                    <td>Symbol Text</td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </dd>
                 
                 

--- a/docs/ontology/0000006/index.html
+++ b/docs/ontology/0000006/index.html
@@ -55,14 +55,16 @@
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                    </dt>
-                    <dd>
-                            <ul>
-                                    <li>R0 (<span class="muted">EXACT</span>)</li>
-                                    <li>basic reproductive number (<span class="muted">EXACT</span>)</li>
-                                    <li>basic reproductive rate (<span class="muted">EXACT</span>)</li>
-                            </ul>
-                    </dd>
+                        Exact                    </dt>
+                    <dd>R0</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Exact                    </dt>
+                    <dd>basic reproductive number</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Exact                    </dt>
+                    <dd>basic reproductive rate</dd>
                 
                 
                 

--- a/docs/ontology/0000007/index.html
+++ b/docs/ontology/0000007/index.html
@@ -55,13 +55,12 @@
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                    </dt>
-                    <dd>
-                            <ul>
-                                    <li>effective reproductive number (<span class="muted">EXACT</span>)</li>
-                                    <li>effective reproductive rate (<span class="muted">EXACT</span>)</li>
-                            </ul>
-                    </dd>
+                        Exact                    </dt>
+                    <dd>effective reproductive number</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Exact                    </dt>
+                    <dd>effective reproductive rate</dd>
                 
                 
                 

--- a/docs/ontology/0000008/index.html
+++ b/docs/ontology/0000008/index.html
@@ -55,10 +55,8 @@
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                    </dt>
-                    <dd>
-                            infectivity (<span class="muted">EXACT</span>)
-                    </dd>
+                        Exact                    </dt>
+                    <dd>infectivity</dd>
                 
                 
                 

--- a/docs/ontology/0000011/index.html
+++ b/docs/ontology/0000011/index.html
@@ -60,7 +60,7 @@
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
                         Related(Symbol Text)                    </dt>
-                    <dd>∂</dd>
+                    <dd>δ</dd>
                 
                 
                 

--- a/docs/ontology/0000011/index.html
+++ b/docs/ontology/0000011/index.html
@@ -53,6 +53,18 @@
                 </dd>
 
                 
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\delta_1</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\delta_2</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\delta_3</dd>
                 
                 
                 

--- a/docs/ontology/0000011/index.html
+++ b/docs/ontology/0000011/index.html
@@ -56,15 +56,7 @@
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
                         Related(Symbol LaTeX)                    </dt>
-                    <dd>\delta_1</dd>
-                    <dt>
-                        <span class="badge badge-primary">Synonym</span>
-                        Related(Symbol LaTeX)                    </dt>
-                    <dd>\delta_2</dd>
-                    <dt>
-                        <span class="badge badge-primary">Synonym</span>
-                        Related(Symbol LaTeX)                    </dt>
-                    <dd>\delta_3</dd>
+                    <dd>\delta</dd>
                 
                 
                 

--- a/docs/ontology/0000011/index.html
+++ b/docs/ontology/0000011/index.html
@@ -57,6 +57,10 @@
                         <span class="badge badge-primary">Synonym</span>
                         Related(Symbol LaTeX)                    </dt>
                     <dd>\delta</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol Text)                    </dt>
+                    <dd>∂</dd>
                 
                 
                 

--- a/docs/ontology/0000012/index.html
+++ b/docs/ontology/0000012/index.html
@@ -29,7 +29,7 @@
             padding-top: 1em;
             background-color: #f5f5f5;
         }
-    </style>    <title>incubation time</title></head>
+    </style>    <title>vaccination rate</title></head>
 
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -42,32 +42,20 @@
 <div class="card">
         <h5 class="card-header">
             <span class="badge badge-info">Term</span>
-            incubation time
+            vaccination rate
         </h5>
         <div class="card-body">
-                <p>The length of time after which an infected person shows symptoms of disease.</p>
+                <p>The rate at which individuals take up vaccination.</p>
             <dl>
                 <dt>Local Unique Identifier</dt>
                 <dd>
-                    <a href="http://34.230.33.149:8772/askemo:0000010">0000010</a>
+                    <a href="http://34.230.33.149:8772/askemo:0000012">0000012</a>
                 </dd>
 
                 
-                    <dt>
-                        <span class="badge badge-primary">Synonym</span>
-                        Exact                    </dt>
-                    <dd>incubation period</dd>
                 
                 
                 
-                    <dt><span class="badge badge-primary">Xref</span> Infectious Disease Ontology</dt>
-                    <dd><a href="https://bioregistry.io/ido:0000519"><code>ido:0000519</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Malaria Ontology</dt>
-                    <dd><a href="https://bioregistry.io/idomal:0000355"><code>idomal:0000355</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Ontology for vector surveillance and management</dt>
-                    <dd><a href="https://bioregistry.io/vsmo:0000499"><code>vsmo:0000499</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Apollo Structured Vocabulary</dt>
-                    <dd><a href="https://bioregistry.io/apollosv:00000317"><code>apollosv:00000317</code></a></dd>
                     <dt>
                         <span class="badge badge-primary">Property</span>
                         suggested_data_type
@@ -80,7 +68,7 @@
                         suggested_unit
                     </dt>
                     <dd>
-                            day
+                            1 / day
                     </dd>
                     <dt>
                         <span class="badge badge-primary">Property</span>

--- a/docs/ontology/0000013/index.html
+++ b/docs/ontology/0000013/index.html
@@ -29,7 +29,7 @@
             padding-top: 1em;
             background-color: #f5f5f5;
         }
-    </style>    <title>incubation time</title></head>
+    </style>    <title>recovery rate</title></head>
 
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -42,32 +42,36 @@
 <div class="card">
         <h5 class="card-header">
             <span class="badge badge-info">Term</span>
-            incubation time
+            recovery rate
         </h5>
         <div class="card-body">
-                <p>The length of time after which an infected person shows symptoms of disease.</p>
+                <p>The rate at which individuals recover after being infected.</p>
             <dl>
                 <dt>Local Unique Identifier</dt>
                 <dd>
-                    <a href="http://34.230.33.149:8772/askemo:0000010">0000010</a>
+                    <a href="http://34.230.33.149:8772/askemo:0000013">0000013</a>
                 </dd>
 
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                        Exact                    </dt>
-                    <dd>incubation period</dd>
+                        Related(Symbol Text)                    </dt>
+                    <dd>γ</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\gamma_1</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\gamma_2</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\delta_4</dd>
                 
                 
                 
-                    <dt><span class="badge badge-primary">Xref</span> Infectious Disease Ontology</dt>
-                    <dd><a href="https://bioregistry.io/ido:0000519"><code>ido:0000519</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Malaria Ontology</dt>
-                    <dd><a href="https://bioregistry.io/idomal:0000355"><code>idomal:0000355</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Ontology for vector surveillance and management</dt>
-                    <dd><a href="https://bioregistry.io/vsmo:0000499"><code>vsmo:0000499</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Apollo Structured Vocabulary</dt>
-                    <dd><a href="https://bioregistry.io/apollosv:00000317"><code>apollosv:00000317</code></a></dd>
                     <dt>
                         <span class="badge badge-primary">Property</span>
                         suggested_data_type
@@ -80,7 +84,7 @@
                         suggested_unit
                     </dt>
                     <dd>
-                            day
+                            1 / day
                     </dd>
                     <dt>
                         <span class="badge badge-primary">Property</span>

--- a/docs/ontology/0000013/index.html
+++ b/docs/ontology/0000013/index.html
@@ -60,15 +60,7 @@
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
                         Related(Symbol LaTeX)                    </dt>
-                    <dd>\gamma_1</dd>
-                    <dt>
-                        <span class="badge badge-primary">Synonym</span>
-                        Related(Symbol LaTeX)                    </dt>
-                    <dd>\gamma_2</dd>
-                    <dt>
-                        <span class="badge badge-primary">Synonym</span>
-                        Related(Symbol LaTeX)                    </dt>
-                    <dd>\delta_4</dd>
+                    <dd>\gamma</dd>
                 
                 
                 

--- a/docs/ontology/0000014/index.html
+++ b/docs/ontology/0000014/index.html
@@ -29,7 +29,7 @@
             padding-top: 1em;
             background-color: #f5f5f5;
         }
-    </style>    <title>incubation time</title></head>
+    </style>    <title>hospital discharge rate</title></head>
 
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -42,32 +42,28 @@
 <div class="card">
         <h5 class="card-header">
             <span class="badge badge-info">Term</span>
-            incubation time
+            hospital discharge rate
         </h5>
         <div class="card-body">
-                <p>The length of time after which an infected person shows symptoms of disease.</p>
+                <p>The rate at which recovered hospitalized individuals are released from hospital.</p>
             <dl>
                 <dt>Local Unique Identifier</dt>
                 <dd>
-                    <a href="http://34.230.33.149:8772/askemo:0000010">0000010</a>
+                    <a href="http://34.230.33.149:8772/askemo:0000014">0000014</a>
                 </dd>
 
                 
                     <dt>
                         <span class="badge badge-primary">Synonym</span>
-                        Exact                    </dt>
-                    <dd>incubation period</dd>
+                        Related(Symbol LaTeX)                    </dt>
+                    <dd>\tau</dd>
+                    <dt>
+                        <span class="badge badge-primary">Synonym</span>
+                        Related(Symbol Text)                    </dt>
+                    <dd>𝜏</dd>
                 
                 
                 
-                    <dt><span class="badge badge-primary">Xref</span> Infectious Disease Ontology</dt>
-                    <dd><a href="https://bioregistry.io/ido:0000519"><code>ido:0000519</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Malaria Ontology</dt>
-                    <dd><a href="https://bioregistry.io/idomal:0000355"><code>idomal:0000355</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Ontology for vector surveillance and management</dt>
-                    <dd><a href="https://bioregistry.io/vsmo:0000499"><code>vsmo:0000499</code></a></dd>
-                    <dt><span class="badge badge-primary">Xref</span> Apollo Structured Vocabulary</dt>
-                    <dd><a href="https://bioregistry.io/apollosv:00000317"><code>apollosv:00000317</code></a></dd>
                     <dt>
                         <span class="badge badge-primary">Property</span>
                         suggested_data_type
@@ -80,7 +76,7 @@
                         suggested_unit
                     </dt>
                     <dd>
-                            day
+                            1 / day
                     </dd>
                     <dt>
                         <span class="badge badge-primary">Property</span>

--- a/docs/ontology/index.html
+++ b/docs/ontology/index.html
@@ -47,7 +47,7 @@
             <p>A custom ontology to support the epidemiology use case in ASKEM.</p>
             <dl>
                 <dt>Number of Terms</dt>
-                <dd>11</dd>
+                <dd>12</dd>
                 <dt>MIRA Epi Metaregistry</dt>
                 <dd>
                     <a href="http://34.230.33.149:8772/askemo">
@@ -147,6 +147,13 @@
                         </td>
                         <td align="right"><a href="0000011">0000011</a></td>
                         <td>progression rate</td>
+                    </tr>
+                    <tr>
+                        <td>
+                                Term
+                        </td>
+                        <td align="right"><a href="0000012">0000012</a></td>
+                        <td>vaccination rate</td>
                     </tr>
                 </tbody>
             </table>

--- a/docs/ontology/index.html
+++ b/docs/ontology/index.html
@@ -47,7 +47,7 @@
             <p>A custom ontology to support the epidemiology use case in ASKEM.</p>
             <dl>
                 <dt>Number of Terms</dt>
-                <dd>12</dd>
+                <dd>14</dd>
                 <dt>MIRA Epi Metaregistry</dt>
                 <dd>
                     <a href="http://34.230.33.149:8772/askemo">
@@ -55,9 +55,36 @@
                     </a>
                 </dd>
             </dl>
-
         </div>
     </div>
+
+    <div class="card" style="margin-top: 1em;">
+            <h5 class="card-header">
+                Synonym Type Definitions
+            </h5>
+            <table class="table table-striped">
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Specificity</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>referenced_by_latex</td>
+                        <td>Symbol LaTeX</td>
+                        <td>RELATED</td>
+                    </tr>
+                    <tr>
+                        <td>referenced_by_symbol</td>
+                        <td>Symbol Text</td>
+                        <td>RELATED</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
         <div class="card" style="margin-top: 1em;">
             <h5 class="card-header">
                 Terms, Relations, and Properties
@@ -68,6 +95,7 @@
                     <th>Type</th>
                     <th>Local Identifier</th>
                     <th>Name</th>
+                    <th>Definition</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -77,6 +105,7 @@
                         </td>
                         <td align="right"><a href="0000001">0000001</a></td>
                         <td>population</td>
+                        <td>The number of people who live in an area being modeled.</td>
                     </tr>
                     <tr>
                         <td>
@@ -84,6 +113,7 @@
                         </td>
                         <td align="right"><a href="0000002">0000002</a></td>
                         <td>doubling time</td>
+                        <td>The length of time that an infectious disease requires to double in incidence.</td>
                     </tr>
                     <tr>
                         <td>
@@ -91,6 +121,7 @@
                         </td>
                         <td align="right"><a href="0000003">0000003</a></td>
                         <td>recovery time</td>
+                        <td>The length of time an infected individual needs to recover after being infected.</td>
                     </tr>
                     <tr>
                         <td>
@@ -98,6 +129,7 @@
                         </td>
                         <td align="right"><a href="0000004">0000004</a></td>
                         <td>infectious time</td>
+                        <td>The length of time an infected individual is infectious after being infected.</td>
                     </tr>
                     <tr>
                         <td>
@@ -105,6 +137,7 @@
                         </td>
                         <td align="right"><a href="0000005">0000005</a></td>
                         <td>effective contact rate</td>
+                        <td>The average number of contacts per person per time which result in an infection. Can be calculated as the transmissibility multiplied by the average number of people exposed.</td>
                     </tr>
                     <tr>
                         <td>
@@ -112,6 +145,7 @@
                         </td>
                         <td align="right"><a href="0000006">0000006</a></td>
                         <td>basic reproduction number</td>
+                        <td>Represents the average number of people who will be infected by any given infected person where all individuals are susceptible to infection. It is calculated as the ratio of the effective contact rate and then mean recovery time.</td>
                     </tr>
                     <tr>
                         <td>
@@ -119,6 +153,7 @@
                         </td>
                         <td align="right"><a href="0000007">0000007</a></td>
                         <td>effective reproduction number</td>
+                        <td>Represents the average number of people who will be infected by any given infected person in a partially susceptible population. It is calculated by multiplying the basic reproduction number by the fraction of the population that is susceptible.</td>
                     </tr>
                     <tr>
                         <td>
@@ -126,6 +161,7 @@
                         </td>
                         <td align="right"><a href="0000008">0000008</a></td>
                         <td>transmissibility</td>
+                        <td>The ability of a person infected with a given pathogen to infect a susceptible person.</td>
                     </tr>
                     <tr>
                         <td>
@@ -133,6 +169,7 @@
                         </td>
                         <td align="right"><a href="0000009">0000009</a></td>
                         <td>virulence</td>
+                        <td>The likelihood of a disease occurring due to a pathogen. Virulence is measured relative to a standard, such as another pathogen or host.</td>
                     </tr>
                     <tr>
                         <td>
@@ -140,6 +177,7 @@
                         </td>
                         <td align="right"><a href="0000010">0000010</a></td>
                         <td>incubation time</td>
+                        <td>The length of time after which an infected person shows symptoms of disease.</td>
                     </tr>
                     <tr>
                         <td>
@@ -147,6 +185,7 @@
                         </td>
                         <td align="right"><a href="0000011">0000011</a></td>
                         <td>progression rate</td>
+                        <td>The rate at which an infected person develops symptoms of disease. Inverse of the incubation time.</td>
                     </tr>
                     <tr>
                         <td>
@@ -154,6 +193,23 @@
                         </td>
                         <td align="right"><a href="0000012">0000012</a></td>
                         <td>vaccination rate</td>
+                        <td>The rate at which individuals take up vaccination.</td>
+                    </tr>
+                    <tr>
+                        <td>
+                                Term
+                        </td>
+                        <td align="right"><a href="0000013">0000013</a></td>
+                        <td>recovery rate</td>
+                        <td>The rate at which individuals recover after being infected.</td>
+                    </tr>
+                    <tr>
+                        <td>
+                                Term
+                        </td>
+                        <td align="right"><a href="0000014">0000014</a></td>
+                        <td>hospital discharge rate</td>
+                        <td>The rate at which recovered hospitalized individuals are released from hospital.</td>
                     </tr>
                 </tbody>
             </table>

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -26,6 +26,8 @@ SYNONYM_TYPES = {
     "oboInOwl:hasBroadSynonym": "BROAD",
     "oboInOwl:hasNarrowSynonym": "NARROW",
     "oboInOwl:hasRelatedSynonym": "RELATED",
+    "askemo:referencedByLatex": "RELATED",
+    "askemo:referencedBySymbol": "RELATED",
     # Don't include these since they are lower specificity
     # "oboInOwl:hasSynonym": "RELATED",
 }

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -20,14 +20,17 @@ EQUIVALENCE_TYPES = {
     #  "owl:equivalentTo",
 }
 
+REFERENCED_BY_LATEX = "referenced_by_latex"
+REFERENCED_BY_SYMBOL = "referenced_by_symbol"
+
 #: Keys are values in ASKEMO and values are OBO specificities
 SYNONYM_TYPES = {
     "oboInOwl:hasExactSynonym": "EXACT",
     "oboInOwl:hasBroadSynonym": "BROAD",
     "oboInOwl:hasNarrowSynonym": "NARROW",
     "oboInOwl:hasRelatedSynonym": "RELATED",
-    "askemo:referencedByLatex": "RELATED",
-    "askemo:referencedBySymbol": "RELATED",
+    REFERENCED_BY_LATEX: "RELATED",
+    REFERENCED_BY_SYMBOL: "RELATED",
     # Don't include these since they are lower specificity
     # "oboInOwl:hasSynonym": "RELATED",
 }

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -98,11 +98,11 @@
         "value": "transmission rate"
       },
       {
-        "type": "askemo:referencedByLatex",
+        "type": "referenced_by_latex",
         "value": "\\beta"
       },
       {
-        "type": "askemo:referencedBySymbol",
+        "type": "referenced_by_symbol",
         "value": "β"
       }
     ],
@@ -248,6 +248,20 @@
     "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "1 / day",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\delta_1"
+      },
+      {
+        "type": "referenced_by_latex",
+        "value": "\\delta_2"
+      },
+      {
+        "type": "referenced_by_latex",
+        "value": "\\delta_3"
+      }
+    ],
     "type": "class"
   },
   {
@@ -266,7 +280,24 @@
     "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "1 / day",
-    "synonyms": [],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "γ"
+      },
+      {
+        "type": "referenced_by_latex",
+        "value": "\\gamma_1"
+      },
+      {
+        "type": "referenced_by_latex",
+        "value": "\\gamma_2"
+      },
+      {
+        "type": "referenced_by_latex",
+        "value": "\\delta_4"
+      }
+    ],
     "type": "class"
   },
   {
@@ -276,7 +307,16 @@
     "physical_min": 0.0,
     "suggested_data_type": "float",
     "suggested_unit": "1 / day",
-    "synonyms": [],
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\tau"
+      },
+      {
+        "type": "referenced_by_symbol",
+        "value": "𝜏"
+      }
+    ],
     "type": "class"
   }
 ]

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -251,15 +251,7 @@
     "synonyms": [
       {
         "type": "referenced_by_latex",
-        "value": "\\delta_1"
-      },
-      {
-        "type": "referenced_by_latex",
-        "value": "\\delta_2"
-      },
-      {
-        "type": "referenced_by_latex",
-        "value": "\\delta_3"
+        "value": "\\delta"
       }
     ],
     "type": "class"
@@ -287,15 +279,7 @@
       },
       {
         "type": "referenced_by_latex",
-        "value": "\\gamma_1"
-      },
-      {
-        "type": "referenced_by_latex",
-        "value": "\\gamma_2"
-      },
-      {
-        "type": "referenced_by_latex",
-        "value": "\\delta_4"
+        "value": "\\gamma"
       }
     ],
     "type": "class"

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -252,6 +252,10 @@
       {
         "type": "referenced_by_latex",
         "value": "\\delta"
+      },
+      {
+        "type": "referenced_by_symbol",
+        "value": "∂"
       }
     ],
     "type": "class"

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -96,6 +96,14 @@
       {
         "type": "oboInOwl:hasExactSynonym",
         "value": "transmission rate"
+      },
+      {
+        "type": "askemo:referencedByLatex",
+        "value": "\\beta"
+      },
+      {
+        "type": "askemo:referencedBySymbol",
+        "value": "β"
       }
     ],
     "type": "class",

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -255,7 +255,7 @@
       },
       {
         "type": "referenced_by_symbol",
-        "value": "∂"
+        "value": "δ"
       }
     ],
     "type": "class"

--- a/mira/dkg/askemo/generate_site.py
+++ b/mira/dkg/askemo/generate_site.py
@@ -8,17 +8,18 @@ from pyobo.ssg import make_site
 from pyobo.struct import make_ad_hoc_ontology
 
 from mira.dkg import ASKEMO
-from mira.dkg.askemo.api import Term, get_askemo_terms, SYNONYM_TYPES
+from mira.dkg.askemo.api import Term, get_askemo_terms, SYNONYM_TYPES, REFERENCED_BY_LATEX, REFERENCED_BY_SYMBOL
 
 HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent.parent.parent.resolve()
 ONTOLOGY_DIRECTORY = ROOT.joinpath("docs", "ontology")
 
-SYMBOL_SYNONYM_TEXT_TYPEDEF = pyobo.SynonymTypeDef("askemo:referencedBySymbol", "Symbol Text", specificity="RELATED")
-SYMBOL_SYNONYM_LATEX_TYPEDEF = pyobo.SynonymTypeDef("askemo:referencedByLatex", "Symbol LaTeX", specificity="RELATED")
-SYNONYM_TYPEDEFS = {
-    s.id: s
-    for s in [SYMBOL_SYNONYM_LATEX_TYPEDEF, SYMBOL_SYNONYM_TEXT_TYPEDEF]
+SYMBOL_SYNONYM_TEXT_TYPEDEF = pyobo.SynonymTypeDef(REFERENCED_BY_SYMBOL, "Symbol Text", specificity="RELATED")
+SYMBOL_SYNONYM_LATEX_TYPEDEF = pyobo.SynonymTypeDef(REFERENCED_BY_LATEX, "Symbol LaTeX", specificity="RELATED")
+SYNONYM_TYPEDEFS = [SYMBOL_SYNONYM_LATEX_TYPEDEF, SYMBOL_SYNONYM_TEXT_TYPEDEF]
+SYNONYM_TYPEDEFS_DICT = {
+    synonym_typedef.id: synonym_typedef
+    for synonym_typedef in SYNONYM_TYPEDEFS
 }
 
 
@@ -44,7 +45,7 @@ def _get_term(term: Term) -> pyobo.Term:
             pyobo.Synonym(
                 name=synonym.value,
                 specificity=SYNONYM_TYPES[synonym.type],
-                type=SYNONYM_TYPEDEFS.get(synonym.type),
+                type=SYNONYM_TYPEDEFS_DICT.get(synonym.type),
             )
             for synonym in term.synonyms or []
         ],
@@ -64,6 +65,7 @@ def main():
         ASKEMO.prefix,
         ASKEMO.name,
         terms=[_get_term(term) for term in get_askemo_terms().values()],
+        _synonym_typedefs=SYNONYM_TYPEDEFS,
     )
     make_site(
         obo,

--- a/mira/dkg/askemo/generate_site.py
+++ b/mira/dkg/askemo/generate_site.py
@@ -14,6 +14,13 @@ HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent.parent.parent.resolve()
 ONTOLOGY_DIRECTORY = ROOT.joinpath("docs", "ontology")
 
+SYMBOL_SYNONYM_TEXT_TYPEDEF = pyobo.SynonymTypeDef("askemo:referencedBySymbol", "Symbol Text", specificity="RELATED")
+SYMBOL_SYNONYM_LATEX_TYPEDEF = pyobo.SynonymTypeDef("askemo:referencedByLatex", "Symbol LaTeX", specificity="RELATED")
+SYNONYM_TYPEDEFS = {
+    s.id: s
+    for s in [SYMBOL_SYNONYM_LATEX_TYPEDEF, SYMBOL_SYNONYM_TEXT_TYPEDEF]
+}
+
 
 def _get_term(term: Term) -> pyobo.Term:
     properties = {}
@@ -37,6 +44,7 @@ def _get_term(term: Term) -> pyobo.Term:
             pyobo.Synonym(
                 name=synonym.value,
                 specificity=SYNONYM_TYPES[synonym.type],
+                type=SYNONYM_TYPEDEFS.get(synonym.type),
             )
             for synonym in term.synonyms or []
         ],


### PR DESCRIPTION
This PR does the following:

1. Introduces two new synonym types: `referenced_by_symbol` and `referenced_by_latex`
2. Curates several examples of these synonym types for [`askem:0000005` (effective contact rate)](http://34.230.33.149:8772/askem:0000005), [`askem:0000013` (recovery rate)](http://34.230.33.149:8772/askem:0000013), and [`askem:0000014` (hospital discharge rate)](http://34.230.33.149:8772/askem:0000014) from the examples for the demo
3. Rebuilds the static site (note that 12, 13, and 14 are new documents in this PR - note that the links for them above won't work until this PR is merged)
4. Takes advantages of some new PyOBO features for static site generation from https://github.com/pyobo/pyobo/pull/138