### PR TITLE
Simplify certain grouped controlled templates by interpreting rate laws

### DIFF
--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -24,6 +24,7 @@ from mira.metamodel import NaturalConversion, Template, ControlledConversion
 from mira.metamodel.ops import stratify
 from mira.modeling import Model
 from mira.metamodel.templates import TemplateModel, TemplateModelDelta
+from mira.metamodel.ops import simplify_rate_laws
 from mira.modeling.bilayer import BilayerModel
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
@@ -193,6 +194,11 @@ def biomodels_id_to_model(
         description="The BioModels model ID to get the template model for.",
         example="BIOMD0000000956",
     ),
+    simplify: bool = Body(
+        default=True,
+        description="Whether to simplify the rate laws of the model.",
+        example=True,
+    )
 ):
     """Get a BioModels base template model by providing its model id"""
     try:
@@ -200,6 +206,8 @@ def biomodels_id_to_model(
     except FileNotFoundError:
         raise HTTPException(status_code=400, detail="Bad model id")
     tm = template_model_from_sbml_string(xml_string, model_id=model_id)
+    if simplify:
+        tm = simplify_rate_laws(tm)
     return tm
 
 

--- a/mira/metamodel/__init__.py
+++ b/mira/metamodel/__init__.py
@@ -1,34 +1,3 @@
+# We expose everything that these submodules expose
 from .io import model_from_json_file, model_to_json_file
-from .templates import (
-    Concept,
-    ControlledConversion,
-    GroupedControlledConversion,
-    GroupedControlledProduction,
-    Initial,
-    NaturalConversion,
-    NaturalDegradation,
-    NaturalProduction,
-    Parameter,
-    Provenance,
-    Template,
-    TemplateModel,
-    TemplateModelDelta,
-)
-
-__all__ = [
-    "Concept",
-    "Parameter",
-    "Initial",
-    "Template",
-    "Provenance",
-    "ControlledConversion",
-    "GroupedControlledProduction",
-    "NaturalConversion",
-    "NaturalDegradation",
-    "NaturalProduction",
-    "GroupedControlledConversion",
-    "TemplateModel",
-    "TemplateModelDelta",
-    "model_from_json_file",
-    "model_to_json_file"
-]
+from .templates import *

--- a/mira/metamodel/io.py
+++ b/mira/metamodel/io.py
@@ -1,4 +1,4 @@
-__all__ = ["model_from_json_file"]
+__all__ = ["model_from_json_file", "model_to_json_file"]
 
 import json
 from .templates import TemplateModel

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -1,7 +1,8 @@
 """Operations for template models."""
 
 import itertools as itt
-from typing import Iterable, Mapping, Optional, Set, Tuple, Type
+from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type, \
+    Union
 
 import sympy
 
@@ -121,6 +122,19 @@ def find_models_with_grounding(template_models: Mapping[str, TemplateModel],
 
 
 def simplify_rate_laws(template_model: TemplateModel):
+    """Rewrite templates by simplifying rate laws.
+
+    Parameters
+    ----------
+    template_model :
+        A template model
+
+    Returns
+    -------
+    :
+        A template model with simplified rate laws (overwrites input,
+        not a copy).
+    """
     new_templates = []
     for template in template_model.templates:
         simplified_templates = simplify_rate_law(template,
@@ -133,7 +147,24 @@ def simplify_rate_laws(template_model: TemplateModel):
     return template_model
 
 
-def simplify_rate_law(template, parameters):
+def simplify_rate_law(template: Template,
+                      parameters: Dict[str, sympy.Symbol]) \
+        -> Union[List[Template], None]:
+    """Break up a complex template into simpler ones by examining the rate law.
+
+    Parameters
+    ----------
+    template :
+        A template to simplify.
+    parameters :
+        A dict of parameters in the template model, needed to interpret
+        the semantics of rate laws.
+
+    Returns
+    -------
+    :
+        A list of templates, which may be empty if the template could not
+    """
     if not isinstance(template, (GroupedControlledConversion,
                                  GroupedControlledProduction)):
         return
@@ -181,6 +212,7 @@ def simplify_rate_law(template, parameters):
 
 
 def get_term_roles(term, template, parameters):
+    """Return terms in a rate law by role."""
     if not term.is_Mul:
         return {}
     term_roles = {}

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -1,5 +1,6 @@
 """Operations for template models."""
 
+from copy import deepcopy
 import itertools as itt
 from typing import Iterable, List, Mapping, Optional, Set, Tuple, Type, Union
 
@@ -121,7 +122,7 @@ def find_models_with_grounding(template_models: Mapping[str, TemplateModel],
 
 
 def simplify_rate_laws(template_model: TemplateModel):
-    """Rewrite templates by simplifying rate laws.
+    """Return a template model after rewriting templates by simplifying rate laws.
 
     Parameters
     ----------
@@ -131,9 +132,10 @@ def simplify_rate_laws(template_model: TemplateModel):
     Returns
     -------
     :
-        A template model with simplified rate laws (overwrites input,
-        not a copy).
+        A template model with simplified rate laws.
     """
+    # Make a copy of the model so that we don't overwrite the original one
+    template_model = deepcopy(template_model)
     new_templates = []
     for template in template_model.templates:
         simplified_templates = simplify_rate_law(template,
@@ -177,6 +179,8 @@ def simplify_rate_law(template: Template,
     # or a sum of multiple terms
     if not rate_law.is_Add:
         return
+    # Make a deepcopy up front so we don't change the original template
+    template = deepcopy(template)
     # Given that this is a sum of terms, we can go term-by-term to
     # check if each term can be broken out
     new_templates = []
@@ -190,16 +194,16 @@ def simplify_rate_law(template: Template,
         if isinstance(template, GroupedControlledConversion) and \
                 set(term_roles) == {'parameter', 'controller', 'subject'}:
             new_template = ControlledConversion(
-                controller=term_roles['controller'],
-                subject=term_roles['subject'],
-                outcome=template.outcome,
+                controller=deepcopy(term_roles['controller']),
+                subject=deepcopy(term_roles['subject']),
+                outcome=deepcopy(template.outcome),
                 rate_law=term
             )
         elif isinstance(template, GroupedControlledProduction) and \
                 set(term_roles) == {'parameter', 'controller'}:
             new_template = ControlledProduction(
-                controller=term_roles['controller'],
-                outcome=template.outcome,
+                controller=deepcopy(term_roles['controller']),
+                outcome=deepcopy(template.outcome),
                 rate_law=term
             )
         if new_template:

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -1,8 +1,7 @@
 """Operations for template models."""
 
 import itertools as itt
-from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type, \
-    Union
+from typing import Iterable, List, Mapping, Optional, Set, Tuple, Type, Union
 
 import sympy
 
@@ -139,8 +138,10 @@ def simplify_rate_laws(template_model: TemplateModel):
     for template in template_model.templates:
         simplified_templates = simplify_rate_law(template,
                                                  template_model.parameters)
-        if not simplified_templates:
+        # If we couldn't simplify anything, we just keep the original template
+        if simplified_templates is None:
             new_templates.append(template)
+        # If simplification resulted in some templates, we add them
         else:
             new_templates += simplified_templates
     template_model.templates = new_templates
@@ -148,7 +149,7 @@ def simplify_rate_laws(template_model: TemplateModel):
 
 
 def simplify_rate_law(template: Template,
-                      parameters: Dict[str, sympy.Symbol]) \
+                      parameters: Mapping[str, Parameter]) \
         -> Union[List[Template], None]:
     """Break up a complex template into simpler ones by examining the rate law.
 

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -182,6 +182,44 @@
         "outcome"
       ]
     },
+    "ControlledProduction": {
+      "title": "ControlledProduction",
+      "description": "Specifies a process of production controlled by one controller",
+      "type": "object",
+      "properties": {
+        "rate_law": {
+          "title": "Rate Law",
+          "type": "string",
+          "example": "2*x"
+        },
+        "type": {
+          "title": "Type",
+          "default": "ControlledProduction",
+          "const": "ControlledProduction",
+          "enum": [
+            "ControlledProduction"
+          ],
+          "type": "string"
+        },
+        "controller": {
+          "$ref": "#/definitions/Concept"
+        },
+        "outcome": {
+          "$ref": "#/definitions/Concept"
+        },
+        "provenance": {
+          "title": "Provenance",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Provenance"
+          }
+        }
+      },
+      "required": [
+        "controller",
+        "outcome"
+      ]
+    },
     "NaturalConversion": {
       "title": "NaturalConversion",
       "description": "Specifies a process of natural conversion from subject to outcome",

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -10,6 +10,7 @@ __all__ = [
     "Template",
     "Provenance",
     "ControlledConversion",
+    "ControlledProduction",
     "NaturalConversion",
     "NaturalProduction",
     "NaturalDegradation",
@@ -526,6 +527,24 @@ class GroupedControlledProduction(Template):
     def get_concepts(self):
         """Return a list of the concepts in this template"""
         return self.controllers + [self.outcome]
+
+
+class ControlledProduction(Template):
+    """Specifies a process of production controlled by one controller"""
+
+    type: Literal["ControlledProduction"] = Field("ControlledProduction", const=True)
+    controller: Concept
+    outcome: Concept
+    provenance: List[Provenance] = Field(default_factory=list)
+
+    concept_keys: ClassVar[List[str]] = ["controller", "outcome"]
+
+    def get_key(self, config: Optional[Config] = None):
+        return (
+            self.type,
+            self.controller.get_key(config=config),
+            self.outcome.get_key(config=config),
+        )
 
 
 class NaturalConversion(Template):

--- a/mira/sources/sbml.py
+++ b/mira/sources/sbml.py
@@ -157,7 +157,8 @@ def template_model_from_sbml_model(
 
     def _lookup_concepts_filtered(species_ids) -> List[Concept]:
         return [
-            concepts[species_id] for species_id in species_ids if species_id not in reporter_ids
+            concepts[species_id] for species_id in species_ids
+            if species_id not in reporter_ids and 'cumulative' not in species_id
         ]
 
     # Iterate thorugh all reactions and piecewise convert to templates

--- a/tests/test_biomodels.py
+++ b/tests/test_biomodels.py
@@ -17,16 +17,18 @@ def test_process_biomodels():
     base_folder = pystow.join('mira', 'biomodels', 'models')
     fnames = glob.glob(os.path.join(base_folder.as_posix(),
                                     'BIOMD*/BIOMD*.xml'))
+    simplified = 0
     for fname in tqdm.tqdm(fnames):
         tm_old = template_model_from_sbml_file(fname)
         old_template_count = len(tm_old.templates)
         tm = simplify_rate_laws(tm_old)
         new_template_count = len(tm.templates)
         if old_template_count != new_template_count:
-            breakpoint()
+            simplified += 1
         model = Model(tm)
         petri = PetriNetModel(model)
         pj = petri.to_json()
         assert pj
         assert tm.templates
+    print(f"Simplified {simplified} out of {len(fnames)} models")
 

--- a/tests/test_biomodels.py
+++ b/tests/test_biomodels.py
@@ -5,6 +5,7 @@ import unittest
 import tqdm
 import pystow
 
+from mira.metamodel.ops import simplify_rate_laws
 from mira.modeling import Model
 from mira.modeling.petri import PetriNetModel
 from mira.sources.sbml import template_model_from_sbml_file
@@ -18,6 +19,11 @@ def test_process_biomodels():
                                     'BIOMD*/BIOMD*.xml'))
     for fname in tqdm.tqdm(fnames):
         tm = template_model_from_sbml_file(fname)
+        old_template_count = len(tm.templates)
+        tm = simplify_rate_laws(tm)
+        new_template_count = len(tm.templates)
+        if old_template_count != new_template_count:
+            breakpoint()
         model = Model(tm)
         petri = PetriNetModel(model)
         pj = petri.to_json()

--- a/tests/test_biomodels.py
+++ b/tests/test_biomodels.py
@@ -18,9 +18,9 @@ def test_process_biomodels():
     fnames = glob.glob(os.path.join(base_folder.as_posix(),
                                     'BIOMD*/BIOMD*.xml'))
     for fname in tqdm.tqdm(fnames):
-        tm = template_model_from_sbml_file(fname)
-        old_template_count = len(tm.templates)
-        tm = simplify_rate_laws(tm)
+        tm_old = template_model_from_sbml_file(fname)
+        old_template_count = len(tm_old.templates)
+        tm = simplify_rate_laws(tm_old)
         new_template_count = len(tm.templates)
         if old_template_count != new_template_count:
             breakpoint()

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -236,7 +236,8 @@ class TestModelApi(unittest.TestCase):
 
     def test_biomodels_id_to_template_model(self):
         model_id = "BIOMD0000000956"
-        response = self.client.get(f"/api/biomodels/{model_id}")
+        response = self.client.get(f"/api/biomodels/{model_id}",
+                                   params={'simplify_rate_laws': True})
         self.assertEqual(200, response.status_code)
 
         # Try to make a template model from the json

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -37,6 +37,6 @@ class TestOperations(unittest.TestCase):
         )
         simplified_templates = \
             simplify_rate_law(template, parameters)
-        assert len(simplified_templates) == 4
+        assert len(simplified_templates) == 4, simplified_templates
         assert all(isinstance(t, ControlledConversion)
                    for t in simplified_templates)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -5,9 +5,13 @@ import unittest
 import sympy
 
 from mira.metamodel import Concept, ControlledConversion, \
-    GroupedControlledConversion
+    GroupedControlledConversion, Parameter
 from mira.examples.sir import cities, sir, sir_2_city
 from mira.metamodel.ops import stratify, simplify_rate_law
+
+
+def _s(s):
+    return sympy.Symbol(s)
 
 
 class TestOperations(unittest.TestCase):
@@ -32,11 +36,56 @@ class TestOperations(unittest.TestCase):
             ],
             subject=Concept(name='Susceptible'),
             outcome=Concept(name='Infected'),
