### PR TITLE
Pin `tox` in GHA to 3.x series

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo apt-get install graphviz libgraphviz-dev
           pip install --upgrade pip setuptools wheel
-          pip install tox
+          pip install "tox<4.0.0"
       - name: Test with pytest
         run: |
           export MIRA_REST_URL=http://34.230.33.149:8771


### PR DESCRIPTION
Unfortunately, there was just a new 4.0 release yesterday with major breaking changes, which also seemed to break the way we were passing environment variables. This PR pins to the 3.x series.