### PR TITLE
Petri net as input

### DIFF
--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -21,3 +21,10 @@ BioModels client (:py:mod:`mira.sources.biomodels`)
 .. automodule:: mira.sources.biomodels
     :members:
     :show-inheritance:
+
+
+Petri net extraction (:py:mod:`mira.sources.petri`)
+---------------------------------------------------
+.. automodule:: mira.sources.petri
+    :members:
+    :show-inheritance:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -395,6 +395,43 @@ class Template(BaseModel):
             k: getattr(self, k) for k in self.concept_keys
         }
 
+    def get_mass_action_rate_law(self, parameter: str) -> sympy.Expr:
+        """Return the mass action rate law for this template.
+
+        Parameters
+        ----------
+        parameter :
+            The parameter to use for the mass-action rate law.
+
+        Returns
+        -------
+        :
+            The mass action rate law for this template.
+        """
+        concepts_by_role = self.get_concepts_by_role()
+        if 'controller' in concepts_by_role:
+            controllers = [concepts_by_role['controller']]
+        elif 'controllers' in concepts_by_role:
+            controllers = concepts_by_role['controllers']
+        else:
+            controllers = []
+        subject = concepts_by_role.get('subject')
+        interactors = controllers + ([subject] if subject else [])
+        rate_law = sympy.Symbol(parameter)
+        for interactor in interactors:
+            rate_law *= sympy.Symbol(interactor.name)
+        return rate_law
+
+    def set_mass_action_rate_law(self, parameter):
+        """Set the rate law of this template to a mass action rate law.
+
+        Parameters
+        ----------
+        parameter :
+            The parameter to use for the mass-action rate.
+        """
+        self.rate_law = SympyExprStr(self.get_mass_action_rate_law(parameter))
+
 
 class Provenance(BaseModel):
     pass

--- a/mira/modeling/petri.py
+++ b/mira/modeling/petri.py
@@ -37,11 +37,17 @@ class PetriNetModel:
             self.states.append(state_data)
 
         for idx, transition in enumerate(model.transitions.values()):
+            # NOTE: this is a bit hacky. It attempts to determine
+            # if the parameter was generated automatically
+            if not isinstance(transition.rate.key, str):
+                pname = f"p_petri_{idx + 1}"
+            else:
+                pname = transition.rate.key
+                pname = sanitize_parameter_name(pname)
             self.transitions.append(
                 {'tname': f"t{idx + 1}",
                  'template_type': transition.template_type,
-                 'parameter_name': sanitize_parameter_name(
-                     str(transition.rate.key)),
+                 'parameter_name': pname,
                  'parameter_value': transition.rate.value}
             )
             for c in transition.control:

--- a/mira/sources/petri.py
+++ b/mira/sources/petri.py
@@ -1,0 +1,79 @@
+import ast
+from collections import defaultdict
+from mira.metamodel import *
+
+
+def template_model_from_petri_json(petri_json):
+    concepts = [state_to_concept(state) for state in petri_json['S']]
+    input_lookup = defaultdict(list)
+    for input in petri_json['I']:
+        input_lookup[input['it']].append(input['is'])
+    output_lookup = defaultdict(list)
+    for output in petri_json['O']:
+        output_lookup[output['ot']].append(output['os'])
+
+    templates = []
+    for idx, transition in enumerate(petri_json.get('T', []), start=1):
+        inputs = input_lookup[idx]
+        outputs = output_lookup[idx]
+        # Since inputs and outputs can contain the same state multiple times
+        # and in general we want to preserve the number of times a state
+        # appears, we identify controllers one by one, and remove them
+        # from the input/output lists
+        controllers = []
+        both = set(inputs) & set(outputs)
+        while both:
+            shared = next(iter(both))
+            controllers.append(shared)
+            inputs.remove(shared)
+            outputs.remove(shared)
+            both = set(inputs) & set(outputs)
+        input_concepts = [concepts[i - 1] for i in inputs]
+        output_concepts = [concepts[i - 1] for i in outputs]
+        controller_concepts = [concepts[i - 1] for i in controllers]
+        templates.extend(transition_to_templates(transition, input_concepts,
+                                                 output_concepts,
+                                                 controller_concepts))
+    return TemplateModel(templates=templates)
+
+def state_to_concept(state):
+    # Example: 'mira_ids': "[('identity', 'ido:0000514')]"
+    mira_ids = ast.literal_eval(state['mira_ids'])
+    if mira_ids:
+        identifiers = dict([mira_ids[0][1].split(':', 1)])
+    else:
+        identifiers = {}
+    # Example: 'mira_context': "[('city', 'geonames:5128581')]"
+    context = dict(ast.literal_eval(state['mira_context']))
+    return Concept(name=state['sname'],
+                   identifiers=identifiers,
+                   context=context,
+                   initial_value=state.get('mira_initial_value'))
+
+
+def transition_to_templates(transition, input_concepts, output_concepts,
+                            controller_concepts):
+    p = transition.get('parameter_value')
+    if not controller_concepts:
+        if not input_concepts:
+            for output_concept in output_concepts:
+                yield NaturalProduction(outcome=output_concept)
+        elif not output_concepts:
+            for input_concept in input_concepts:
+                yield NaturalDegradation(subject=input_concept)
+        else:
+            for input_concept in input_concepts:
+                for output_concept in output_concepts:
+                    yield NaturalConversion(subject=input_concept,
+                                            outcome=output_concept)
+    else:
+        if not (len(input_concepts) == 1 and len(output_concepts) == 1):
+            return
+        if len(controller_concepts) == 1:
+            yield ControlledConversion(controller=controller_concepts[0],
+                                       subject=input_concepts[0],
+                                       outcome=output_concepts[0])
+        else:
+            yield GroupedControlledConversion(controllers=controller_concepts,
+                                              subject=input_concepts[0],
+                                              outcome=output_concepts[0])