-            rate_law=sympy.parse_expr('1.0*Susceptible*(Ailing*gamma + Diagnosed*beta + Infected*alpha + Recognized*delta)',
-                                      local_dict={p: sympy.Symbol(p) for p in parameters})
+            rate_law=sympy.parse_expr('1.0*Susceptible*(Ailing*gamma + '
+                                      'Diagnosed*beta + Infected*alpha + '
+                                      'Recognized*delta)',
+                                      local_dict={p: _s(p) for p in parameters})
         )
         simplified_templates = \
             simplify_rate_law(template, parameters)
         assert len(simplified_templates) == 4, simplified_templates
         assert all(isinstance(t, ControlledConversion)
                    for t in simplified_templates)
+
+    def test_simplify_rate_law2(self):
+        def _make_template(rate_law):
+            template = GroupedControlledConversion(
+                rate_law=rate_law,
+                controllers=[Concept(name='A'),
+                             Concept(name='B')],
+                subject=Concept(name='S'),
+                outcome=Concept(name='O'))
+            return template
+
+        # This one cannot be simplified
+        rate_law = (_s('alpha') * _s('S') * _s('A')) / _s('B')
+        template = _make_template(rate_law)
+        templates = simplify_rate_law(template,
+                                      {'alpha': Parameter(name='alpha',
+                                                          value=1.0)})
+        assert len(templates) == 1, templates
+        assert templates[0].type == 'GroupedControlledConversion'
+
+        # This one can be simplified
+        rate_law = (1 - _s('alpha')) * _s('S') * (_s('A') + _s('B'))
+        template = _make_template(rate_law)
+        templates = simplify_rate_law(template,
+                                      {'alpha': Parameter(name='alpha',
+                                                          value=1.0)})
+        assert len(templates) == 2, templates
+        assert all(t.type == 'ControlledConversion' for t in templates)
+
+        # This one can be simplified too
+        rate_law = (1 - _s('alpha')) * _s('S') * (_s('A') + _s('beta')*_s('B'))
+        template = _make_template(rate_law)
+        templates = simplify_rate_law(template,
+                                      {'alpha': Parameter(name='alpha',
+                                                          value=1.0),
+                                       'beta': Parameter(name='beta',
+                                                         value=2.0)})
+        assert len(templates) == 2, templates
+        assert all(t.type == 'ControlledConversion' for t in templates)
+        assert templates[0].rate_law.args[0].equals(
+            (1 - _s('alpha')) * _s('S') * _s('A'))
+        assert templates[1].rate_law.args[0].equals(
+            (1 - _s('alpha')) * _s('beta') * _s('S') * _s('B'))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -2,8 +2,12 @@
 
 import unittest
 
