### PR TITLE
Add root-path argument to uvicorn startup script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           pip install "tox<4.0.0"
       - name: Test with pytest
         run: |
-          export MIRA_REST_URL=http://34.230.33.149:8771
+          export MIRA_REST_URL=https://d1t1rcuq5sa4r0.cloudfront.net
           tox -e py
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v1

--- a/docker/Dockerfile.metaregistry
+++ b/docker/Dockerfile.metaregistry
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-ARG version=2022-11-28
+ARG version=2022-12-08
 ARG domain=epi
 
 RUN python -m pip install --upgrade pip && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,3 +47,7 @@ Once the build finished, you can run the container locally as:
 ```shell
 docker run --detach -p 8772:8772 --name mira_metaregistry mira_metaregistry:latest
 ```
+
+Optionally, add the argument `-e ROOT_PATH='/prefix'` to run the metaregistry under a path prefix. This is useful e.g. 
+wh en deploying the metaregistry together with other resources behind a proxy (Cloud Front, load balancer + nginx, 
+etc).

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,9 +48,13 @@ Once the build finished, you can run the container locally as:
 docker run --detach -p 8772:8772 --name mira_metaregistry mira_metaregistry:latest
 ```
 
-Optionally, add the argument `-e ROOT_PATH='/prefix'` to run the metaregistry under a path prefix. This is useful e.g. 
-wh en deploying the metaregistry together with other resources behind a proxy (Cloud Front, load balancer + nginx, 
-etc).
+Optionally, add the arguments `-e ROOT_PATH='/prefix'` and/or `-e BASE_URL=d1t1rcuq5sa4r0.cloudfront.net` to run the
+metaregistry under a path prefix and/or changing the api-docs base url, respectively. This is useful e.g. when
+deploying the metaregistry together with other resources behind a proxy (Cloud Front, load balancer + nginx, etc):
+
+```shell
+docker run --detach -p 8772:8772 -e ROOT_PATH='/reg' -e BASE_URL=d1t1rcuq5sa4r0.cloudfront.net mira_metaregistry:latest
+```
 
 ## Important Note on Path Prefix Behavior
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,3 +51,31 @@ docker run --detach -p 8772:8772 --name mira_metaregistry mira_metaregistry:late
 Optionally, add the argument `-e ROOT_PATH='/prefix'` to run the metaregistry under a path prefix. This is useful e.g. 
 wh en deploying the metaregistry together with other resources behind a proxy (Cloud Front, load balancer + nginx, 
 etc).
+
+## Important Note on Path Prefix Behavior
+
+Both the domain knowledge graph and the metaregistry are able to run with path prefixes. They do however behave 
+differently in one very important aspect: the domain knowledge graph app, which runs on FastAPI, assumes that the 
+proxy strips the path prefix, while the metaregistry app, which runs with Flask does not. The main reason for this is 
+that FastAPI has a simple setting that turns on 'path prefix'-mode and sets up the API and the swagger documentation 
+to automatically assume this
+(see more [here](https://fastapi.tiangolo.com/advanced/behind-a-proxy/#proxy-with-a-stripped-path-prefix)). For Flask 
+on the other hand, there is no single place that does all the setup, and the dependencies for the metaregistry 
+currently makes it rather difficult to do this. For now, the setup simply adds a path prefix and the app will then run 
+assuming the proxy doesn't strip the prefix.
+
+To summarize:
+
+DKG app, when using path prefix:
+```text
+Browser on https://d1t1rcuq5sa4r0.cloudfront.net/prefix/path -> 
+Proxy on http://0.0.0.0:1234/prefix/path -> 
+Server on http://0.0.0.0:8771/path
+```
+
+Metaregistry app, when using path prefix:
+```text
+Browser on https://d1t1rcuq5sa4r0.cloudfront.net/prefix/path -> 
+Proxy on http://0.0.0.0:1234/prefix/path -> 
+Server on http://0.0.0.0:8772/prefix/path
+```

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -2,4 +2,8 @@
 neo4j start
 sleep 100
 neo4j status
-uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app
+if [ "${ROOT_PATH}" ]; then
+  uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app --root-path "${ROOT_PATH}"
+else
+  uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app
+fi

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -3,7 +3,9 @@ neo4j start
 sleep 100
 neo4j status
 if [ "${ROOT_PATH}" ]; then
+  echo "Running with root path set to ${ROOT_PATH}"
   uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app --root-path "${ROOT_PATH}"
 else
+  echo 'No root path set in environment, running at "/"'
   uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app
 fi

--- a/mira/dkg/metaregistry/cli.py
+++ b/mira/dkg/metaregistry/cli.py
@@ -16,6 +16,9 @@ __all__ = ["main"]
 @click.option("--host", default="0.0.0.0", show_default=True)
 @click.option("--port", default=5000, type=int, show_default=True)
 @click.option("--config", type=Path, help="Path to custom metaregistry configuration.")
+@click.option("--client-base-url", default="",
+              help="Domain name for deployment e.g.: "
+                   "d1t1rcuq5sa4r0.cloudfront.net")
 @click.option("--root-path", type=str, required=False, default="",
               help="Set a different root path than the default, e.g. when "
                    "running behind a proxy. The root path can also be set "
@@ -32,6 +35,7 @@ def main(
     host: str,
     port: int,
     config: Path,
+    client_base_url: str,
     root_path: str,
     with_gunicorn: bool,
     workers: int,
@@ -49,7 +53,12 @@ def main(
     else:
         click.secho(f"Using root path '{root_path}' from command line option",
                     fg="yellow", bold=True)
-    app = get_app(config=config, root_path=root_path)
+    if client_base_url:
+        click.echo(f"Domain name set to {client_base_url}")
+
+    app = get_app(
+        config=config, root_path=root_path, client_base_url=client_base_url
+    )
     run_app(app, host=host, port=str(port), with_gunicorn=with_gunicorn, workers=workers)
 
 

--- a/mira/dkg/metaregistry/cli.py
+++ b/mira/dkg/metaregistry/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import click
 from more_click import run_app, with_gunicorn_option, workers_option
 
-from mira.dkg.metaregistry.utils import get_app
+from mira.dkg.metaregistry.utils import get_app, PrefixMiddleware
 
 __all__ = ["main"]
 
@@ -42,7 +42,10 @@ def main(
             print(f"No {root_path} set, app's root will be at '/'")
     else:
         print(f"Using root path {root_path}")
-    app = get_app(config=config, root_prefix=root_path)
+    app = get_app(config=config)
+    if root_path:
+        prefixed_app = PrefixMiddleware(app, prefix=root_path)
+        app = prefixed_app
     run_app(app, host=host, port=str(port), with_gunicorn=with_gunicorn, workers=workers)
 
 

--- a/mira/dkg/metaregistry/cli.py
+++ b/mira/dkg/metaregistry/cli.py
@@ -16,17 +16,21 @@ __all__ = ["main"]
 @click.option("--host", default="0.0.0.0", show_default=True)
 @click.option("--port", default=5000, type=int, show_default=True)
 @click.option("--config", type=Path, help="Path to custom metaregistry configuration.")
+@click.option("--root-path", type=str, help="Set a different root path than "
+                                            "the default, e.g. when running "
+                                            "behind a proxy.")
 @workers_option
 @with_gunicorn_option
 def main(
     host: str,
     port: int,
     config: Path,
+    root_path: str,
     with_gunicorn: bool,
     workers: int,
 ):
     """Run a custom Bioregistry instance based on a MIRA DKG."""
-    app = get_app(config=config)
+    app = get_app(config=config, root_prefix=root_path)
     run_app(app, host=host, port=str(port), with_gunicorn=with_gunicorn, workers=workers)
 
 

--- a/mira/dkg/metaregistry/cli.py
+++ b/mira/dkg/metaregistry/cli.py
@@ -24,7 +24,8 @@ __all__ = ["main"]
                    "precedence over 'ROOT_PATH'. Note that setting this "
                    "assumes that the prefixed path *is* forwarded to the "
                    "app, meaning the proxy server (cloudfront, nginx) "
-                   "*should not* strip the prefix.")
+                   "*should not* strip the prefix, which is normally what's "
+                   "done.")
 @workers_option
 @with_gunicorn_option
 def main(

--- a/mira/dkg/metaregistry/cli.py
+++ b/mira/dkg/metaregistry/cli.py
@@ -16,10 +16,10 @@ __all__ = ["main"]
 @click.option("--host", default="0.0.0.0", show_default=True)
 @click.option("--port", default=5000, type=int, show_default=True)
 @click.option("--config", type=Path, help="Path to custom metaregistry configuration.")
-@click.option("--client-base-url", default="",
+@click.option("--client-base-url", default="", envvar="BASE_URL",
               help="Domain name for deployment e.g.: "
                    "d1t1rcuq5sa4r0.cloudfront.net")
-@click.option("--root-path", type=str, required=False, default="",
+@click.option("--root-path", default="", envvar="ROOT_PATH",
               help="Set a different root path than the default, e.g. when "
                    "running behind a proxy. The root path can also be set "
                    "via the environment using 'ROOT_PATH' for use in e.g. a "
@@ -41,18 +41,9 @@ def main(
     workers: int,
 ):
     """Run a custom Bioregistry instance based on a MIRA DKG."""
-    if not root_path:
-        import os
-        if os.environ.get("ROOT_PATH"):
-            root_path = os.environ["ROOT_PATH"]
-            click.secho(f"Using root path {root_path} from environment",
-                        fg="green", bold=True)
-        else:
-            click.echo("No root_path set, app's root will be at '/'")
+    if root_path:
+        click.echo(f"Using root path {root_path}")
 
-    else:
-        click.secho(f"Using root path '{root_path}' from command line option",
-                    fg="yellow", bold=True)
     if client_base_url:
         click.echo(f"Domain name set to {client_base_url}")
 

--- a/mira/dkg/metaregistry/cli.py
+++ b/mira/dkg/metaregistry/cli.py
@@ -16,9 +16,12 @@ __all__ = ["main"]
 @click.option("--host", default="0.0.0.0", show_default=True)
 @click.option("--port", default=5000, type=int, show_default=True)
 @click.option("--config", type=Path, help="Path to custom metaregistry configuration.")
-@click.option("--root-path", type=str, help="Set a different root path than "
-                                            "the default, e.g. when running "
-                                            "behind a proxy.")
+@click.option("--root-path", type=str, required=False, default="",
+              help="Set a different root path than the default, e.g. when "
+                   "running behind a proxy. The root path can also be set "
+                   "via the environment using 'ROOT_PATH' for use in e.g. a "
+                   "docker. If both are set, the --root-path option takes "
+                   "precedence over 'ROOT_PATH'.")
 @workers_option
 @with_gunicorn_option
 def main(
@@ -30,6 +33,15 @@ def main(
     workers: int,
 ):
     """Run a custom Bioregistry instance based on a MIRA DKG."""
+    if not root_path:
+        import os
+        if os.environ.get("ROOT_PATH"):
+            root_path = os.environ["ROOT_PATH"]
+            print(f"Using root path {root_path} from environment")
+        else:
+            print(f"No {root_path} set, app's root will be at '/'")
+    else:
+        print(f"Using root path {root_path}")
     app = get_app(config=config, root_prefix=root_path)
     run_app(app, host=host, port=str(port), with_gunicorn=with_gunicorn, workers=workers)
 

--- a/mira/dkg/metaregistry/utils.py
+++ b/mira/dkg/metaregistry/utils.py
@@ -30,7 +30,7 @@ def parse_config(path: Path) -> Config:
 
 
 def get_app(
-    config: Union[None, str, Path, Config] = None, root_prefix: str = ""
+    config: Union[None, str, Path, Config] = None
 ) -> Flask:
     """Get the MIRA metaregistry app."""
     if config is None:
@@ -43,10 +43,7 @@ def get_app(
         config = parse_config(config)
 
     manager = Manager(registry=config.registry, collections=config.collections, contexts={})
-    flask_app = bioregistry.app.impl.get_app(manager=manager, config=config.web)
-    if root_prefix:
-        flask_app.config["APPLICATION_ROOT"] = root_prefix
-    return flask_app
+    return bioregistry.app.impl.get_app(manager=manager, config=config.web)
 
 
 class PrefixMiddleware(object):

--- a/mira/dkg/metaregistry/utils.py
+++ b/mira/dkg/metaregistry/utils.py
@@ -14,7 +14,7 @@ from flask import Flask
 
 from mira.dkg.models import Config
 
-__all__ = ["get_app", "PrefixMiddleware"]
+__all__ = ["get_app"]
 
 
 def parse_config(path: Path) -> Config:

--- a/mira/dkg/metaregistry/utils.py
+++ b/mira/dkg/metaregistry/utils.py
@@ -30,7 +30,7 @@ def parse_config(path: Path) -> Config:
 
 
 def get_app(
-    config: Union[None, str, Path, Config] = None,
+    config: Union[None, str, Path, Config] = None, root_prefix: str = ""
 ) -> Flask:
     """Get the MIRA metaregistry app."""
     if config is None:
@@ -43,4 +43,7 @@ def get_app(
         config = parse_config(config)
 
     manager = Manager(registry=config.registry, collections=config.collections, contexts={})
-    return bioregistry.app.impl.get_app(manager=manager, config=config.web)
+    flask_app = bioregistry.app.impl.get_app(manager=manager, config=config.web)
+    if root_prefix:
+        flask_app.config["APPLICATION_ROOT"] = root_prefix
+    return flask_app

--- a/mira/dkg/metaregistry/utils.py
+++ b/mira/dkg/metaregistry/utils.py
@@ -32,8 +32,8 @@ def parse_config(path: Path) -> Config:
 
 def simple(env, resp):
     """A simple mock root endpoint to mount another flask app to"""
-    resp(b'200 OK', [(b'Content-Type', b'text/plain')])
-    return [b'Hello WSGI World']
+    resp('200 OK', [('Content-Type', 'text/plain')])
+    return [b'Metaregistry root']
 
 
 def get_app(

--- a/mira/dkg/metaregistry/utils.py
+++ b/mira/dkg/metaregistry/utils.py
@@ -50,7 +50,11 @@ def get_app(
         config = parse_config(config)
 
     manager = Manager(
-        registry=config.registry, collections=config.collections, contexts={}
+        registry=config.registry, collections=config.collections,
+        contexts={}, base_url="localhost:8772"
+        # fixme: 1. how to set http vs https? 2. This needs to be set to
+        #  whatever the public facing endpoint will be, i.e. the cloudfront
+        #  address, which probably needs to be hardcoded
     )
     app = bioregistry.app.impl.get_app(manager=manager, config=config.web)
     if root_path:

--- a/mira/dkg/metaregistry/utils.py
+++ b/mira/dkg/metaregistry/utils.py
@@ -54,6 +54,11 @@ def get_app(
     )
     app = bioregistry.app.impl.get_app(manager=manager, config=config.web)
     if root_path:
+        # Set basePath for swagger to know where to send example requests
+        if app.swag.template is None:
+            app.swag.template = {}
+        app.swag.template["basePath"] = root_path
+
         # Follows
         # https://stackoverflow.com/a/18967744/10478812 and
         # https://gist.github.com/svieira/3434cbcaf627e50a4808

--- a/mira/dkg/metaregistry/utils.py
+++ b/mira/dkg/metaregistry/utils.py
@@ -37,7 +37,9 @@ def simple(env, resp):
 
 
 def get_app(
-    config: Union[None, str, Path, Config] = None, root_path: str = ""
+    config: Union[None, str, Path, Config] = None,
+    root_path: str = "",
+    client_base_url: str = "",
 ) -> Flask:
     """Get the MIRA metaregistry app."""
     if config is None:
@@ -50,12 +52,13 @@ def get_app(
         config = parse_config(config)
 
     manager = Manager(
-        registry=config.registry, collections=config.collections,
-        contexts={}, base_url="localhost:8772"
-        # fixme: 1. how to set http vs https? 2. This needs to be set to
-        #  whatever the public facing endpoint will be, i.e. the cloudfront
-        #  address, which probably needs to be hardcoded
+        registry=config.registry, collections=config.collections, contexts={}
     )
+
+    if client_base_url:
+        # fixme: Set this better when the http-banana in bioregistry is fixed
+        manager.base_url = client_base_url
+
     app = bioregistry.app.impl.get_app(manager=manager, config=config.web)
     if root_path:
         # Set basePath for swagger to know where to send example requests


### PR DESCRIPTION
This PR adds the root path argument to the uvicorn startup script for the dkg. This allows the service to be run under a prefix, i.e. `/app` instead of directly at the root, `/`. An update to the metaregistry is also made to be able to run it under a prefix.

Adding `ROOT_PATH` when starting the docker that runs the dkg app should be enough to have the app run with the updated root path.

_Edit: converted to draft since this is still untested_