### PR TITLE
Add prefix and label filters to search API

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -291,6 +291,22 @@ def search(
     q: str = Query(..., example="infect"),
     limit: int = 25,
     offset: int = 0,
+    prefixes: Optional[str] = Query(
+        default=None,
+        description="A comma-separated list of prefixes",
+        examples={
+            "no prefix filter": {
+                "summary": "Don't filter by prefix",
+                "value": None,
+            },
+            "search for units": {
+                "summary": "Search for units, which have Wikidata prefixes",
+                "value": "wikidata",
+            },
+        },
+    ),
 ):
     """Get nodes based on a search to their name/synonyms."""
-    return request.app.state.client.search(q, limit=limit, offset=offset)
+    return request.app.state.client.search(
+        q, limit=limit, offset=offset, prefixes=prefixes and prefixes.split(","),
+    )

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -305,8 +305,26 @@ def search(
             },
         },
     ),
+    labels: Optional[str] = Query(
+        default=None,
+        description="A comma-separated list of labels",
+        examples={
+            "no label filter": {
+                "summary": "Don't filter by label",
+                "value": None,
+            },
+            "search for units": {
+                "summary": "Search for units, which are labeled as `unit`",
+                "value": "unit",
+            },
+        },
+    ),
 ):
     """Get nodes based on a search to their name/synonyms."""
     return request.app.state.client.search(
-        q, limit=limit, offset=offset, prefixes=prefixes and prefixes.split(","),
+        q,
+        limit=limit,
+        offset=offset,
+        prefixes=prefixes and prefixes.split(","),
+        labels=labels and labels.split(","),
     )

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -382,8 +382,29 @@ class Neo4jClient:
         limit: int = 25,
         offset: int = 0,
         prefixes: Union[None, str, Iterable[str]] = None,
+        labels: Union[None, str, Iterable[str]] = None,
     ) -> List[Entity]:
-        """Search nodes for a given name or synonym substring."""
+        """Search nodes for a given name or synonym substring.
+
+        Parameters
+        ----------
+        query :
+            The query string to search (by a normalized substring search).
+        limit :
+            The number of results to return. Useful for pagination.
+        offset :
+            The offset of the entities to return. Useful for pagination.
+        prefixes :
+            A prefix or list of prefixes. If given, any result matching any
+            of the prefixes will be retained.
+        labels :
+            A label or list of labels used for filtering results. If given,
+            any result with any of the labels will be retained.
+
+        Returns
+        -------
+        A list of entity objects that match all of the query parameters
+        """
         rv = self._search(query)
         if prefixes is not None:
             prefix_set = {prefixes} if isinstance(prefixes, str) else set(prefixes)
@@ -391,6 +412,13 @@ class Neo4jClient:
                 entity
                 for entity in rv
                 if entity.prefix in prefix_set
+            ]
+        if labels is not None:
+            labels_set = {labels} if isinstance(labels, str) else set(labels)
+            rv = [
+                entity
+                for entity in rv
+                if any(label in labels_set for label in entity.labels)
             ]
         return rv[offset: offset + limit] if offset else rv[: limit]
 

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -376,9 +376,22 @@ class Neo4jClient:
                 counter_data[label] = res[0][0]
         return Counter(counter_data)
 
-    def search(self, query: str, limit: int = 25, offset: int = 0) -> List[Entity]:
+    def search(
+        self,
+        query: str,
+        limit: int = 25,
+        offset: int = 0,
+        prefixes: Union[None, str, Iterable[str]] = None,
+    ) -> List[Entity]:
         """Search nodes for a given name or synonym substring."""
         rv = self._search(query)
+        if prefixes is not None:
+            prefix_set = {prefixes} if isinstance(prefixes, str) else set(prefixes)
+            rv = [
+                entity
+                for entity in rv
+                if entity.prefix in prefix_set
+            ]
         return rv[offset: offset + limit] if offset else rv[: limit]
 
     @lru_cache(maxsize=20)

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -94,6 +94,26 @@ class TestDKG(unittest.TestCase):
         e2 = [Entity(**e) for e in res2.json()]
         self.assertEqual(e1[5:], e2)
 
+        res3 = self.client.get("/api/search", params={
+            "q": "count", "limit": 20, "offset": 5, "labels": "unit"
+        })
+        self.assertEqual(200, res3.status_code, msg=res3.content)
+        e3 = [Entity(**e) for e in res3.json()]
+        self.assertTrue(all(
+            "unit" in e.labels
+            for e in e3
+        ))
+
+        res4 = self.client.get("/api/search", params={
+            "q": "count", "limit": 20, "offset": 5, "prefixes": "wikidata"
+        })
+        self.assertEqual(200, res3.status_code, msg=res4.content)
+        e4 = [Entity(**e) for e in res3.json()]
+        self.assertTrue(all(
+            "wikidata" == e.prefix
+            for e in e4
+        ))
+
     def test_entity(self):
         """Test getting entities."""
         res = self.client.get("/api/entity/ido:0000463")


### PR DESCRIPTION
This PR enables filtering by prefix/label in the search API and includes unit tests.

For example, if you're interested to filter to nodes labeled as units (i.e. with the `unit` label), you can do the following:

http://localhost:5000/api/search?q=count&labels=unit

```json
[
  {"id":"wikidata:Q5176811","name":"Count per Liter","type":"class","obsolete":false,"synonyms":[],"xrefs":[],"labels":["unit","wikidata"],"properties":{}},
  {"id":"wikidata:Q52307097","name":"white blood cell count","type":"class","obsolete":false,"description":"number of white blood cells in the blood","synonyms":[],"xrefs":[],"labels":["unit","wikidata"],"properties":{}}
]
```

Similarly, you can use the query parameter `prefixes` to filter by prefixes, such as if you want to get content from the APOLLO Structured Vocabulary or Wikidata: 
http://localhost:5000/api/search?q=count&prefixes=wikidata,apollosv 


## Screenshot

Here's a screenshot of the new API documentation

<img width="1135" alt="Screenshot 2022-12-02 at 14 52 42" src="https://user-images.githubusercontent.com/5069736/205308150-8e47143e-98b9-43bb-971c-663d86945fec.png">