+import sympy
+
+from mira.metamodel import Concept, ControlledConversion, \
+    GroupedControlledConversion
 from mira.examples.sir import cities, sir, sir_2_city
-from mira.metamodel.ops import stratify
+from mira.metamodel.ops import stratify, simplify_rate_law
 
 
 class TestOperations(unittest.TestCase):
@@ -16,3 +20,22 @@ class TestOperations(unittest.TestCase):
             {template.get_key() for template in sir_2_city.templates},
             {template.get_key() for template in actual.templates},
         )
+
+
+def test_simplify_rate_law():
+    template = GroupedControlledConversion(
+        controllers=[
+            Concept('Ailing'),
+            Concept('Diagnosed'),
+            Concept('Infected'),
+            Concept('Recognized')
+        ],
+        subject=Concept('Susceptible'),
+        outcome=Concept('Infected'),
+        rate_law=sympy.parse_expr('1.0*Susceptible*(Ailing*gamma + Diagnosed*beta + Infected*alpha + Recognized*delta)')
+    )
+    simplified_templates = \
+        simplify_rate_law(template, ['alpha', 'beta', 'gamma', 'delta'])
+    assert len(simplified_templates) == 4
+    assert all(isinstance(t, ControlledConversion)
+               for t in simplified_templates)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -21,21 +21,22 @@ class TestOperations(unittest.TestCase):
             {template.get_key() for template in actual.templates},
         )
 