--- a/tests/test_petri_source.py
+++ b/tests/test_petri_source.py
@@ -32,3 +32,24 @@ def test_petri_reverse():
     assert tm.templates[0].outcome.identifiers == infected.identifiers
     assert tm.templates[1].subject.identifiers == infected.identifiers
     assert tm.templates[1].outcome.identifiers == recovered.identifiers
+
+
+def test_petri_reverse_parameterized():
+    from mira.examples.sir import sir_parameterized
+    pm = PetriNetModel(Model(sir_parameterized))
+    pj = pm.to_json()
+    tm = template_model_from_petri_json(pj)
+    assert len(tm.templates) == 2
+    assert isinstance(tm.templates[0], ControlledConversion)
+    assert isinstance(tm.templates[1], NaturalConversion)
+    assert tm.parameters['beta'].name == 'beta', tm.parameters
+    assert tm.parameters['beta'].value == 0.1
+    assert tm.parameters['gamma'].name == 'gamma'
+    assert tm.parameters['gamma'].value == 0.2
+    assert tm.initials['susceptible_population'].concept.name == \
+        susceptible.name
+    assert tm.initials['susceptible_population'].concept.identifiers == \
+        susceptible.identifiers
+    assert tm.initials['susceptible_population'].value == 1
+    assert tm.templates[0].rate_law
+    assert tm.templates[1].rate_law

--- a/tests/test_petri_source.py
+++ b/tests/test_petri_source.py
@@ -1,0 +1,34 @@
+from mira.examples.sir import sir, susceptible, infected, recovered
+from mira.metamodel import *
+from mira.modeling import Model
+from mira.modeling.petri import PetriNetModel
+from mira.sources.petri import state_to_concept, template_model_from_petri_json
+
+
+def test_state_to_concept():
+    state = {'sname': 'susceptible_population',
+             'mira_ids': "[('identity', 'ido:0000514')]",
+             'mira_context': "[('city', 'geonames:5128581')]"}
+    concept = state_to_concept(state)
+    assert concept.name == 'susceptible_population'
+    assert concept.identifiers == {'ido': '0000514'}
+    assert concept.context == {'city': 'geonames:5128581'}
+
+
+def test_petri_reverse():
+    pm = PetriNetModel(Model(sir))
+    pj = pm.to_json()
+    tm = template_model_from_petri_json(pj)
+    assert len(tm.templates) == 2
+    assert isinstance(tm.templates[0], ControlledConversion)
+    assert isinstance(tm.templates[1], NaturalConversion)
+    assert tm.templates[0].controller.name == infected.name
+    assert tm.templates[0].subject.name == susceptible.name
+    assert tm.templates[0].outcome.name == infected.name
+    assert tm.templates[1].subject.name == infected.name
+    assert tm.templates[1].outcome.name == recovered.name
+    assert tm.templates[0].controller.identifiers == infected.identifiers
+    assert tm.templates[0].subject.identifiers == susceptible.identifiers
+    assert tm.templates[0].outcome.identifiers == infected.identifiers
+    assert tm.templates[1].subject.identifiers == infected.identifiers
+    assert tm.templates[1].outcome.identifiers == recovered.identifiers


### PR DESCRIPTION
This PR adds a new source module that can read Petri net JSON objects into a TemplateModel. This allows ingesting ones that were generated by MIRA as well.