### PR TITLE
Add transitive closure endpoint

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from mira.dkg.client import Entity, AskemEntity
+from mira.dkg.utils import DKG_REFINER_RELS
 
 __all__ = [
     "api_blueprint",
@@ -91,6 +92,25 @@ def get_entity(
 def get_lexical(request: Request):
     """Get lexical information (i.e., name, synonyms, and description) for all entities in the graph."""
     return request.app.state.client.get_lexical()
+
+
+@api_blueprint.get(
+    "/transitive_closure",
+    response_model=List[List[str]],
+    tags=["relations"],
+    response_description="A successful response contains a list namespace, "
+    "identifier pairs, representing a transitive closure of relations of the "
+    "requested type(s)",
+)
+def get_transitive_closure(
+    request: Request,
+    relation_types: List[str] = DKG_REFINER_RELS,
+):
+    """Get a transitive closure of the requested type(s)"""
+    return (
+        request.app.state.client.get_transitive_closure(rels=relation_types)
+        or []
+    )
 
 
 class RelationResponse(BaseModel):

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -1,6 +1,6 @@
 """API endpoints."""
 
-from typing import Any, List, Mapping, Optional, Tuple, Union
+from typing import Any, List, Mapping, Optional, Union
 
 from fastapi import APIRouter, Body, Path, Query, Request
 from neo4j.graph import Relationship

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -200,7 +200,7 @@ def get_relations(
                     "limit": 2,
                 },
             },
-            "increase path length of query": {
+            "any path length allowed": {
                 "summary": "Query a variable number of hops",
                 "description": "Distinct is given as true since there might be multiple paths from the source to each given target.",
                 "value": {

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -98,9 +98,12 @@ def get_lexical(request: Request):
     "/transitive_closure",
     response_model=List[List[str]],
     tags=["relations"],
-    response_description="A successful response contains a list namespace, "
-    "identifier pairs, representing a transitive closure of relations of the "
-    "requested type(s)",
+    response_description="A successful response contains a list of entity "
+    "pairs, representing a transitive closure set for the relations of the "
+    "requested type(s). The pairs are ordered as (successor, descendant). "
+    "Note that if rels are ones that point towards taxonomical parents "
+    "(e.g., subclassof, part_of), then the pairs are interpreted as "
+    "(taxonomical child, taxonomical ancestor).",
 )
 def get_transitive_closure(
     request: Request,

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -104,11 +104,18 @@ def get_lexical(request: Request):
 )
 def get_transitive_closure(
     request: Request,
-    relation_types: List[str] = DKG_REFINER_RELS,
+    relation_types: List[str] = Query(
+        ...,
+        description="A list of relation types to get a transitive closure for",
+        title="This is a title",
+        example=DKG_REFINER_RELS,
+    ),
 ):
     """Get a transitive closure of the requested type(s)"""
     return (
-        request.app.state.client.get_transitive_closure(rels=relation_types)
+        list(
+            request.app.state.client.get_transitive_closure(rels=relation_types)
+        )
         or []
     )
 

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -101,8 +101,8 @@ def get_lexical(request: Request):
     response_description="A successful response contains a list of entity "
     "pairs, representing a transitive closure set for the relations of the "
     "requested type(s). The pairs are ordered as (successor, descendant). "
-    "Note that if rels are ones that point towards taxonomical parents "
-    "(e.g., subclassof, part_of), then the pairs are interpreted as "
+    "Note that if the relations are ones that point towards taxonomical "
+    "parents (e.g., subclassof, part_of), then the pairs are interpreted as "
     "(taxonomical child, taxonomical ancestor).",
 )
 def get_transitive_closure(

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -53,6 +53,21 @@ class TestDKG(unittest.TestCase):
             )
         )
 
+    def test_get_transitive_closure(self):
+        """Test getting a transitive closure"""
+        # NOTE: takes ~45 s to run with local Neo4j deployment
+        response = self.client.get(
+            "/api/transitive_closure",
+            params={"relation_types": "subclassof"},
+        )
+        self.assertEqual(
+            response.status_code, 200, msg=f"Got status {response.status_code}"
+        )
+        res_json = response.json()
+        self.assertIsInstance(res_json, list)
+        self.assertEqual(len(res_json[0]), 2)
+        self.assertTrue(any(t[0].split(":")[0] == "go" for t in res_json))
+
     def test_get_relations(self):
         """Test getting relations."""
         spec = inspect.signature(get_relations)


### PR DESCRIPTION
This PR adds a new endpoint, `/api/transitive_closure`, in `mira/dkg/api.py` that allows for a download of a transitive closure of the provided relation types.

A test for the endpoint is also added.