### PR TITLE
Petri input endpoint

### DIFF
--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -19,7 +19,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from mira.dkg.utils import DKG_REFINER_RELS
-from mira.examples.sir import sir_bilayer
+from mira.examples.sir import sir_bilayer, sir
 from mira.metamodel import NaturalConversion, Template, ControlledConversion
 from mira.metamodel.ops import stratify
 from mira.modeling import Model
@@ -92,6 +92,9 @@ Transitions = List[Dict[Literal["tname", "template_type",
 Inputs = List[Dict[Literal["is", "it"], int]]
 Outputs = List[Dict[Literal["os", "ot"], int]]
 
+# PetriNetModel json example
+petrinet_json = PetriNetModel(Model(sir)).to_json()
+
 
 class PetriNetResponse(BaseModel):
     S: States = Field(..., description="A list of states")  # States
@@ -112,7 +115,7 @@ def model_to_petri(template_model: Dict[str, Any] = Body(..., example=template_m
 
 # From PetriNetJson
 @model_blueprint.post("/from_petrinet", tags=["modeling"], response_model=TemplateModel)
-def petri_to_model(petri_json: Dict[str, Any]):
+def petri_to_model(petri_json: Dict[str, Any] = Body(..., example=petrinet_json)):
     """Create a TemplateModel from a PetriNet model"""
     return template_model_from_petri_json(petri_json)
 

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -28,6 +28,7 @@ from mira.modeling.bilayer import BilayerModel
 from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
 from mira.sources.bilayer import template_model_from_bilayer
+from mira.sources.petri import template_model_from_petri_json
 from mira.sources.sbml import template_model_from_sbml_string
 from mira.sources.biomodels import get_sbml_model
 
@@ -107,6 +108,13 @@ def model_to_petri(template_model: Dict[str, Any] = Body(..., example=template_m
     petri_net = PetriNetModel(model)
     petri_net_json = petri_net.to_json()
     return petri_net_json
+
+
+# From PetriNetJson
+@model_blueprint.post("/from_petrinet", tags=["modeling"], response_model=TemplateModel)
+def petri_to_model(petri_json: Dict[str, Any]):
+    """Create a TemplateModel from a PetriNet model"""
+    return template_model_from_petri_json(petri_json)
 
 
 # Model stratification

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -8,7 +8,7 @@ from typing import List, Union
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from mira.examples.sir import sir_parameterized
+from mira.examples.sir import sir_parameterized, sir
 from mira.dkg.model import model_blueprint
 from mira.dkg.api import RelationQuery
 from mira.dkg.web_client import is_ontological_child_web, get_relations_web
@@ -22,6 +22,7 @@ from mira.modeling.petri import PetriNetModel
 from mira.modeling.viz import GraphicalModel
 from mira.sources.bilayer import template_model_from_bilayer
 from mira.sources.biomodels import get_sbml_model
+from mira.sources.petri import template_model_from_petri_json
 from mira.sources.sbml import template_model_from_sbml_string
 
 
@@ -132,6 +133,25 @@ class TestModelApi(unittest.TestCase):
             "/api/to_petrinet", json=json.loads(sir_parameterized.json())
         )
         self.assertEqual(200, response.status_code, msg=response.content)
+
+    def test_petri_to_template_model(self):
+        petrinet_json = PetriNetModel(Model(sir)).to_json()
+        tm = template_model_from_petri_json(petrinet_json)
+        response = self.client.post("/api/from_petrinet", json=petrinet_json)
+        self.assertEqual(200, response.status_code, msg=response.content)
+        resp_json_str = sorted_json_str(response.json())
+        tm_json_str = sorted_json_str(tm.dict())
+        self.assertEqual(resp_json_str, tm_json_str)
+
+    def test_petri_to_template_model_parameterized(self):
+        petrinet_json = PetriNetModel(Model(sir_parameterized)).to_json()
+        tm = template_model_from_petri_json(petrinet_json)
+        response = self.client.post("/api/from_petrinet", json=petrinet_json)
+        self.assertEqual(200, response.status_code, msg=response.content)
+        resp_json_str = sorted_json_str(response.json())
+        tm_json_str = sorted_json_str(tm.dict())
+        self.assertEqual(resp_json_str, tm_json_str)
+
 
     def test_stratify(self):
         """Test the stratification endpoint"""


### PR DESCRIPTION
This PR adds a new endpoint that takes a PetriNet json as input and produces the corresponding TemplateModel json. This PR is a made possible by the code added in #109.

Two tests are added to test the new endpoint.