### PR TITLE
More caches

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -315,8 +315,8 @@ def is_ontological_child(
         child_curie=query.child_curie,
         parent_curie=query.parent_curie,
         is_child=request.app.state.refinement_closure.is_ontological_child(
-            query.child_curie,
-            query.parent_curie
+            child_curie=query.child_curie,
+            parent_curie=query.parent_curie
         )
     )
 

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -91,7 +91,7 @@ def get_entity(
 )
 def get_lexical(request: Request):
     """Get lexical information (i.e., name, synonyms, and description) for all entities in the graph."""
-    return request.app.state.client.get_lexical()
+    return request.app.state.lexical_dump
 
 
 @api_blueprint.get(

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -307,7 +307,7 @@ def is_ontological_child(
     request: Request,
     query: IsOntChildQuery = Body(
         ...,
-        example={"child_curie": "vo:0001113", "parent_cure": "obi:0000047"}
+        example={"child_curie": "vo:0001113", "parent_curie": "obi:0000047"},
     )
 ):
     """Check if one CURIE is an ontological child of another CURIE"""

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -281,6 +281,46 @@ def get_relations(
         return [RelationResponse(subject=s, predicate=p, object=o) for s, p, o in records]
 
 
+class IsOntChildResult(BaseModel):
+    """Result of a query to /is_ontological_child"""
+
+    child_curie: str = Field(..., description="The child CURIE")
+    parent_curie: str = Field(..., description="The parent CURIE")
+    is_child: bool = Field(..., description="True if the child CURIE is an "
+                                            "ontological child of the parent "
+                                            "CURIE")
+
+
+class IsOntChildQuery(BaseModel):
+    """Query for /is_ontological_child"""
+
+    child_curie: str = Field(..., description="The child CURIE")
+    parent_curie: str = Field(..., description="The parent CURIE")
+
+
+@api_blueprint.post(
+    "/is_ontological_child",
+    response_model=IsOntChildResult,
+    tags=["relations"]
+)
+def is_ontological_child(
+    request: Request,
+    query: IsOntChildQuery = Body(
+        ...,
+        example={"child_curie": "vo:0001113", "parent_cure": "obi:0000047"}
+    )
+):
+    """Check if one CURIE is an ontological child of another CURIE"""
+    return IsOntChildResult(
+        child_curie=query.child_curie,
+        parent_curie=query.parent_curie,
+        is_child=request.app.state.refinement_closure.is_ontological_child(
+            query.child_curie,
+            query.parent_curie
+        )
+    )
+
+
 @api_blueprint.get(
     "/search",
     response_model=List[Union[AskemEntity, Entity]],

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -115,12 +115,15 @@ def get_transitive_closure(
     ),
 ):
     """Get a transitive closure of the requested type(s)"""
-    return (
-        list(
+    # The closure of the refiner relations are cached in the app state and can
+    # be returned immediately
+    if set(relation_types) == set(DKG_REFINER_RELS):
+        return list(request.app.state.refinement_closure.transitive_closure)
+    # Other relations have to be queried for
+    else:
+        return list(
             request.app.state.client.get_transitive_closure(rels=relation_types)
-        )
-        or []
-    )
+        ) or []
 
 
 class RelationResponse(BaseModel):

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -360,7 +360,11 @@ class Neo4jClient:
 
         if isinstance(prefix, str):
             prefix = [prefix]
-        terms = list(itt.chain.from_iterable(self.get_grounder_terms(p) for p in prefix))
+        terms = list(
+            itt.chain.from_iterable(
+                self.get_grounder_terms(p) for p in tqdm(prefix)
+            )
+        )
         return Grounder(terms)
 
     def get_node_counter(self) -> Counter:
@@ -505,7 +509,7 @@ class Neo4jClient:
         g.add_edges_from([(n['id'], m['id']) for n, m in r])
         for node in g:
             transitive_closure |= {
-                (node, desc) for desc in networkx.descendants(g, node)
+                (node, desc) for desc in tqdm(networkx.descendants(g, node))
             }
         return transitive_closure
 

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -362,7 +362,9 @@ class Neo4jClient:
             prefix = [prefix]
         terms = list(
             itt.chain.from_iterable(
-                self.get_grounder_terms(p) for p in tqdm(prefix)
+                self.get_grounder_terms(p) for p in tqdm(
+                    prefix, desc="Caching grounding terms"
+                )
             )
         )
         return Grounder(terms)
@@ -503,13 +505,13 @@ class Neo4jClient:
         if not r:
             return None
 
-        logger.info('Building transitive closure...')
         transitive_closure = set()
         g = networkx.DiGraph()
         g.add_edges_from([(n['id'], m['id']) for n, m in r])
-        for node in g:
+        for node in tqdm(g, total=len(g.nodes),
+                         desc=f"Building transitive closure for {rels}"):
             transitive_closure |= {
-                (node, desc) for desc in tqdm(networkx.descendants(g, node))
+                (node, desc) for desc in networkx.descendants(g, node)
             }
         return transitive_closure
 

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     import gilda.grounder
     import gilda.term
 
-__all__ = ["Neo4jClient"]
+__all__ = ["Neo4jClient", "Entity"]
 
 logger = logging.getLogger(__name__)
 

--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -1,11 +1,12 @@
 """Utilities and constants for the MIRA app."""
 
 from dataclasses import dataclass
+from typing import List
 
 from gilda.grounder import Grounder
 
-from mira.dkg.client import Neo4jClient
-from mira.dkg.resources import SLIMS
+from mira.dkg.client import Neo4jClient, Entity
+from mira.metamodel.templates import RefinementClosure
 
 __all__ = [
     "MiraState",
@@ -20,6 +21,8 @@ class MiraState:
 
     client: Neo4jClient
     grounder: Grounder
+    refinement_closure: RefinementClosure
+    lexical_dump: List[Entity]
 
 
 #: A list of all prefixes used in MIRA

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -15,7 +15,7 @@ __all__ = [
     "ground_web",
     "search_web",
     "get_transitive_closure_web",
-    "is_ontological_child",
+    "is_ontological_child_web",
 ]
 
 
@@ -276,7 +276,7 @@ def get_transitive_closure_web(
     return {tuple(pair) for pair in res_json}
 
 
-def is_ontological_child(
+def is_ontological_child_web(
     child_curie: str, parent_curie: str, api_url: Optional[str] = None
 ) -> bool:
     """Check if one curie is a child term of another curie

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -297,8 +297,10 @@ def is_ontological_child(
         True if the assumption that `child_curie` is an ontological child of
         `parent_curie` holds
     """
-    rel_model = api.RelationQuery(
-        source_curie=child_curie, relations=DKG_REFINER_RELS, target_curie=parent_curie, limit=1
+    res_json = web_client(
+        "/is_ontological_child",
+        method="post",
+        query_json={"child_curie": child_curie, "parent_cure": parent_curie},
+        api_url=api_url
     )
-    res = get_relations_web(relations_model=rel_model, api_url=api_url)
-    return res is not None and len(res) > 0
+    return res_json["is_child"]

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -300,7 +300,7 @@ def is_ontological_child(
     res_json = web_client(
         "/is_ontological_child",
         method="post",
-        query_json={"child_curie": child_curie, "parent_cure": parent_curie},
+        query_json={"child_curie": child_curie, "parent_curie": parent_curie},
         api_url=api_url
     )
     return res_json["is_child"]

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -1,5 +1,5 @@
 """Neo4j client module."""
-
+import logging
 from textwrap import dedent
 
 import flask
@@ -14,6 +14,10 @@ from mira.dkg.model import model_blueprint
 from mira.dkg.ui import ui_blueprint
 from mira.dkg.utils import PREFIXES, MiraState
 from mira.metamodel.templates import RefinementClosure
+
+
+logger = logging.getLogger(__name__)
+
 
 __all__ = [
     "flask_app",
@@ -70,18 +74,23 @@ app.include_router(model_blueprint, prefix="/api")
 
 flask_app = flask.Flask(__name__)
 
-Bootstrap5(flask_app)
 
-# Set MIRA_NEO4J_URL in the environment
-# to point this somewhere specific
-client = Neo4jClient()
-app.state = flask_app.config["mira"] = MiraState(
-    client=client,
-    grounder=client.get_grounder(PREFIXES),
-    refinement_closure=RefinementClosure(client.get_transitive_closure()),
-    lexical_dump=client.get_lexical(),
-)
+@app.on_event("startup")
+def startup_event():
+    """Runs on startup of FastAPI"""
+    logger.info("Running app startup function")
+    Bootstrap5(flask_app)
 
-flask_app.register_blueprint(ui_blueprint)
+    # Set MIRA_NEO4J_URL in the environment
+    # to point this somewhere specific
+    client = Neo4jClient()
+    app.state = flask_app.config["mira"] = MiraState(
+        client=client,
+        grounder=client.get_grounder(PREFIXES),
+        refinement_closure=RefinementClosure(client.get_transitive_closure()),
+        lexical_dump=client.get_lexical(),
+    )
 
-app.mount("/", WSGIMiddleware(flask_app))
+    flask_app.register_blueprint(ui_blueprint)
+
+    app.mount("/", WSGIMiddleware(flask_app))

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -13,6 +13,7 @@ from mira.dkg.grounding import grounding_blueprint
 from mira.dkg.model import model_blueprint
 from mira.dkg.ui import ui_blueprint
 from mira.dkg.utils import PREFIXES, MiraState
+from mira.metamodel.templates import RefinementClosure
 
 __all__ = [
     "flask_app",
@@ -77,6 +78,8 @@ client = Neo4jClient()
 app.state = flask_app.config["mira"] = MiraState(
     client=client,
     grounder=client.get_grounder(PREFIXES),
+    refinement_closure=RefinementClosure(client.get_transitive_closure()),
+    lexical_dump=client.get_lexical(),
 )
 
 flask_app.register_blueprint(ui_blueprint)

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from mira.examples.sir import sir_parameterized
 from mira.dkg.model import model_blueprint
 from mira.dkg.api import RelationQuery
-from mira.dkg.web_client import is_ontological_child, get_relations_web
+from mira.dkg.web_client import is_ontological_child_web, get_relations_web
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion
 from mira.metamodel.ops import stratify
 from mira.metamodel.templates import TemplateModel, TemplateModelDelta, \
@@ -308,7 +308,7 @@ class TestModelApi(unittest.TestCase):
             template_model2=sir_templ_model_ctx,
             # If the dkg is out of sync with what is on the server,
             # the is_ontological_child functions might give different results
-            refinement_function=is_ontological_child,
+            refinement_function=is_ontological_child_web,
         )
         local_str = sorted_json_str(tmd.graph_as_json())
         resp_str = sorted_json_str(response.json())
@@ -342,7 +342,7 @@ class TestModelApi(unittest.TestCase):
             template_model2=sir_templ_model_ctx,
             # If the dkg is out of sync with what is on the server,
             # the is_ontological_child functions might give different results
-            refinement_function=is_ontological_child,
+            refinement_function=is_ontological_child_web,
         )
 
         tmpf = self._get_tmp_file(file_ending="png")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -4,7 +4,7 @@ from mira.metamodel import ControlledConversion, Concept, NaturalConversion, \
     NaturalDegradation, Template, GroupedControlledConversion, \
     GroupedControlledProduction
 from mira.metamodel.templates import Config
-from mira.dkg.web_client import is_ontological_child
+from mira.dkg.web_client import is_ontological_child_web
 
 # Provide to tests that are not meant to test ontological refinements;
 # returning False ensures that tests that check context refinements only
@@ -175,31 +175,31 @@ def test_concept_refinement_grounding():
     one_dim_spat_gnd_ctx = one_dim_spat_gnd.with_context(location="Stockholm")
     # test grounded
     assert one_dim_spat_gnd.refinement_of(
-        spatial_region_gnd, refinement_func=is_ontological_child, with_context=False
+        spatial_region_gnd, refinement_func=is_ontological_child_web, with_context=False
     )
     assert not one_dim_spat_gnd.refinement_of(
-        spatial_region, refinement_func=is_ontological_child, with_context=False
+        spatial_region, refinement_func=is_ontological_child_web, with_context=False
     )
     assert one_dim_spat_gnd.refinement_of(
-        spatial_region_gnd, refinement_func=is_ontological_child, with_context=True
+        spatial_region_gnd, refinement_func=is_ontological_child_web, with_context=True
     )
     assert not one_dim_spat_gnd.refinement_of(
-        spatial_region, refinement_func=is_ontological_child, with_context=True
+        spatial_region, refinement_func=is_ontological_child_web, with_context=True
     )
     assert one_dim_spat_gnd_ctx.refinement_of(
-        one_dim_spat_gnd, refinement_func=is_ontological_child, with_context=True
+        one_dim_spat_gnd, refinement_func=is_ontological_child_web, with_context=True
     )
 
     # test ungrounded
     assert not spatial_region.refinement_of(
-        one_dim_spat, refinement_func=is_ontological_child, with_context=False
+        one_dim_spat, refinement_func=is_ontological_child_web, with_context=False
     )
     spatial_region_ctx = spatial_region.with_context(location="Stockholm")
     assert spatial_region_ctx.refinement_of(
-        spatial_region, refinement_func=is_ontological_child, with_context=True
+        spatial_region, refinement_func=is_ontological_child_web, with_context=True
     )
     assert not spatial_region_ctx.refinement_of(
-        spatial_region_gnd, refinement_func=is_ontological_child, with_context=True
+        spatial_region_gnd, refinement_func=is_ontological_child_web, with_context=True
     )
 
 
@@ -207,7 +207,7 @@ def test_concept_refinement_simple_context():
     spatial_region_gnd = Concept(name="spatial region", identifiers={"bfo": "0000006"})
     spatial_region_ctx = spatial_region_gnd.with_context(location="Stockholm")
     assert len(spatial_region_ctx.context)
-    kw = {"refinement_func": is_ontological_child, "with_context": True}
+    kw = {"refinement_func": is_ontological_child_web, "with_context": True}
 
     # Test both empty
     assert spatial_region_gnd.refinement_of(spatial_region_gnd, **kw)
@@ -225,7 +225,7 @@ def test_concept_refinement_context():
     spatial_region_more_ctx = spatial_region_gnd.with_context(location="Stockholm", year=2010)
     spatial_region_diff_ctx = spatial_region_gnd.with_context(year=2007, count=10)
 
-    kw = {"refinement_func": is_ontological_child, "with_context": True}
+    kw = {"refinement_func": is_ontological_child_web, "with_context": True}
 
     # Exactly equal context
     assert spatial_region_ctx.refinement_of(spatial_region_ctx, **kw)
@@ -319,9 +319,9 @@ def test_different_class_refinement():
     t3 = GroupedControlledConversion(subject=s, outcome=o,
                                      controllers=[c1, c2])
 
-    assert t2.refinement_of(t1, refinement_func=is_ontological_child)
-    assert t3.refinement_of(t1, refinement_func=is_ontological_child)
-    assert t3.refinement_of(t2, refinement_func=is_ontological_child)
+    assert t2.refinement_of(t1, refinement_func=is_ontological_child_web)
+    assert t3.refinement_of(t1, refinement_func=is_ontological_child_web)
+    assert t3.refinement_of(t2, refinement_func=is_ontological_child_web)
 
     t4 = ControlledConversion(subject=c1, outcome=o, controller=c1)
-    assert not t4.refinement_of(t1, refinement_func=is_ontological_child)
+    assert not t4.refinement_of(t1, refinement_func=is_ontological_child_web)

--- a/tests/test_templatemodel_delta.py
+++ b/tests/test_templatemodel_delta.py
@@ -2,7 +2,7 @@ import unittest
 from itertools import product, permutations
 from typing import Tuple
 
-from mira.dkg.web_client import is_ontological_child
+from mira.dkg.web_client import is_ontological_child_web
 from mira.examples.sir import sir, cities
 from mira.metamodel.templates import TemplateModelDelta, TemplateModel, get_concept_graph_key
 
@@ -68,7 +68,7 @@ class TestTemplateModelDelta(unittest.TestCase):
         self.sir_nyc = TemplateModel(templates=[t.with_context(city=nyc) for t in sir.templates])
 
     def test_equal_no_context(self):
-        tmd = TemplateModelDelta(self.sir, self.sir, refinement_function=is_ontological_child)
+        tmd = TemplateModelDelta(self.sir, self.sir, refinement_function=is_ontological_child_web)
 
         # one node per template per TemplateModel + one node per concept,
         # unless they're merged
@@ -96,7 +96,7 @@ class TestTemplateModelDelta(unittest.TestCase):
 
     def test_equal_context(self):
         tmd_context = TemplateModelDelta(
-            self.sir_boston, self.sir_boston, refinement_function=is_ontological_child
+            self.sir_boston, self.sir_boston, refinement_function=is_ontological_child_web
         )
         node_count, edge_count = get_counts(tmd_context)
         # one node per template per TemplateModel
@@ -126,7 +126,7 @@ class TestTemplateModelDelta(unittest.TestCase):
 
     def test_not_equal_or_refinement(self):
         tm_delta_nothing = TemplateModelDelta(
-            self.sir_boston, self.sir_nyc, refinement_function=is_ontological_child
+            self.sir_boston, self.sir_nyc, refinement_function=is_ontological_child_web
         )
         # one node per template per TemplateModel + one node per concept
         node_count, edge_count = get_counts(tm_delta_nothing)
@@ -145,8 +145,8 @@ class TestTemplateModelDelta(unittest.TestCase):
         )
 
     def test_refinement(self):
-        tmd_vs_boston = TemplateModelDelta(self.sir, self.sir_boston, is_ontological_child)
-        tmd_vs_nyc = TemplateModelDelta(self.sir, self.sir_nyc, is_ontological_child)
+        tmd_vs_boston = TemplateModelDelta(self.sir, self.sir_boston, is_ontological_child_web)
+        tmd_vs_nyc = TemplateModelDelta(self.sir, self.sir_nyc, is_ontological_child_web)
 
         self.assert_(
             all(

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -2,10 +2,13 @@ import pytest
 
 from requests import HTTPError
 
-from mira.metamodel.templates import RefinementClosure, get_dkg_refinement_closure
+from mira.metamodel.templates import (
+    RefinementClosure,
+    get_dkg_refinement_closure,
+)
 from mira.dkg.api import RelationQuery, RelationResponse, FullRelationResponse
 from mira.dkg.client import Entity
-from mira.dkg.grounding import GroundRequest, GroundResults, GroundResult
+from mira.dkg.grounding import GroundResults, GroundResult
 from mira.dkg.web_client import *
 from mira.dkg.web_client import web_client
 
@@ -16,7 +19,9 @@ def test_web_client():
         web_client(endpoint="/relations", method="post", query_json=None)
     except Exception as exc:
         assert isinstance(exc, ValueError)
-        assert "POST request to endpoint /relations requires query data" in str(exc)
+        assert "POST request to endpoint /relations requires query data" in str(
+            exc
+        )
     else:
         raise AssertionError(f"Expected POST request ValueError")
 
@@ -38,11 +43,15 @@ def test_web_client():
 
 
 def test_get_relations():
-    res = get_relations_web(relations_model=RelationQuery(source_type="vo", limit=2))
+    res = get_relations_web(
+        relations_model=RelationQuery(source_type="vo", limit=2)
+    )
     assert isinstance(res, list)
     assert isinstance(res[0], RelationResponse)
 
-    res = get_relations_web(relations_model=RelationQuery(source_type="vo", limit=2, full=True))
+    res = get_relations_web(
+        relations_model=RelationQuery(source_type="vo", limit=2, full=True)
+    )
     assert isinstance(res, list)
     assert isinstance(res[0], FullRelationResponse)
 
@@ -77,6 +86,7 @@ def test_is_ontological_child():
 
 @pytest.mark.slow
 def test_transitive_closure():
+    # Takes ~30 s locally
     tc = get_transitive_closure_web(["subclassof"])
     assert isinstance(tc, set)
     assert isinstance(list(tc)[0], tuple)
@@ -88,6 +98,9 @@ def test_transitive_closure():
 
 @pytest.mark.slow
 def test_get_refinement_closure():
+    # Takes ~30 s locally
+    # Tests getting the refinement closure, which uses
+    # get_transitive_closure_web
     rc = get_dkg_refinement_closure()
     # Check that the transitive closure
     assert isinstance(rc.transitive_closure, set)
@@ -104,6 +117,7 @@ def test_get_refinement_closure():
 
 @pytest.mark.slow
 def test_lexical():
+    # Takes ~10 s locally
     res = get_lexical_web()
     assert res is not None
     assert isinstance(res, list)

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -67,6 +67,14 @@ def test_ground():
     assert isinstance(res.results[0], GroundResult)
 
 
+def test_is_ontological_child():
+    is_child = is_ontological_child_web(
+        child_curie="vo:0001113",
+        parent_curie="obi:0000047",
+    )
+    assert isinstance(is_child, bool)
+
+
 @pytest.mark.slow
 def test_transitive_closure():
     tc = get_transitive_closure_web(["subclassof"])


### PR DESCRIPTION
This PR adds caches for the lexical dump and the transitive closure of refinements.

Specific changes:
- The endpoint `/lexical` now uses the cached dump
- The endpoint `/transitive_closure` return the refinement closure from cache. Other transitive closures are still queried for their specific type
- A new endpoint `/is_ontological_child` is added that uses `RefinementClosure.is_ontological_child` from the cache
- `is_ontological_child_web` (renamed from `is_ontological_child`) in the `web_client` module is updated to use the new endpoint
- The version date for the metaregistry docker is updated
- Add a startup script for the main dkg app to avoid app loading on module import/load
- Minor cleanup

_Note: some tests assume that the dkg docker is deployed with the code in this PR and will fail_