### PR TITLE
Add probonto to DKG build

### DIFF
--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -61,6 +61,8 @@ PREFIXES = [
     # "cl",
     # "chebi",
     # "mondo",
+    # Domain specific
+    "probonto",
 ]
 
 #: A list of all relation types that are considered refinement relations


### PR DESCRIPTION
This PR adds the [Probability Distribution Ontology](https://bioregistry.io/registry/probonto) to the builds for the MIRA domain knowledge graph and metaregistry to support @djinnome and @samwitty. 

todo:

- [ ] Test build
- [ ] Redeploy