### PR TITLE
Common ancestors query

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -403,9 +403,9 @@ class ParentQuery(BaseModel):
 )
 def common_parent(
     request: Request,
-    # fixme: fix the examples
-    query: ParentQuery = Body(..., example={"curie1": "ido:0000514",
-                                            "curie2": "ido:0000511"}),
+    query: ParentQuery = Body(
+        ..., example={"curie1": "ido:0000566", "curie2": "ido:0000567"}
+    ),
 ):
     """Get the common parent of two CURIEs"""
     entity = request.app.state.client.get_common_parent(query.curie1,

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -398,7 +398,7 @@ class ParentQuery(BaseModel):
 
 @api_blueprint.post(
     "/common_parent",
-    response_model=Entity,
+    response_model=List[Entity],
     tags=["relations"],
 )
 def common_parent(

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -403,6 +403,7 @@ class ParentQuery(BaseModel):
 )
 def common_parent(
     request: Request,
+    # fixme: fix the examples
     query: ParentQuery = Body(..., example={"curie1": "ido:0000514",
                                             "curie2": "ido:0000511"}),
 ):

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -408,6 +408,6 @@ def common_parent(
     ),
 ):
     """Get the common parent of two CURIEs"""
-    entity = request.app.state.client.get_common_parent(query.curie1,
-                                                        query.curie2)
+    entity = request.app.state.client.get_common_parents(query.curie1,
+                                                         query.curie2)
     return entity

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -389,3 +389,24 @@ def search(
         labels=labels and labels.split(","),
         wikidata_fallback=wikidata_fallback,
     )
+
+
+class ParentQuery(BaseModel):
+    curie1: str = Field(..., description="The first CURIE")
+    curie2: str = Field(..., description="The second CURIE")
+
+
+@api_blueprint.post(
+    "/common_parent",
+    response_model=Entity,
+    tags=["relations"],
+)
+def common_parent(
+    request: Request,
+    query: ParentQuery = Body(..., example={"curie1": "ido:0000514",
+                                            "curie2": "ido:0000511"}),
+):
+    """Get the common parent of two CURIEs"""
+    entity = request.app.state.client.get_common_parent(query.curie1,
+                                                        query.curie2)
+    return entity

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -526,7 +526,7 @@ class Neo4jClient:
             }
         return transitive_closure
 
-    def shares_parent(self, curie1: str, curie2: str) -> Optional[Entity]:
+    def get_common_parent(self, curie1: str, curie2: str) -> Optional[Entity]:
         """Return true if two entities share a parent."""
         refiner_rels = '|'.join(DKG_REFINER_RELS)
         cypher = f"""\

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -533,7 +533,7 @@ class Neo4jClient:
             f"""MATCH ({{ id: '{curie1}'}})-[:{refiner_rels}]->(p)<-[:{refiner_rels}]-({{id: '{curie2}'}})
             RETURN p"""
         res = self.query_tx(cypher)
-        return [self.neo4j_to_node(r[0]) for r in res] if res else None
+        return [Entity(**self.neo4j_to_node(r[0])) for r in res] if res else None
 
 
 # Follows example here:

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -20,7 +20,6 @@ from typing_extensions import Literal, TypeAlias
 
 from .models import EntityType, Synonym, Xref
 from .resources import get_resource_path
-from .utils import DKG_REFINER_RELS
 
 if TYPE_CHECKING:
     import gilda.grounder
@@ -528,6 +527,7 @@ class Neo4jClient:
 
     def get_common_parent(self, curie1: str, curie2: str) -> Optional[Entity]:
         """Return true if two entities share a parent."""
+        from mira.dkg.utils import DKG_REFINER_RELS
         refiner_rels = '|'.join(DKG_REFINER_RELS)
         cypher = f"""\
             MATCH ({{ id: '{curie1}'}})-[:{refiner_rels}]->(p)<-[:{refiner_rels}]-({{id: '{curie2}'}})

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -525,16 +525,15 @@ class Neo4jClient:
             }
         return transitive_closure
 
-    def get_common_parent(self, curie1: str, curie2: str) -> Optional[Entity]:
-        """Return true if two entities share a parent."""
+    def get_common_parents(self, curie1: str, curie2: str) -> Optional[List[Entity]]:
+        """Return the direct parents of two entities."""
         from mira.dkg.utils import DKG_REFINER_RELS
         refiner_rels = '|'.join(DKG_REFINER_RELS)
-        cypher = f"""\
-            MATCH ({{ id: '{curie1}'}})-[:{refiner_rels}]->(p)<-[:{refiner_rels}]-({{id: '{curie2}'}})
-            RETURN p
-        """
-        r = self.query_tx(cypher)
-        return self.neo4j_to_node(r[0]) if r else None
+        cypher = \
+            f"""MATCH ({{ id: '{curie1}'}})-[:{refiner_rels}]->(p)<-[:{refiner_rels}]-({{id: '{curie2}'}})
+            RETURN p"""
+        res = self.query_tx(cypher)
+        return [self.neo4j_to_node(r[0]) for r in res] if res else None
 
 
 # Follows example here:

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -189,3 +189,12 @@ class TestDKG(unittest.TestCase):
             for e in entities
         ))
         self.assertEqual([], entities)
+
+    def test_parent_query(self):
+        """Test parent query."""
+        res = self.client.get("/api/parents", params={
+            "id": "askemo:0000008", "relation_types": "subclassof"
+        })
+        self.assertEqual(200, res.status_code)
+        self.assertEqual(1, len(res.json()))
+        self.assertEqual("askemo:0000007", res.json()[0]["id"])

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -194,15 +194,16 @@ class TestDKG(unittest.TestCase):
         """Test parent query."""
         res = self.client.post(
             "/api/common_parent",
-            # fixme: get curies that actually work
-            json={"curie1": "askemo:0000008",
-                  "curie2": "askemo:0000007"}
+            json={"curie1": "ido:0000566",
+                  "curie2": "ido:0000567"}
         )
         self.assertEqual(200, res.status_code)
 
         # Try to parse the json to an Entity object
-        entity = Entity(**res.json())
+        entities = [Entity(**r) for r in res.json()]
 
         # Check that the parent is correct
-        assert entity.id == "askemo:0000009"
+        assert len(entities) == 1
+        entity = entities[0]
+        assert entity.id == "ido:0000504"
         assert not entity.obsolete

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -192,9 +192,17 @@ class TestDKG(unittest.TestCase):
 
     def test_parent_query(self):
         """Test parent query."""
-        res = self.client.get("/api/parents", params={
-            "id": "askemo:0000008", "relation_types": "subclassof"
-        })
+        res = self.client.post(
+            "/api/common_parent",
+            # fixme: get curies that actually work
+            json={"curie1": "askemo:0000008",
+                  "curie2": "askemo:0000007"}
+        )
         self.assertEqual(200, res.status_code)
-        self.assertEqual(1, len(res.json()))
-        self.assertEqual("askemo:0000007", res.json()[0]["id"])
+
+        # Try to parse the json to an Entity object
+        entity = Entity(**res.json())
+
+        # Check that the parent is correct
+        assert entity.id == "askemo:0000009"
+        assert not entity.obsolete


### PR DESCRIPTION
This PR implements a query that returns the one step common parents, e.g. the input `curie2=ido:0000566` (primary infection), `curie2=ido:0000567` (secondary infection) would return `ido:0000504` (infectious disorder).

_To consider: should we add `direct` as a boolean parameter that would allow arbitrary length for the ancestor linkages?_