-
-def test_simplify_rate_law():
-    template = GroupedControlledConversion(
-        controllers=[
-            Concept('Ailing'),
-            Concept('Diagnosed'),
-            Concept('Infected'),
-            Concept('Recognized')
-        ],
-        subject=Concept('Susceptible'),
-        outcome=Concept('Infected'),
-        rate_law=sympy.parse_expr('1.0*Susceptible*(Ailing*gamma + Diagnosed*beta + Infected*alpha + Recognized*delta)')
-    )
-    simplified_templates = \
-        simplify_rate_law(template, ['alpha', 'beta', 'gamma', 'delta'])
-    assert len(simplified_templates) == 4
-    assert all(isinstance(t, ControlledConversion)
-               for t in simplified_templates)
+    def test_simplify_rate_law(self):
+        parameters = ['alpha', 'beta', 'gamma', 'delta']
+        template = GroupedControlledConversion(
+            controllers=[
+                Concept(name='Ailing'),
+                Concept(name='Diagnosed'),
+                Concept(name='Infected'),
+                Concept(name='Recognized')
+            ],
+            subject=Concept(name='Susceptible'),
+            outcome=Concept(name='Infected'),
+            rate_law=sympy.parse_expr('1.0*Susceptible*(Ailing*gamma + Diagnosed*beta + Infected*alpha + Recognized*delta)',
+                                      local_dict={p: sympy.Symbol(p) for p in parameters})
+        )
+        simplified_templates = \
+            simplify_rate_law(template, parameters)
+        assert len(simplified_templates) == 4
+        assert all(isinstance(t, ControlledConversion)
+                   for t in simplified_templates)


### PR DESCRIPTION
This PR implements one pattern of breaking up grouped controlled templates that can be replaced by multiple simpler templates but only by interpreting the rate law. There are certain other simplifications that might be possible that can be added later.