### PR TITLE
Space ontology export

### DIFF
--- a/mira/dkg/askemo/__init__.py
+++ b/mira/dkg/askemo/__init__.py
@@ -1,7 +1,8 @@
 """ASKEM Ontology."""
 
-from .api import get_askemo_terms
+from .api import get_askemo_terms, get_askemosw_terms
 
 __all__ = [
     "get_askemo_terms",
+    "get_askemosw_terms",
 ]

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -8,8 +8,9 @@ from mira.dkg.models import EntityType, Synonym, Xref
 
 HERE = Path(__file__).parent.resolve()
 ONTOLOGY_PATH = HERE.joinpath("askemo.json")
+SW_ONTOLOGY_PATH = HERE.joinpath("askemosw.json")
 
-#: Valid equivalence annotions in ASKEMO
+#: Valid equivalence annotations in ASKEMO
 EQUIVALENCE_TYPES = {
     "skos:exactMatch",
     "skos:relatedMatch",
@@ -53,6 +54,7 @@ class Term(BaseModel):
     suggested_unit: Optional[str] = None
     typical_min: Optional[float] = None
     typical_max: Optional[float] = None
+    # TODO add dimensionality, potentially in a subclass
 
     @property
     def prefix(self) -> str:
@@ -61,7 +63,7 @@ class Term(BaseModel):
 
 
 def get_askemo_terms() -> Mapping[str, Term]:
-    """Load the ontology JSON."""
+    """Load the epi ontology JSON."""
     rv = {}
     for obj in json.loads(ONTOLOGY_PATH.read_text()):
         term = Term.parse_obj(obj)
@@ -69,18 +71,28 @@ def get_askemo_terms() -> Mapping[str, Term]:
     return rv
 
 
-def write(ontology: Mapping[str, Term]) -> None:
+def get_askemosw_terms() -> Mapping[str, Term]:
+    """Load the space weather ontology JSON."""
+    rv = {}
+    for obj in json.loads(SW_ONTOLOGY_PATH.read_text()):
+        term = Term.parse_obj(obj)
+        rv[term.id] = term
+    return rv
+
+
+def write(ontology: Mapping[str, Term], path: Path) -> None:
     terms = [
         term.dict(exclude_unset=True, exclude_defaults=True, exclude_none=True)
         for _curie, term in sorted(ontology.items())
     ]
-    ONTOLOGY_PATH.write_text(
+    path.write_text(
         json.dumps(terms, sort_keys=True, ensure_ascii=False, indent=2)
     )
 
 
 def lint():
-    write(get_askemo_terms())
+    write(get_askemo_terms(), ONTOLOGY_PATH)
+    write(get_askemosw_terms(), SW_ONTOLOGY_PATH)
 
 
 if __name__ == "__main__":

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -54,6 +54,7 @@ class Term(BaseModel):
     suggested_unit: Optional[str] = None
     typical_min: Optional[float] = None
     typical_max: Optional[float] = None
+    dimensionality: Optional[str] = None
     # TODO add dimensionality, potentially in a subclass
 
     @property

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -15,7 +15,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000002",
     "name": "Molecular mass",
     "xrefs": [
@@ -182,10 +182,10 @@
   {
     "description": "Specific heat ratio or adiabatic index",
     "id": "askemosw:0000013",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -212,10 +212,10 @@
   {
     "description": "Eddy diffusion coefficient",
     "id": "askemosw:0000015",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -257,10 +257,10 @@
   {
     "description": "gravitational acceleration vector field",
     "id": "askemosw:0000018",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -377,10 +377,10 @@
   {
     "description": "The coefficient of viscosity",
     "id": "askemosw:0000026",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -420,7 +420,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000029",
     "name": "Charge",
     "xrefs": [
@@ -435,7 +435,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000030",
     "name": "Quantal negative charge",
     "xrefs": [
@@ -450,7 +450,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000031",
     "name": "Quantal positive charge",
     "xrefs": [
@@ -540,7 +540,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000037",
     "name": "photon",
     "xrefs": [
@@ -555,7 +555,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000038",
     "name": "Vector",
     "xrefs": [
@@ -572,10 +572,10 @@
   {
     "description": "Unit vector for the magnetic field",
     "id": "askemosw:0000039",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -585,7 +585,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000040",
     "name": "dimensionless unit",
     "xrefs": [
@@ -600,7 +600,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000041",
     "name": "Variable",
     "xrefs": [
@@ -630,7 +630,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000043",
     "name": "Constant",
     "xrefs": [
@@ -647,10 +647,10 @@
   {
     "description": "Planck's constant",
     "id": "askemosw:0000044",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -707,10 +707,10 @@
   {
     "description": "The Maxwellian-averaged momentum transfer cross section for species $n$.",
     "id": "askemosw:0000048",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -765,7 +765,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000052",
     "name": "Interplanetary medium",
     "xrefs": [
@@ -780,7 +780,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000053",
     "name": "Interplanetary magnetic fields",
     "xrefs": [
@@ -795,7 +795,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000054",
     "name": "magnetosphere",
     "xrefs": [
@@ -810,7 +810,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000055",
     "name": "Troposphere",
     "xrefs": [
@@ -825,7 +825,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000056",
     "name": "coordinate system",
     "xrefs": [
@@ -840,7 +840,7 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000057",
     "name": "spherical coordinate system",
     "xrefs": [
@@ -855,12 +855,12 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000058",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],
@@ -870,12 +870,12 @@
     "suggested_unit": null
   },
   {
-    "description": NaN,
+    "description": null,
     "id": "askemosw:0000059",
-    "name": NaN,
+    "name": null,
     "xrefs": [
       {
-        "id": NaN,
+        "id": null,
         "type": "skos:exactMatch"
       }
     ],

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -1,872 +1,7 @@
 [
   {
-    "id": "askemosw:0000001",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Matter Density",
-    "name": "Matter Density",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\rho"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:00101"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000002",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Molecular mass",
-    "name": "Molecular mass",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C75764"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000003",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Mass of the electron",
-    "name": "electronic mass",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "m_e"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "fix:0000508"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000004",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "molar mass",
-    "name": "molar mass",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\bar{m}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "om:MolarMass"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000005",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Number Density",
-    "name": "Material volumnal density",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "N_s"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01412"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000006",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "pressure",
-    "name": "Pressure",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C25195"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000007",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "partial pressure",
-    "name": "Partial gas pressure",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:00018"
-      },
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000006"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000008",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Absolute temperature",
-    "name": "Temperature",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C25206"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000009",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Electron temperature",
-    "name": "Temperature",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "T_e"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000008"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000010",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Ion temperature",
-    "name": "Temperature",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "T_i"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000008"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000011",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Velocity of neutral species",
-    "name": "Velocity",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{u}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C179817"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000012",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Time",
-    "name": "Time",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C25207"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000013",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Specific heat ratio or adiabatic index",
-    "name": "Heat capacity ratio",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\gamma"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000014",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Radial distance",
-    "name": "Radius",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C63921"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000015",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Eddy diffusion coefficient",
-    "name": "Eddy diffusion coefficient",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "K_e"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000016",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Diffusion coefficient",
-    "name": "Diffusion coefficient",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01306"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000017",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Gravitational acceleration",
-    "name": "Gravitational acceleration",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "om:GravitationalAcceleration"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000018",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "gravitational acceleration vector field",
-    "name": "gravitational acceleration vector",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{g}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000039"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000019",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Spatial angle",
-    "name": "Spatial angle",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01659"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000020",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "polar angle",
-    "name": "polar angle",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\theta"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000019"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000021",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "azimuthal angle",
-    "name": "azimuthal angle",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\phi"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000019"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000022",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Temporal Frequency",
-    "name": "Temporal Frequency",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\nu"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C25515"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000023",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Specific heat capacity",
-    "name": "Specific heat capacity",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01509"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000024",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Specific heat at constant volume",
-    "name": "Specific heat capacity at constant volume",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "c_\\text{v}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000023"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000025",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Specific heat at constant pressure",
-    "name": "Specific heat capacity at constant pressure",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "c_\\text{p}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000023"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000026",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Electron thermal conductivity",
-    "name": "Thermal conductivity",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\kappa"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01308"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000027",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Heat flow rate",
-    "name": "Heat flow rate",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{q}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:00201"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000028",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "The coefficient of viscosity",
-    "name": "viscosity coefficient",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\eta"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000029",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Molecular viscosity",
-    "name": "Fluid viscosity",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mu"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:00112"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000030",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "External electric field",
-    "name": "electric field",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{E}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "om:ElectricField"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000031",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Charge",
-    "name": "Charge",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01476"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000032",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Quantal negative charge",
-    "name": "Quantal negative charge",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01122"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000033",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Quantal positive charge",
-    "name": "Quantal positive charge",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01120"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000034",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Magnetic field",
-    "name": "Magnetic Fields",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{B}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "uat:994"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000035",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Free electron",
-    "name": "electron",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "chebi:10545"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000036",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "atomic cation",
-    "name": "Atomic cation",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01080"
-      }
-    ]
-  },
-  {
-    "id": "",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "atomic anion",
-    "name": "Atomic anion",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01040"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000037",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "molecular ion",
-    "name": "Charged molecule",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "opb:01160"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000038",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "photon",
-    "name": "photon",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "chebi:30212"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000039",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Vector",
-    "name": "Vector",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C54169"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000040",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "A vector of constant mangnitude equal to one",
-    "name": "unit vector",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{e}_{i}"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000039"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000041",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "dimensionless unit",
-    "name": "dimensionless unit",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "uo:0000186"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000042",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Variable",
-    "name": "Variable",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C54166"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000043",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "number of points along the field line, used to determine the relationship between $q, s, r\\,and \\theta$ in \\ref{sami_eq1} and \\ref{sami_eq2}",
-    "name": "Count",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "N_z"
-      }
-    ],
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C25463"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000044",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Constant",
-    "name": "Constant",
-    "xrefs": [
-      {
-        "type": "skos:exactMatch",
-        "id": "ncit:C64638"
-      }
-    ]
-  },
-  {
-    "id": "askemosw:0000045",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Planck's constant",
-    "name": "Planck's constant",
-    "xrefs": [
-      {
-        "type": "skos:broader",
-        "id": "askemosw:0000044"
-      }
-    ]
-  },
-  {
-    "id": "",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Reduced Planck's constant, hbar=h/2*pi",
+    "id": "",
     "name": "Reduced Planck's constant",
     "synonyms": [
       {
@@ -874,21 +9,681 @@
         "value": "\\hbar"
       }
     ],
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:broader",
-        "id": "askemosw:0000044"
+        "id": "askemosw:0000044",
+        "type": "skos:broader"
       }
     ]
   },
   {
-    "id": "askemosw:0000046",
+    "description": "Matter Density",
+    "id": "askemosw:0000001",
+    "name": "Matter Density",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\rho"
+      }
+    ],
     "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
+    "xrefs": [
+      {
+        "id": "opb:00101",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Molecular mass",
+    "id": "askemosw:0000002",
+    "name": "Molecular mass",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C75764",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Mass of the electron",
+    "id": "askemosw:0000003",
+    "name": "electronic mass",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "m_e"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "fix:0000508",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "molar mass",
+    "id": "askemosw:0000004",
+    "name": "molar mass",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\bar{m}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "om:MolarMass",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Number Density",
+    "id": "askemosw:0000005",
+    "name": "Material volumnal density",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "N_s"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01412",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "pressure",
+    "id": "askemosw:0000006",
+    "name": "Pressure",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C25195",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "partial pressure",
+    "id": "askemosw:0000007",
+    "name": "Partial gas pressure",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:00018",
+        "type": "skos:exactMatch"
+      },
+      {
+        "id": "askemosw:0000006",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "Absolute temperature",
+    "id": "askemosw:0000008",
+    "name": "Temperature",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C25206",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Electron temperature",
+    "id": "askemosw:0000009",
+    "name": "Temperature",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "T_e"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000008",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "Ion temperature",
+    "id": "askemosw:0000010",
+    "name": "Temperature",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "T_i"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000008",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "Velocity of neutral species",
+    "id": "askemosw:0000011",
+    "name": "Velocity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{u}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C179817",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Time",
+    "id": "askemosw:0000012",
+    "name": "Time",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C25207",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Specific heat ratio or adiabatic index",
+    "id": "askemosw:0000013",
+    "name": "Heat capacity ratio",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\gamma"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Radial distance",
+    "id": "askemosw:0000014",
+    "name": "Radius",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C63921",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Eddy diffusion coefficient",
+    "id": "askemosw:0000015",
+    "name": "Eddy diffusion coefficient",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "K_e"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Diffusion coefficient",
+    "id": "askemosw:0000016",
+    "name": "Diffusion coefficient",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01306",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Gravitational acceleration",
+    "id": "askemosw:0000017",
+    "name": "Gravitational acceleration",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "om:GravitationalAcceleration",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "gravitational acceleration vector field",
+    "id": "askemosw:0000018",
+    "name": "gravitational acceleration vector",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{g}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000039",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "Spatial angle",
+    "id": "askemosw:0000019",
+    "name": "Spatial angle",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01659",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "polar angle",
+    "id": "askemosw:0000020",
+    "name": "polar angle",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\theta"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000019",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "azimuthal angle",
+    "id": "askemosw:0000021",
+    "name": "azimuthal angle",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\phi"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000019",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "Temporal Frequency",
+    "id": "askemosw:0000022",
+    "name": "Temporal Frequency",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\nu"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C25515",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Specific heat capacity",
+    "id": "askemosw:0000023",
+    "name": "Specific heat capacity",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01509",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Specific heat at constant volume",
+    "id": "askemosw:0000024",
+    "name": "Specific heat capacity at constant volume",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "c_\\text{v}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000023",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "Specific heat at constant pressure",
+    "id": "askemosw:0000025",
+    "name": "Specific heat capacity at constant pressure",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "c_\\text{p}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000023",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "Electron thermal conductivity",
+    "id": "askemosw:0000026",
+    "name": "Thermal conductivity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\kappa"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01308",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Heat flow rate",
+    "id": "askemosw:0000027",
+    "name": "Heat flow rate",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{q}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:00201",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "The coefficient of viscosity",
+    "id": "askemosw:0000028",
+    "name": "viscosity coefficient",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\eta"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Molecular viscosity",
+    "id": "askemosw:0000029",
+    "name": "Fluid viscosity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mu"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:00112",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "External electric field",
+    "id": "askemosw:0000030",
+    "name": "electric field",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{E}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "om:ElectricField",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Charge",
+    "id": "askemosw:0000031",
+    "name": "Charge",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01476",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Quantal negative charge",
+    "id": "askemosw:0000032",
+    "name": "Quantal negative charge",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01122",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Quantal positive charge",
+    "id": "askemosw:0000033",
+    "name": "Quantal positive charge",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01120",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Magnetic field",
+    "id": "askemosw:0000034",
+    "name": "Magnetic Fields",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{B}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "uat:994",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Free electron",
+    "id": "askemosw:0000035",
+    "name": "electron",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "chebi:10545",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "atomic cation",
+    "id": "askemosw:0000036",
+    "name": "Atomic cation",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01080",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "molecular ion",
+    "id": "askemosw:0000037",
+    "name": "Charged molecule",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01160",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "photon",
+    "id": "askemosw:0000038",
+    "name": "photon",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "chebi:30212",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Vector",
+    "id": "askemosw:0000039",
+    "name": "Vector",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C54169",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "A vector of constant mangnitude equal to one",
+    "id": "askemosw:0000040",
+    "name": "unit vector",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{e}_{i}"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000039",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
+    "description": "dimensionless unit",
+    "id": "askemosw:0000041",
+    "name": "dimensionless unit",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "uo:0000186",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Variable",
+    "id": "askemosw:0000042",
+    "name": "Variable",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C54166",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "number of points along the field line, used to determine the relationship between $q, s, r\\,and \\theta$ in \\ref{sami_eq1} and \\ref{sami_eq2}",
+    "id": "askemosw:0000043",
+    "name": "Count",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "N_z"
+      }
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C25463",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Constant",
+    "id": "askemosw:0000044",
+    "name": "Constant",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "ncit:C64638",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "Planck's constant",
+    "id": "askemosw:0000045",
+    "name": "Planck's constant",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "askemosw:0000044",
+        "type": "skos:broader"
+      }
+    ]
+  },
+  {
     "description": "Boltzmann constant",
+    "id": "askemosw:0000046",
     "name": "Boltzmann constant",
     "synonyms": [
       {
@@ -896,25 +691,21 @@
         "value": "k_B"
       }
     ],
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "opb:01625"
+        "id": "opb:01625",
+        "type": "skos:exactMatch"
       },
       {
-        "type": "skos:broader",
-        "id": "askemosw:0000044"
+        "id": "askemosw:0000044",
+        "type": "skos:broader"
       }
     ]
   },
   {
-    "id": "askemosw:0000047",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Gas constant",
+    "id": "askemosw:0000047",
     "name": "gas constant",
     "synonyms": [
       {
@@ -922,25 +713,21 @@
         "value": "R^*"
       }
     ],
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "om:GasConstant"
+        "id": "om:GasConstant",
+        "type": "skos:exactMatch"
       },
       {
-        "type": "skos:broader",
-        "id": "askemosw:0000044"
+        "id": "askemosw:0000044",
+        "type": "skos:broader"
       }
     ]
   },
   {
-    "id": "askemosw:0000048",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Avagadro constant",
+    "id": "askemosw:0000048",
     "name": "Avogadro constant",
     "synonyms": [
       {
@@ -948,164 +735,129 @@
         "value": "N_A"
       }
     ],
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "opb:01622"
+        "id": "opb:01622",
+        "type": "skos:exactMatch"
       },
       {
-        "type": "skos:broader",
-        "id": "askemosw:0000044"
+        "id": "askemosw:0000044",
+        "type": "skos:broader"
       }
     ]
   },
   {
-    "id": "askemosw:0000049",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "cross section",
-    "name": "cross section"
+    "id": "askemosw:0000049",
+    "name": "cross section",
+    "type": "class"
   },
   {
+    "description": "Region in the upper atmosphere",
     "id": "askemosw:0000050",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
-    "description": "Region in the upper atmosphere",
     "name": "Thermosphere",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "uat:1694"
+        "id": "uat:1694",
+        "type": "skos:exactMatch"
       },
       {
-        "type": "skos:exactMatch",
-        "id": "envo:01000541"
+        "id": "envo:01000541",
+        "type": "skos:exactMatch"
       }
     ]
   },
   {
-    "id": "askemosw:0000051",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Region in the upper atmosphere",
+    "id": "askemosw:0000051",
     "name": "Earth Ionosphere",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "uat:860"
+        "id": "uat:860",
+        "type": "skos:exactMatch"
       },
       {
-        "type": "skos:exactMatch",
-        "id": "envo:01000545"
+        "id": "envo:01000545",
+        "type": "skos:exactMatch"
       }
     ]
   },
   {
-    "id": "askemosw:0000052",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Outermost atmosphere of the Sun",
+    "id": "askemosw:0000052",
     "name": "Solar corona",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "uat:1483"
+        "id": "uat:1483",
+        "type": "skos:exactMatch"
       }
     ]
   },
   {
-    "id": "askemosw:0000053",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Interplanetary medium",
+    "id": "askemosw:0000053",
     "name": "Interplanetary medium",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "uat:825"
+        "id": "uat:825",
+        "type": "skos:exactMatch"
       }
     ]
   },
   {
-    "id": "askemosw:0000054",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Interplanetary magnetic fields",
+    "id": "askemosw:0000054",
     "name": "Interplanetary magnetic fields",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "uat:824"
+        "id": "uat:824",
+        "type": "skos:exactMatch"
       },
       {
-        "type": "skos:broader",
-        "id": "askemosw:0000034"
+        "id": "askemosw:0000034",
+        "type": "skos:broader"
       }
     ]
   },
   {
-    "id": "askemosw:0000055",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "magnetosphere",
+    "id": "askemosw:0000055",
     "name": "magnetosphere",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "envo:01001194"
+        "id": "envo:01001194",
+        "type": "skos:exactMatch"
       }
     ]
   },
   {
-    "id": "askemosw:0000056",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "Troposphere",
+    "id": "askemosw:0000056",
     "name": "Troposphere",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "uat:1718"
+        "id": "uat:1718",
+        "type": "skos:exactMatch"
       }
     ]
   },
   {
-    "id": "askemosw:0000057",
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null,
-    "dimension": null,
     "description": "coordinate system",
+    "id": "askemosw:0000057",
     "name": "coordinate system",
+    "type": "class",
     "xrefs": [
       {
-        "type": "skos:exactMatch",
-        "id": "stato:0000010"
+        "id": "stato:0000010",
+        "type": "skos:exactMatch"
       }
     ]
   }

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -838,5 +838,38 @@
         "type": "skos:exactMatch"
       }
     ]
+  },
+  {
+    "description": "spherical coordinate system",
+    "id": "askemosw:0000060",
+    "name": "spherical coordinate system",
+    "parents": [
+      "askemosw:0000059"
+    ],
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "stato:0000014",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "dipole coordinate system",
+    "id": "askemosw:0000061",
+    "name": "dipole coordinate system",
+    "parents": [
+      "askemosw:0000059"
+    ],
+    "type": "class"
+  },
+  {
+    "description": "geomagnetic latitude, longitude, altitude (GLA) coordinate system",
+    "id": "askemosw:0000062",
+    "name": "geomagnetic latitude, longitude, altitude (GLA) coordinate system",
+    "parents": [
+      "askemosw:0000059"
+    ],
+    "type": "class"
   }
 ]

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -61,7 +61,7 @@
     "type": "class",
     "xrefs": [
       {
-        "id": "om:MolarMass",
+        "id": "uo:MolarMass",
         "type": "skos:exactMatch"
       }
     ]
@@ -238,7 +238,7 @@
     "type": "class",
     "xrefs": [
       {
-        "id": "om:GravitationalAcceleration",
+        "id": "uo:GravitationalAcceleration",
         "type": "skos:exactMatch"
       }
     ]
@@ -248,7 +248,7 @@
     "id": "askemosw:0000018",
     "name": "gravitational acceleration vector",
     "parents": [
-      "askemosw:0000039"
+      "askemosw:0000040"
     ],
     "synonyms": [
       {
@@ -439,7 +439,7 @@
     "type": "class",
     "xrefs": [
       {
-        "id": "om:ElectricField",
+        "id": "uo:ElectricField",
         "type": "skos:exactMatch"
       }
     ]
@@ -523,8 +523,20 @@
     ]
   },
   {
-    "description": "molecular ion",
+    "description": "atomic anion",
     "id": "askemosw:0000037",
+    "name": "Atomic anion",
+    "type": "class",
+    "xrefs": [
+      {
+        "id": "opb:01040",
+        "type": "skos:exactMatch"
+      }
+    ]
+  },
+  {
+    "description": "molecular ion",
+    "id": "askemosw:0000038",
     "name": "Charged molecule",
     "type": "class",
     "xrefs": [
@@ -536,7 +548,7 @@
   },
   {
     "description": "photon",
-    "id": "askemosw:0000038",
+    "id": "askemosw:0000039",
     "name": "photon",
     "type": "class",
     "xrefs": [
@@ -548,7 +560,7 @@
   },
   {
     "description": "Vector",
-    "id": "askemosw:0000039",
+    "id": "askemosw:0000040",
     "name": "Vector",
     "type": "class",
     "xrefs": [
@@ -560,10 +572,10 @@
   },
   {
     "description": "A vector of constant mangnitude equal to one",
-    "id": "askemosw:0000040",
+    "id": "askemosw:0000041",
     "name": "unit vector",
     "parents": [
-      "askemosw:0000039"
+      "askemosw:0000040"
     ],
     "synonyms": [
       {
@@ -575,7 +587,7 @@
   },
   {
     "description": "dimensionless unit",
-    "id": "askemosw:0000041",
+    "id": "askemosw:0000042",
     "name": "dimensionless unit",
     "type": "class",
     "xrefs": [
@@ -587,7 +599,7 @@
   },
   {
     "description": "Variable",
-    "id": "askemosw:0000042",
+    "id": "askemosw:0000043",
     "name": "Variable",
     "type": "class",
     "xrefs": [
@@ -599,7 +611,7 @@
   },
   {
     "description": "number of points along the field line, used to determine the relationship between $q, s, r\\,and \\theta$ in \\ref{sami_eq1} and \\ref{sami_eq2}",
-    "id": "askemosw:0000043",
+    "id": "askemosw:0000044",
     "name": "Count",
     "synonyms": [
       {
@@ -617,7 +629,7 @@
   },
   {
     "description": "Constant",
-    "id": "askemosw:0000044",
+    "id": "askemosw:0000045",
     "name": "Constant",
     "type": "class",
     "xrefs": [
@@ -629,19 +641,34 @@
   },
   {
     "description": "Planck's constant",
-    "id": "askemosw:0000045",
+    "id": "askemosw:0000046",
     "name": "Planck's constant",
     "parents": [
-      "askemosw:0000044"
+      "askemosw:0000045"
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Reduced Planck's constant, hbar=h/2*pi",
+    "id": "askemosw:0000047",
+    "name": "Reduced Planck's constant",
+    "parents": [
+      "askemosw:0000045"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\hbar"
+      }
     ],
     "type": "class"
   },
   {
     "description": "Boltzmann constant",
-    "id": "askemosw:0000046",
+    "id": "askemosw:0000048",
     "name": "Boltzmann constant",
     "parents": [
-      "askemosw:0000044"
+      "askemosw:0000045"
     ],
     "synonyms": [
       {
@@ -659,10 +686,10 @@
   },
   {
     "description": "Gas constant",
-    "id": "askemosw:0000047",
+    "id": "askemosw:0000049",
     "name": "gas constant",
     "parents": [
-      "askemosw:0000044"
+      "askemosw:0000045"
     ],
     "synonyms": [
       {
@@ -673,17 +700,17 @@
     "type": "class",
     "xrefs": [
       {
-        "id": "om:GasConstant",
+        "id": "uo:GasConstant",
         "type": "skos:exactMatch"
       }
     ]
   },
   {
     "description": "Avagadro constant",
-    "id": "askemosw:0000048",
+    "id": "askemosw:0000050",
     "name": "Avogadro constant",
     "parents": [
-      "askemosw:0000044"
+      "askemosw:0000045"
     ],
     "synonyms": [
       {
@@ -701,13 +728,13 @@
   },
   {
     "description": "cross section",
-    "id": "askemosw:0000049",
+    "id": "askemosw:0000051",
     "name": "cross section",
     "type": "class"
   },
   {
     "description": "Region in the upper atmosphere",
-    "id": "askemosw:0000050",
+    "id": "askemosw:0000052",
     "name": "Thermosphere",
     "type": "class",
     "xrefs": [
@@ -723,7 +750,7 @@
   },
   {
     "description": "Region in the upper atmosphere",
-    "id": "askemosw:0000051",
+    "id": "askemosw:0000053",
     "name": "Earth Ionosphere",
     "type": "class",
     "xrefs": [
@@ -739,7 +766,7 @@
   },
   {
     "description": "Outermost atmosphere of the Sun",
-    "id": "askemosw:0000052",
+    "id": "askemosw:0000054",
     "name": "Solar corona",
     "type": "class",
     "xrefs": [
@@ -751,7 +778,7 @@
   },
   {
     "description": "Interplanetary medium",
-    "id": "askemosw:0000053",
+    "id": "askemosw:0000055",
     "name": "Interplanetary medium",
     "type": "class",
     "xrefs": [
@@ -763,7 +790,7 @@
   },
   {
     "description": "Interplanetary magnetic fields",
-    "id": "askemosw:0000054",
+    "id": "askemosw:0000056",
     "name": "Interplanetary magnetic fields",
     "parents": [
       "askemosw:0000034"
@@ -778,7 +805,7 @@
   },
   {
     "description": "magnetosphere",
-    "id": "askemosw:0000055",
+    "id": "askemosw:0000057",
     "name": "magnetosphere",
     "type": "class",
     "xrefs": [
@@ -790,7 +817,7 @@
   },
   {
     "description": "Troposphere",
-    "id": "askemosw:0000056",
+    "id": "askemosw:0000058",
     "name": "Troposphere",
     "type": "class",
     "xrefs": [
@@ -802,7 +829,7 @@
   },
   {
     "description": "coordinate system",
-    "id": "askemosw:0000057",
+    "id": "askemosw:0000059",
     "name": "coordinate system",
     "type": "class",
     "xrefs": [

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -1,1061 +1,1112 @@
 [
   {
-    "description": "Total mass density",
+    "id": "askemosw:0000001",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Matter Density",
+    "name": "Matter Density",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\rho"
       }
     ],
-    "id": "askemosw:0000001",
-    "name": "Matter Density",
     "xrefs": [
       {
-        "id": "opb:00101",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "opb:00101"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000002",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000002",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Molecular mass",
     "name": "Molecular mass",
     "xrefs": [
       {
-        "id": "ncit:C75764",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C75764"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000003",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Mass of the electron",
+    "name": "electronic mass",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "m_e"
       }
     ],
-    "id": "askemosw:0000003",
-    "name": "electronic mass",
     "xrefs": [
       {
-        "id": "fix:0000508",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "fix:0000508"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000004",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Mean atmospheric mass",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "molar mass",
+    "name": "molar mass",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\bar{m}"
       }
     ],
-    "id": "askemosw:0000004",
-    "name": "molar mass",
     "xrefs": [
       {
-        "id": "om:MolarMass",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "om:MolarMass"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000005",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Number Density",
+    "name": "Material volumnal density",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "N_s"
       }
     ],
-    "id": "askemosw:0000005",
-    "name": "Material volumnal density",
     "xrefs": [
       {
-        "id": "opb:01412",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "opb:01412"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000006",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "neutral pressure",
-    "id": "askemosw:0000006",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "pressure",
     "name": "Pressure",
     "xrefs": [
       {
-        "id": "ncit:C25195",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C25195"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000007",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "partial pressure",
-    "id": "askemosw:0000007",
     "name": "Partial gas pressure",
     "xrefs": [
       {
-        "id": "opb:00018",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "opb:00018"
+      },
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000006"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000008",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Absolute temperature",
-    "id": "askemosw:0000008",
     "name": "Temperature",
     "xrefs": [
       {
-        "id": "ncit:C25206",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C25206"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000009",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Electron temperature",
+    "name": "Temperature",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "T_e"
       }
     ],
-    "id": "askemosw:0000009",
-    "name": "Temperature",
     "xrefs": [
       {
-        "id": "ncit:C25206",
-        "type": "skos:exactMatch"
+        "type": "skos:broader",
+        "id": "askemosw:0000008"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000010",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Absolute temperature of ion",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Ion temperature",
+    "name": "Temperature",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "T_i"
       }
     ],
-    "id": "askemosw:0000010",
-    "name": "Temperature",
     "xrefs": [
       {
-        "id": "ncit:C25206",
-        "type": "skos:exactMatch"
+        "type": "skos:broader",
+        "id": "askemosw:0000008"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000011",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Velocity of neutral species",
+    "name": "Velocity",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\mathbf{u}"
       }
     ],
-    "id": "askemosw:0000011",
-    "name": "Velocity",
     "xrefs": [
       {
-        "id": "ncit:C179817",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C179817"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000012",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Time",
-    "id": "askemosw:0000012",
     "name": "Time",
     "xrefs": [
       {
-        "id": "ncit:C25207",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C25207"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000013",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Specific heat ratio or adiabatic index",
+    "name": "Heat capacity ratio",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\gamma"
       }
-    ],
-    "id": "askemosw:0000013",
-    "name": null,
-    "xrefs": [
-      {
-        "id": null,
-        "type": "skos:exactMatch"
-      }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000014",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Radial distance",
-    "id": "askemosw:0000014",
     "name": "Radius",
     "xrefs": [
       {
-        "id": "ncit:C63921",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C63921"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000015",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Eddy diffusion coefficient",
+    "name": "Eddy diffusion coefficient",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "K_e"
       }
-    ],
-    "id": "askemosw:0000015",
-    "name": null,
-    "xrefs": [
-      {
-        "id": null,
-        "type": "skos:exactMatch"
-      }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000016",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Diffusion coefficient between species $s$ and $q$",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "D_{qs}"
-      }
-    ],
-    "id": "askemosw:0000016",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Diffusion coefficient",
     "name": "Diffusion coefficient",
     "xrefs": [
       {
-        "id": "opb:01306",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "opb:01306"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000017",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Radial component of gravitational acceleration",
-    "id": "askemosw:0000017",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Gravitational acceleration",
     "name": "Gravitational acceleration",
     "xrefs": [
       {
-        "id": "om:GravitationalAcceleration",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "om:GravitationalAcceleration"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000018",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "gravitational acceleration vector field",
+    "name": "gravitational acceleration vector",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\mathbf{g}"
       }
     ],
-    "id": "askemosw:0000018",
-    "name": null,
     "xrefs": [
       {
-        "id": null,
-        "type": "skos:exactMatch"
+        "type": "skos:broader",
+        "id": "askemosw:0000039"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000019",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Spatial angle",
+    "name": "Spatial angle",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01659"
+      }
+    ]
   },
   {
-    "description": "e.g. North latitude",
+    "id": "askemosw:0000020",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "polar angle",
+    "name": "polar angle",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\theta"
       }
     ],
-    "id": "askemosw:0000019",
-    "name": "Spatial angle",
     "xrefs": [
       {
-        "id": "opb:01659",
-        "type": "skos:exactMatch"
+        "type": "skos:broader",
+        "id": "askemosw:0000019"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000021",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "e.g. East Longitude",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "azimuthal angle",
+    "name": "azimuthal angle",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\phi"
       }
     ],
-    "id": "askemosw:0000020",
-    "name": "Spatial angle",
     "xrefs": [
       {
-        "id": "opb:01659",
-        "type": "skos:exactMatch"
+        "type": "skos:broader",
+        "id": "askemosw:0000019"
       }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
+    ]
   },
   {
-    "description": "Ion-neutral collision frequency",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\nu_{in}"
-      }
-    ],
-    "id": "askemosw:0000021",
-    "name": "Temporal Frequency",
-    "xrefs": [
-      {
-        "id": "ncit:C25515",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Specific heat at constant volume",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "c_\\text{v}"
-      }
-    ],
     "id": "askemosw:0000022",
-    "name": "Specific heat capacity",
-    "xrefs": [
-      {
-        "id": "opb:01509",
-        "type": "skos:exactMatch"
-      }
-    ],
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Specific heat at constant pressure",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "C_p"
-      }
-    ],
-    "id": "askemosw:0000023",
-    "name": "Specific heat capacity",
-    "xrefs": [
-      {
-        "id": "opb:01509",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Electron thermal conductivity",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\kappa_e"
-      }
-    ],
-    "id": "askemosw:0000024",
-    "name": "Thermal conductivity",
-    "xrefs": [
-      {
-        "id": "opb:01308",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "e.g. Electron heat flux",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{q}_e"
-      }
-    ],
-    "id": "askemosw:0000025",
-    "name": "Heat flow rate",
-    "xrefs": [
-      {
-        "id": "opb:00201",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "The coefficient of viscosity",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\eta"
-      }
-    ],
-    "id": "askemosw:0000026",
-    "name": null,
-    "xrefs": [
-      {
-        "id": null,
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Molecular viscosity",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mu"
-      }
-    ],
-    "id": "askemosw:0000027",
-    "name": "Fluid viscosity",
-    "xrefs": [
-      {
-        "id": "opb:00112",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "External electric field",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{E}"
-      }
-    ],
-    "id": "askemosw:0000028",
-    "name": "electric field",
-    "xrefs": [
-      {
-        "id": "om:ElectricField",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000029",
-    "name": "Charge",
-    "xrefs": [
-      {
-        "id": "opb:01476",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000030",
-    "name": "Quantal negative charge",
-    "xrefs": [
-      {
-        "id": "opb:01122",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000031",
-    "name": "Quantal positive charge",
-    "xrefs": [
-      {
-        "id": "opb:01120",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Magnetic field",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\mathbf{B}"
-      }
-    ],
-    "id": "askemosw:0000032",
-    "name": "Magnetic Fields",
-    "xrefs": [
-      {
-        "id": "uat:994",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Free electron",
-    "id": "askemosw:0000033",
-    "name": "electron",
-    "xrefs": [
-      {
-        "id": "chebi:10545",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "atomic cation",
-    "id": "askemosw:0000034",
-    "name": "Atomic cation",
-    "xrefs": [
-      {
-        "id": "opb:01080",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "molecular ion",
-    "id": "askemosw:0000035",
-    "name": "Charged molecule",
-    "xrefs": [
-      {
-        "id": "opb:01160",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "e.g. Photon frequency",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Temporal Frequency",
+    "name": "Temporal Frequency",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\nu"
       }
     ],
-    "id": "askemosw:0000036",
-    "name": "Temporal Frequency",
     "xrefs": [
       {
-        "id": "ncit:C25515",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C25515"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000023",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000037",
-    "name": "photon",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Specific heat capacity",
+    "name": "Specific heat capacity",
     "xrefs": [
       {
-        "id": "chebi:30212",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "opb:01509"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000024",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000038",
-    "name": "Vector",
-    "xrefs": [
-      {
-        "id": "ncit:C54169",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Unit vector for the magnetic field",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Specific heat at constant volume",
+    "name": "Specific heat capacity at constant volume",
     "synonyms": [
       {
         "type": "referenced_by_latex",
-        "value": "\\mathbf{b}"
+        "value": "c_\\text{v}"
       }
     ],
-    "id": "askemosw:0000039",
-    "name": null,
     "xrefs": [
       {
-        "id": null,
-        "type": "skos:exactMatch"
+        "type": "skos:broader",
+        "id": "askemosw:0000023"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000025",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Specific heat at constant pressure",
+    "name": "Specific heat capacity at constant pressure",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "c_\\text{p}"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000023"
+      }
+    ]
   },
   {
-    "description": null,
+    "id": "askemosw:0000026",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Electron thermal conductivity",
+    "name": "Thermal conductivity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\kappa"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01308"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000027",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Heat flow rate",
+    "name": "Heat flow rate",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{q}"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:00201"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000028",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "The coefficient of viscosity",
+    "name": "viscosity coefficient",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\eta"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000029",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Molecular viscosity",
+    "name": "Fluid viscosity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mu"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:00112"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000030",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "External electric field",
+    "name": "electric field",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{E}"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "om:ElectricField"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000031",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Charge",
+    "name": "Charge",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01476"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000032",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Quantal negative charge",
+    "name": "Quantal negative charge",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01122"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000033",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Quantal positive charge",
+    "name": "Quantal positive charge",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01120"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000034",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Magnetic field",
+    "name": "Magnetic Fields",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{B}"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "uat:994"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000035",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Free electron",
+    "name": "electron",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "chebi:10545"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000036",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "atomic cation",
+    "name": "Atomic cation",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01080"
+      }
+    ]
+  },
+  {
+    "id": "",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "atomic anion",
+    "name": "Atomic anion",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01040"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000037",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "molecular ion",
+    "name": "Charged molecule",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "opb:01160"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000038",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "photon",
+    "name": "photon",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "chebi:30212"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000039",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Vector",
+    "name": "Vector",
+    "xrefs": [
+      {
+        "type": "skos:exactMatch",
+        "id": "ncit:C54169"
+      }
+    ]
+  },
+  {
     "id": "askemosw:0000040",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "A vector of constant mangnitude equal to one",
+    "name": "unit vector",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{e}_{i}"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000039"
+      }
+    ]
+  },
+  {
+    "id": "askemosw:0000041",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "dimensionless unit",
     "name": "dimensionless unit",
     "xrefs": [
       {
-        "id": "uo:0000186",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "uo:0000186"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000042",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000041",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Variable",
     "name": "Variable",
     "xrefs": [
       {
-        "id": "ncit:C54166",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C54166"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000043",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "number of points along the field line, used to determine the relationship between $q, s, r\\,and \\theta$ in \\ref{sami_eq1} and \\ref{sami_eq2}",
+    "name": "Count",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "N_z"
       }
     ],
-    "id": "askemosw:0000042",
-    "name": "Count",
     "xrefs": [
       {
-        "id": "ncit:C25463",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C25463"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000044",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000043",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Constant",
     "name": "Constant",
     "xrefs": [
       {
-        "id": "ncit:C64638",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "ncit:C64638"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000045",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Planck's constant",
-    "id": "askemosw:0000044",
-    "name": null,
+    "name": "Planck's constant",
     "xrefs": [
       {
-        "id": null,
-        "type": "skos:exactMatch"
+        "type": "skos:broader",
+        "id": "askemosw:0000044"
       }
-    ],
+    ]
+  },
+  {
+    "id": "",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Reduced Planck's constant, hbar=h/2*pi",
+    "name": "Reduced Planck's constant",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\hbar"
+      }
+    ],
+    "xrefs": [
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000044"
+      }
+    ]
   },
   {
+    "id": "askemosw:0000046",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Boltzmann constant",
+    "name": "Boltzmann constant",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "k_B"
       }
     ],
-    "id": "askemosw:0000045",
-    "name": "Boltzmann constant",
     "xrefs": [
       {
-        "id": "opb:01625",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "opb:01625"
+      },
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000044"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000047",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Gas constant",
+    "name": "gas constant",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "R^*"
       }
     ],
-    "id": "askemosw:0000046",
-    "name": "gas constant",
     "xrefs": [
       {
-        "id": "om:GasConstant",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "om:GasConstant"
+      },
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000044"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000048",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Avagadro constant",
+    "name": "Avogadro constant",
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "N_A"
       }
     ],
-    "id": "askemosw:0000047",
-    "name": "Avogadro constant",
     "xrefs": [
       {
-        "id": "opb:01622",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "opb:01622"
+      },
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000044"
       }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
+    ]
   },
   {
-    "description": "The Maxwellian-averaged momentum transfer cross section for species $n$.",
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "(q_D)_n"
-      }
-    ],
-    "id": "askemosw:0000048",
-    "name": null,
-    "xrefs": [
-      {
-        "id": null,
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": "Region in the upper atmosphere",
     "id": "askemosw:0000049",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "cross section",
+    "name": "cross section"
+  },
+  {
+    "id": "askemosw:0000050",
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Region in the upper atmosphere",
     "name": "Thermosphere",
     "xrefs": [
       {
-        "id": "uat:1694",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "uat:1694"
+      },
+      {
+        "type": "skos:exactMatch",
+        "id": "envo:01000541"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000051",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Region in the upper atmosphere",
-    "id": "askemosw:0000050",
     "name": "Earth Ionosphere",
     "xrefs": [
       {
-        "id": "uat:860",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "uat:860"
+      },
+      {
+        "type": "skos:exactMatch",
+        "id": "envo:01000545"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000052",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
+    "suggested_unit": null,
+    "dimension": null,
     "description": "Outermost atmosphere of the Sun",
-    "id": "askemosw:0000051",
     "name": "Solar corona",
     "xrefs": [
       {
-        "id": "uat:1483",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "uat:1483"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000053",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000052",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Interplanetary medium",
     "name": "Interplanetary medium",
     "xrefs": [
       {
-        "id": "uat:825",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "uat:825"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000054",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000053",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Interplanetary magnetic fields",
     "name": "Interplanetary magnetic fields",
     "xrefs": [
       {
-        "id": "uat:824",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "uat:824"
+      },
+      {
+        "type": "skos:broader",
+        "id": "askemosw:0000034"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000055",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000054",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "magnetosphere",
     "name": "magnetosphere",
     "xrefs": [
       {
-        "id": "envo:01001194",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "envo:01001194"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000056",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000055",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "Troposphere",
     "name": "Troposphere",
     "xrefs": [
       {
-        "id": "uat:1718",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "uat:1718"
       }
-    ],
+    ]
+  },
+  {
+    "id": "askemosw:0000057",
     "type": "class",
     "physical_min": null,
     "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000056",
+    "suggested_unit": null,
+    "dimension": null,
+    "description": "coordinate system",
     "name": "coordinate system",
     "xrefs": [
       {
-        "id": "stato:0000010",
-        "type": "skos:exactMatch"
+        "type": "skos:exactMatch",
+        "id": "stato:0000010"
       }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000057",
-    "name": "spherical coordinate system",
-    "xrefs": [
-      {
-        "id": "stato:0000014",
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000058",
-    "name": null,
-    "xrefs": [
-      {
-        "id": null,
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
-  },
-  {
-    "description": null,
-    "id": "askemosw:0000059",
-    "name": null,
-    "xrefs": [
-      {
-        "id": null,
-        "type": "skos:exactMatch"
-      }
-    ],
-    "type": "class",
-    "physical_min": null,
-    "suggested_data_type": null,
-    "suggested_unit": null
+    ]
   }
 ]

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -1,0 +1,887 @@
+[
+  {
+    "description": "Total mass density",
+    "id": "askemosw:0000001",
+    "name": "Matter Density",
+    "xrefs": [
+      {
+        "id": "opb:00101",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000002",
+    "name": "Molecular mass",
+    "xrefs": [
+      {
+        "id": "ncit:C75764",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Mass of the electron",
+    "id": "askemosw:0000003",
+    "name": "electronic mass",
+    "xrefs": [
+      {
+        "id": "fix:0000508",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Mean atmospheric mass",
+    "id": "askemosw:0000004",
+    "name": "molar mass",
+    "xrefs": [
+      {
+        "id": "om:MolarMass",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Number Density",
+    "id": "askemosw:0000005",
+    "name": "Material volumnal density",
+    "xrefs": [
+      {
+        "id": "opb:01412",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "neutral pressure",
+    "id": "askemosw:0000006",
+    "name": "Pressure",
+    "xrefs": [
+      {
+        "id": "ncit:C25195",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "partial pressure",
+    "id": "askemosw:0000007",
+    "name": "Partial gas pressure",
+    "xrefs": [
+      {
+        "id": "opb:00018",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Absolute temperature",
+    "id": "askemosw:0000008",
+    "name": "Temperature",
+    "xrefs": [
+      {
+        "id": "ncit:C25206",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Electron temperature",
+    "id": "askemosw:0000009",
+    "name": "Temperature",
+    "xrefs": [
+      {
+        "id": "ncit:C25206",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Absolute temperature of ion",
+    "id": "askemosw:0000010",
+    "name": "Temperature",
+    "xrefs": [
+      {
+        "id": "ncit:C25206",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Velocity of neutral species",
+    "id": "askemosw:0000011",
+    "name": "Velocity",
+    "xrefs": [
+      {
+        "id": "ncit:C179817",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Time",
+    "id": "askemosw:0000012",
+    "name": "Time",
+    "xrefs": [
+      {
+        "id": "ncit:C25207",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Specific heat ratio or adiabatic index",
+    "id": "askemosw:0000013",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Radial distance",
+    "id": "askemosw:0000014",
+    "name": "Radius",
+    "xrefs": [
+      {
+        "id": "ncit:C63921",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Eddy diffusion coefficient",
+    "id": "askemosw:0000015",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Diffusion coefficient between species $s$ and $q$",
+    "id": "askemosw:0000016",
+    "name": "Diffusion coefficient",
+    "xrefs": [
+      {
+        "id": "opb:01306",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Radial component of gravitational acceleration",
+    "id": "askemosw:0000017",
+    "name": "Gravitational acceleration",
+    "xrefs": [
+      {
+        "id": "om:GravitationalAcceleration",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "gravitational acceleration vector field",
+    "id": "askemosw:0000018",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "e.g. North latitude",
+    "id": "askemosw:0000019",
+    "name": "Spatial angle",
+    "xrefs": [
+      {
+        "id": "opb:01659",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "e.g. East Longitude",
+    "id": "askemosw:0000020",
+    "name": "Spatial angle",
+    "xrefs": [
+      {
+        "id": "opb:01659",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Ion-neutral collision frequency",
+    "id": "askemosw:0000021",
+    "name": "Temporal Frequency",
+    "xrefs": [
+      {
+        "id": "ncit:C25515",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Specific heat at constant volume",
+    "id": "askemosw:0000022",
+    "name": "Specific heat capacity",
+    "xrefs": [
+      {
+        "id": "opb:01509",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Specific heat at constant pressure",
+    "id": "askemosw:0000023",
+    "name": "Specific heat capacity",
+    "xrefs": [
+      {
+        "id": "opb:01509",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Electron thermal conductivity",
+    "id": "askemosw:0000024",
+    "name": "Thermal conductivity",
+    "xrefs": [
+      {
+        "id": "opb:01308",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "e.g. Electron heat flux",
+    "id": "askemosw:0000025",
+    "name": "Heat flow rate",
+    "xrefs": [
+      {
+        "id": "opb:00201?",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "The coefficient of viscosity",
+    "id": "askemosw:0000026",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Molecular viscosity",
+    "id": "askemosw:0000027",
+    "name": "Fluid viscosity",
+    "xrefs": [
+      {
+        "id": "opb:00112",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "External electric field",
+    "id": "askemosw:0000028",
+    "name": "electric field",
+    "xrefs": [
+      {
+        "id": "om:ElectricField",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000029",
+    "name": "Charge",
+    "xrefs": [
+      {
+        "id": "opb:01476",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000030",
+    "name": "Quantal negative charge",
+    "xrefs": [
+      {
+        "id": "opb:01122",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000031",
+    "name": "Quantal positive charge",
+    "xrefs": [
+      {
+        "id": "opb:01120",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Magnetic field",
+    "id": "askemosw:0000032",
+    "name": "Magnetic Fields",
+    "xrefs": [
+      {
+        "id": "uat:994",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Free electron",
+    "id": "askemosw:0000033",
+    "name": "electron",
+    "xrefs": [
+      {
+        "id": "chebi:10545",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "atomic cation",
+    "id": "askemosw:0000034",
+    "name": "Atomic cation",
+    "xrefs": [
+      {
+        "id": "opb:01080",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "molecular ion",
+    "id": "askemosw:0000035",
+    "name": "Charged molecule",
+    "xrefs": [
+      {
+        "id": "opb:01160",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "e.g. Photon frequency",
+    "id": "askemosw:0000036",
+    "name": "Temporal Frequency",
+    "xrefs": [
+      {
+        "id": "ncit:C25515",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000037",
+    "name": "photon",
+    "xrefs": [
+      {
+        "id": "chebi:30212",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000038",
+    "name": "Vector",
+    "xrefs": [
+      {
+        "id": "ncit:C54169",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Unit vector for the magnetic field",
+    "id": "askemosw:0000039",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000040",
+    "name": "dimensionless unit",
+    "xrefs": [
+      {
+        "id": "uo:0000186",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000041",
+    "name": "Variable",
+    "xrefs": [
+      {
+        "id": "ncit:C54166",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "number of points along the field line, used to determine the relationship between $q, s, r\\,and \\theta$ in \\ref{sami_eq1} and \\ref{sami_eq2}",
+    "id": "askemosw:0000042",
+    "name": "Count",
+    "xrefs": [
+      {
+        "id": "ncit:C25463",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000043",
+    "name": "Constant",
+    "xrefs": [
+      {
+        "id": "ncit:C64638",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Planck's constant",
+    "id": "askemosw:0000044",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Boltzmann constant",
+    "id": "askemosw:0000045",
+    "name": "Boltzmann constant",
+    "xrefs": [
+      {
+        "id": "opb:01625",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Gas constant",
+    "id": "askemosw:0000046",
+    "name": "gas constant",
+    "xrefs": [
+      {
+        "id": "om:GasConstant",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Avagadro constant",
+    "id": "askemosw:0000047",
+    "name": "Avogadro constant",
+    "xrefs": [
+      {
+        "id": "opb:01622",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "The Maxwellian-averaged momentum transfer cross section for species $n$.",
+    "id": "askemosw:0000048",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Region in the upper atmosphere",
+    "id": "askemosw:0000049",
+    "name": "Thermosphere",
+    "xrefs": [
+      {
+        "id": "uat:1694",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Region in the upper atmosphere",
+    "id": "askemosw:0000050",
+    "name": "Earth Ionosphere",
+    "xrefs": [
+      {
+        "id": "uat:860",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": "Outermost atmosphere of the Sun",
+    "id": "askemosw:0000051",
+    "name": "Solar corona",
+    "xrefs": [
+      {
+        "id": "uat:1483",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000052",
+    "name": "Interplanetary medium",
+    "xrefs": [
+      {
+        "id": "uat:825",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000053",
+    "name": "Interplanetary magnetic fields",
+    "xrefs": [
+      {
+        "id": "uat:824",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000054",
+    "name": "magnetosphere",
+    "xrefs": [
+      {
+        "id": "envo:01001194",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000055",
+    "name": "Troposphere",
+    "xrefs": [
+      {
+        "id": "uat:1718",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000056",
+    "name": "coordinate system",
+    "xrefs": [
+      {
+        "id": "stato:0000010",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000057",
+    "name": "spherical coordinate system",
+    "xrefs": [
+      {
+        "id": "stato:0000014",
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000058",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  },
+  {
+    "description": NaN,
+    "id": "askemosw:0000059",
+    "name": NaN,
+    "xrefs": [
+      {
+        "id": NaN,
+        "type": "skos:exactMatch"
+      }
+    ],
+    "type": "class",
+    "physical_min": null,
+    "suggested_data_type": null,
+    "suggested_unit": null
+  }
+]

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -3,19 +3,16 @@
     "description": "Reduced Planck's constant, hbar=h/2*pi",
     "id": "",
     "name": "Reduced Planck's constant",
+    "parents": [
+      "askemosw:0000044"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\hbar"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000044",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "Matter Density",
@@ -117,15 +114,14 @@
     "description": "partial pressure",
     "id": "askemosw:0000007",
     "name": "Partial gas pressure",
+    "parents": [
+      "askemosw:0000006"
+    ],
     "type": "class",
     "xrefs": [
       {
         "id": "opb:00018",
         "type": "skos:exactMatch"
-      },
-      {
-        "id": "askemosw:0000006",
-        "type": "skos:broader"
       }
     ]
   },
@@ -145,37 +141,31 @@
     "description": "Electron temperature",
     "id": "askemosw:0000009",
     "name": "Temperature",
+    "parents": [
+      "askemosw:0000008"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "T_e"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000008",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "Ion temperature",
     "id": "askemosw:0000010",
     "name": "Temperature",
+    "parents": [
+      "askemosw:0000008"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "T_i"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000008",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "Velocity of neutral species",
@@ -271,19 +261,16 @@
     "description": "gravitational acceleration vector field",
     "id": "askemosw:0000018",
     "name": "gravitational acceleration vector",
+    "parents": [
+      "askemosw:0000039"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\mathbf{g}"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000039",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "Spatial angle",
@@ -301,37 +288,31 @@
     "description": "polar angle",
     "id": "askemosw:0000020",
     "name": "polar angle",
+    "parents": [
+      "askemosw:0000019"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\theta"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000019",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "azimuthal angle",
     "id": "askemosw:0000021",
     "name": "azimuthal angle",
+    "parents": [
+      "askemosw:0000019"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\phi"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000019",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "Temporal Frequency",
@@ -367,37 +348,31 @@
     "description": "Specific heat at constant volume",
     "id": "askemosw:0000024",
     "name": "Specific heat capacity at constant volume",
+    "parents": [
+      "askemosw:0000023"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "c_\\text{v}"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000023",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "Specific heat at constant pressure",
     "id": "askemosw:0000025",
     "name": "Specific heat capacity at constant pressure",
+    "parents": [
+      "askemosw:0000023"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "c_\\text{p}"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000023",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "Electron thermal conductivity",
@@ -601,19 +576,16 @@
     "description": "A vector of constant mangnitude equal to one",
     "id": "askemosw:0000040",
     "name": "unit vector",
+    "parents": [
+      "askemosw:0000039"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
         "value": "\\mathbf{e}_{i}"
       }
     ],
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000039",
-        "type": "skos:broader"
-      }
-    ]
+    "type": "class"
   },
   {
     "description": "dimensionless unit",
@@ -673,18 +645,18 @@
     "description": "Planck's constant",
     "id": "askemosw:0000045",
     "name": "Planck's constant",
-    "type": "class",
-    "xrefs": [
-      {
-        "id": "askemosw:0000044",
-        "type": "skos:broader"
-      }
-    ]
+    "parents": [
+      "askemosw:0000044"
+    ],
+    "type": "class"
   },
   {
     "description": "Boltzmann constant",
     "id": "askemosw:0000046",
     "name": "Boltzmann constant",
+    "parents": [
+      "askemosw:0000044"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
@@ -696,10 +668,6 @@
       {
         "id": "opb:01625",
         "type": "skos:exactMatch"
-      },
-      {
-        "id": "askemosw:0000044",
-        "type": "skos:broader"
       }
     ]
   },
@@ -707,6 +675,9 @@
     "description": "Gas constant",
     "id": "askemosw:0000047",
     "name": "gas constant",
+    "parents": [
+      "askemosw:0000044"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
@@ -718,10 +689,6 @@
       {
         "id": "om:GasConstant",
         "type": "skos:exactMatch"
-      },
-      {
-        "id": "askemosw:0000044",
-        "type": "skos:broader"
       }
     ]
   },
@@ -729,6 +696,9 @@
     "description": "Avagadro constant",
     "id": "askemosw:0000048",
     "name": "Avogadro constant",
+    "parents": [
+      "askemosw:0000044"
+    ],
     "synonyms": [
       {
         "type": "referenced_by_latex",
@@ -740,10 +710,6 @@
       {
         "id": "opb:01622",
         "type": "skos:exactMatch"
-      },
-      {
-        "id": "askemosw:0000044",
-        "type": "skos:broader"
       }
     ]
   },
@@ -813,15 +779,14 @@
     "description": "Interplanetary magnetic fields",
     "id": "askemosw:0000054",
     "name": "Interplanetary magnetic fields",
+    "parents": [
+      "askemosw:0000034"
+    ],
     "type": "class",
     "xrefs": [
       {
         "id": "uat:824",
         "type": "skos:exactMatch"
-      },
-      {
-        "id": "askemosw:0000034",
-        "type": "skos:broader"
       }
     ]
   },

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -46,6 +46,7 @@
   },
   {
     "description": "Mass of the electron",
+    "dimensionality": "kg",
     "id": "askemosw:0000003",
     "name": "electronic mass",
     "synonyms": [

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -1,6 +1,12 @@
 [
   {
     "description": "Total mass density",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\rho"
+      }
+    ],
     "id": "askemosw:0000001",
     "name": "Matter Density",
     "xrefs": [
@@ -31,6 +37,12 @@
   },
   {
     "description": "Mass of the electron",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "m_e"
+      }
+    ],
     "id": "askemosw:0000003",
     "name": "electronic mass",
     "xrefs": [
@@ -46,6 +58,12 @@
   },
   {
     "description": "Mean atmospheric mass",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\bar{m}"
+      }
+    ],
     "id": "askemosw:0000004",
     "name": "molar mass",
     "xrefs": [
@@ -61,6 +79,12 @@
   },
   {
     "description": "Number Density",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "N_s"
+      }
+    ],
     "id": "askemosw:0000005",
     "name": "Material volumnal density",
     "xrefs": [
@@ -121,6 +145,12 @@
   },
   {
     "description": "Electron temperature",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "T_e"
+      }
+    ],
     "id": "askemosw:0000009",
     "name": "Temperature",
     "xrefs": [
@@ -136,6 +166,12 @@
   },
   {
     "description": "Absolute temperature of ion",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "T_i"
+      }
+    ],
     "id": "askemosw:0000010",
     "name": "Temperature",
     "xrefs": [
@@ -151,6 +187,12 @@
   },
   {
     "description": "Velocity of neutral species",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{u}"
+      }
+    ],
     "id": "askemosw:0000011",
     "name": "Velocity",
     "xrefs": [
@@ -181,6 +223,12 @@
   },
   {
     "description": "Specific heat ratio or adiabatic index",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\gamma"
+      }
+    ],
     "id": "askemosw:0000013",
     "name": null,
     "xrefs": [
@@ -211,6 +259,12 @@
   },
   {
     "description": "Eddy diffusion coefficient",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "K_e"
+      }
+    ],
     "id": "askemosw:0000015",
     "name": null,
     "xrefs": [
@@ -226,6 +280,12 @@
   },
   {
     "description": "Diffusion coefficient between species $s$ and $q$",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "D_{qs}"
+      }
+    ],
     "id": "askemosw:0000016",
     "name": "Diffusion coefficient",
     "xrefs": [
@@ -256,6 +316,12 @@
   },
   {
     "description": "gravitational acceleration vector field",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{g}"
+      }
+    ],
     "id": "askemosw:0000018",
     "name": null,
     "xrefs": [
@@ -271,6 +337,12 @@
   },
   {
     "description": "e.g. North latitude",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\theta"
+      }
+    ],
     "id": "askemosw:0000019",
     "name": "Spatial angle",
     "xrefs": [
@@ -286,6 +358,12 @@
   },
   {
     "description": "e.g. East Longitude",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\phi"
+      }
+    ],
     "id": "askemosw:0000020",
     "name": "Spatial angle",
     "xrefs": [
@@ -301,6 +379,12 @@
   },
   {
     "description": "Ion-neutral collision frequency",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\nu_{in}"
+      }
+    ],
     "id": "askemosw:0000021",
     "name": "Temporal Frequency",
     "xrefs": [
@@ -316,6 +400,12 @@
   },
   {
     "description": "Specific heat at constant volume",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "c_\\text{v}"
+      }
+    ],
     "id": "askemosw:0000022",
     "name": "Specific heat capacity",
     "xrefs": [
@@ -331,6 +421,12 @@
   },
   {
     "description": "Specific heat at constant pressure",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "C_p"
+      }
+    ],
     "id": "askemosw:0000023",
     "name": "Specific heat capacity",
     "xrefs": [
@@ -346,6 +442,12 @@
   },
   {
     "description": "Electron thermal conductivity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\kappa_e"
+      }
+    ],
     "id": "askemosw:0000024",
     "name": "Thermal conductivity",
     "xrefs": [
@@ -361,11 +463,17 @@
   },
   {
     "description": "e.g. Electron heat flux",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{q}_e"
+      }
+    ],
     "id": "askemosw:0000025",
     "name": "Heat flow rate",
     "xrefs": [
       {
-        "id": "opb:00201?",
+        "id": "opb:00201",
         "type": "skos:exactMatch"
       }
     ],
@@ -376,6 +484,12 @@
   },
   {
     "description": "The coefficient of viscosity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\eta"
+      }
+    ],
     "id": "askemosw:0000026",
     "name": null,
     "xrefs": [
@@ -391,6 +505,12 @@
   },
   {
     "description": "Molecular viscosity",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mu"
+      }
+    ],
     "id": "askemosw:0000027",
     "name": "Fluid viscosity",
     "xrefs": [
@@ -406,6 +526,12 @@
   },
   {
     "description": "External electric field",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{E}"
+      }
+    ],
     "id": "askemosw:0000028",
     "name": "electric field",
     "xrefs": [
@@ -466,6 +592,12 @@
   },
   {
     "description": "Magnetic field",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{B}"
+      }
+    ],
     "id": "askemosw:0000032",
     "name": "Magnetic Fields",
     "xrefs": [
@@ -526,6 +658,12 @@
   },
   {
     "description": "e.g. Photon frequency",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\nu"
+      }
+    ],
     "id": "askemosw:0000036",
     "name": "Temporal Frequency",
     "xrefs": [
@@ -571,6 +709,12 @@
   },
   {
     "description": "Unit vector for the magnetic field",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "\\mathbf{b}"
+      }
+    ],
     "id": "askemosw:0000039",
     "name": null,
     "xrefs": [
@@ -616,6 +760,12 @@
   },
   {
     "description": "number of points along the field line, used to determine the relationship between $q, s, r\\,and \\theta$ in \\ref{sami_eq1} and \\ref{sami_eq2}",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "N_z"
+      }
+    ],
     "id": "askemosw:0000042",
     "name": "Count",
     "xrefs": [
@@ -661,6 +811,12 @@
   },
   {
     "description": "Boltzmann constant",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "k_B"
+      }
+    ],
     "id": "askemosw:0000045",
     "name": "Boltzmann constant",
     "xrefs": [
@@ -676,6 +832,12 @@
   },
   {
     "description": "Gas constant",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "R^*"
+      }
+    ],
     "id": "askemosw:0000046",
     "name": "gas constant",
     "xrefs": [
@@ -691,6 +853,12 @@
   },
   {
     "description": "Avagadro constant",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "N_A"
+      }
+    ],
     "id": "askemosw:0000047",
     "name": "Avogadro constant",
     "xrefs": [
@@ -706,6 +874,12 @@
   },
   {
     "description": "The Maxwellian-averaged momentum transfer cross section for species $n$.",
+    "synonyms": [
+      {
+        "type": "referenced_by_latex",
+        "value": "(q_D)_n"
+      }
+    ],
     "id": "askemosw:0000048",
     "name": null,
     "xrefs": [

--- a/mira/dkg/askemo/askemosw.json
+++ b/mira/dkg/askemo/askemosw.json
@@ -1,20 +1,5 @@
 [
   {
-    "description": "Reduced Planck's constant, hbar=h/2*pi",
-    "id": "",
-    "name": "Reduced Planck's constant",
-    "parents": [
-      "askemosw:0000044"
-    ],
-    "synonyms": [
-      {
-        "type": "referenced_by_latex",
-        "value": "\\hbar"
-      }
-    ],
-    "type": "class"
-  },
-  {
     "description": "Matter Density",
     "id": "askemosw:0000001",
     "name": "Matter Density",

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -8,8 +8,8 @@ from mira.dkg.askemo.api import Term, write
 
 header_row = 1
 row_count = 59
-columns = list(range(10))
 google_sheet_csv_export_url = os.environ["SPACE_ONTOLOGY_URL"]
+columns = list(range(11))
 
 
 def read_google_sheet(
@@ -139,6 +139,9 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
 
         if xrefs:
             out_record["xrefs"] = xrefs
+
+        if record["dimensions"]:
+            out_record["dimensionality"] = record["dimensions"]
 
         term = Term(**out_record)
         terms[term.id] = term

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -1,0 +1,18 @@
+import os
+
+import pandas as pd
+
+header_row = 1
+row_count = 59
+columns = list(range(8))
+google_sheet_csv_export_url = os.environ["SPACE_ONTOLOGY_URL"]
+
+df = pd.read_csv(
+    google_sheet_csv_export_url,
+    header=header_row,
+    nrows=row_count,
+    usecols=columns,
+)
+
+print(df.head())
+print(df.tail())

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -1,18 +1,100 @@
+import json
 import os
+from typing import List
 
 import pandas as pd
 
 header_row = 1
 row_count = 59
-columns = list(range(8))
+columns = list(range(9))
 google_sheet_csv_export_url = os.environ["SPACE_ONTOLOGY_URL"]
 
-df = pd.read_csv(
-    google_sheet_csv_export_url,
-    header=header_row,
-    nrows=row_count,
-    usecols=columns,
-)
 
-print(df.head())
-print(df.tail())
+def read_google_sheet(
+    url: str = google_sheet_csv_export_url,
+    header: int = header_row,
+    nrows: int = row_count,
+    usecols: List[int] = None,
+) -> pd.DataFrame:
+    if usecols is None:
+        usecols = columns
+    return pd.read_csv(url, header=header, nrows=nrows, usecols=usecols)
+
+
+def export_to_json(sheet_df: pd.DataFrame, path: str = None):
+    # DataFrame columns:
+    # 'symbol',
+    # 'ASKEMOSW',
+    # 'name',
+    # 'Parent ASKEMOSW',
+    # 'suggested grounding',
+    # 'grounded name',
+    # 'Link to grounding',
+    # 'description',
+    # 'Notes'
+
+    # Output should roughly follow this format:
+    #   [{
+    #     "description": "The number of people who live in an area being modeled.",
+    #     "id": "askemo:0000001",
+    #     "name": "population",
+    #     "physical_min": 0.0,
+    #     "suggested_data_type": "int",
+    #     "suggested_unit": "person",
+    #     "type": "class",
+    #     "xrefs": [
+    #       {
+    #         "id": "ido:0000509",
+    #         "type": "skos:exactMatch"
+    #       }
+    #     ]
+    #   }, ...]
+
+    # Map from column name to json key in the output
+    column_mapping = {
+        "description": "description",
+        "ASKEMOSW": "id",
+        "name": "name",
+        "suggested grounding": "xrefs",
+        "grounded name": "name",
+    }
+
+    json_records = sheet_df.to_dict(orient="records")
+    output_records = []
+    for record in json_records:
+        out_record = {}
+
+        # If the description is empty, use the grounded name
+        if record["description"] == "":
+            out_record["description"] = record["grounded name"]
+        else:
+            out_record["description"] = record["description"]
+
+        for column_name, json_key in column_mapping.items():
+            if column_name == "suggested grounding":
+                out_record[json_key] = [
+                    {"id": record[column_name], "type": "skos:exactMatch"}
+                ]
+            else:
+                out_record[json_key] = record[column_name]
+
+        out_record["type"] = "class"
+
+        # TODO: Add these fields to the google sheet
+        out_record["physical_min"] = None
+        out_record["suggested_data_type"] = None
+        out_record["suggested_unit"] = None
+
+        output_records.append(out_record)
+
+    if path is not None:
+        print(f"Writing to {path}")
+        with open(path, "w") as f:
+            json.dump(output_records, f, indent=2)
+    else:
+        return output_records
+
+
+if __name__ == "__main__":
+    df = read_google_sheet()
+    jr = export_to_json(df, "askemosw.json")

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -7,7 +7,11 @@ from mira.dkg.askemo.api import Term, write, HERE
 
 header_row = 1
 row_count = 59
-google_sheet_csv_export_url = os.environ["SPACE_ONTOLOGY_URL"]
+google_sheet_csv_export_url = (
+    "https://docs.google.com/spreadsheets/d/e/2PACX"
+    "-1vSVyEBHj8JbFCpLrD4Czs0LZ8G4_koL-OHADahJ0IjWF7NnVzk4McXCcQRcznFF-o"
+    "-Z71THHBALPMhR/pub?gid=1138696824&single=true&output=csv"
+)
 columns = list(range(11))
 
 

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 header_row = 1
 row_count = 59
-columns = list(range(9))
+columns = list(range(10))
 google_sheet_csv_export_url = os.environ["SPACE_ONTOLOGY_URL"]
 
 
@@ -27,12 +27,13 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
     # 'symbol',
     # 'ASKEMOSW',
     # 'name',
-    # 'Parent ASKEMOSW',
+    # 'parent ASKEMOSW',
     # 'suggested grounding',
     # 'grounded name',
     # 'Link to grounding',
     # 'description',
-    # 'Notes'
+    # 'example usage',
+    # 'xrefs'
 
     # Output should roughly follow this format:
     #   [{

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -111,4 +111,4 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
 
 if __name__ == "__main__":
     df = read_google_sheet()
-    jr = export_to_json(df, "askemosw.json")
+    export_to_json(df, "askemosw.json")

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -42,6 +42,11 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
     #     "physical_min": 0.0,
     #     "suggested_data_type": "int",
     #     "suggested_unit": "person",
+    #     "synonyms": [
+    #       {
+    #         "type": "referenced_by_latex",
+    #         "value": "N"
+    #       }
     #     "type": "class",
     #     "xrefs": [
     #       {
@@ -73,6 +78,20 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
             out_record["description"] = record["grounded name"]
         else:
             out_record["description"] = record["name"]
+
+        # If the symbol field has a value, put it in synonyms -> {type:
+        # "referenced_by_latex", value: <symbol>}
+        if record["symbol"] and not (
+            isinstance(record["symbol"], float) and math.isnan(record["symbol"])
+        ):
+            # Get rid of the $ in the symbol and any accidental whitespace
+            record["symbol"] = record["symbol"].replace("$", "").strip()
+
+            # If the symbol string is only alphabetical, skip it
+            if not record["symbol"].isalpha():
+                out_record["synonyms"] = [
+                    {"type": "referenced_by_latex", "value": record["symbol"]}
+                ]
 
         for column_name, json_key in column_mapping.items():
             if column_name == "suggested grounding":

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -56,7 +56,7 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
     #     "synonyms": [
     #       {
     #         "type": "referenced_by_latex",
-    #         "value": "N"
+    #         "value": "N_i"
     #       }
     #     "type": "class",
     #     "xrefs": [
@@ -150,5 +150,6 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
 
 
 if __name__ == "__main__":
+    # todo: propagate the dimensions to the google sheet
     df = read_google_sheet()
     export_to_json(df, "askemosw.json")

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -17,9 +17,20 @@ def read_google_sheet(
     nrows: int = row_count,
     usecols: List[int] = None,
 ) -> pd.DataFrame:
+    """Read the google sheet csv export into a pandas dataframe.
+
+    Set empty cells to empty string instead of NaN.
+    """
     if usecols is None:
         usecols = columns
-    return pd.read_csv(url, header=header, nrows=nrows, usecols=usecols)
+    return pd.read_csv(
+        url,
+        header=header,
+        nrows=nrows,
+        usecols=usecols,
+        na_filter=False,
+        dtype=str,
+    )
 
 
 def export_to_json(sheet_df: pd.DataFrame, path: str = None):

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -1,12 +1,11 @@
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import click
 import pandas as pd
 from mira.dkg.askemo.api import Term, write, HERE
 
-header_row = 1
-row_count = 59
+header_row = 3
 google_sheet_csv_export_url = (
     "https://docs.google.com/spreadsheets/d/e/2PACX"
     "-1vSVyEBHj8JbFCpLrD4Czs0LZ8G4_koL-OHADahJ0IjWF7NnVzk4McXCcQRcznFF-o"
@@ -18,8 +17,8 @@ columns = list(range(11))
 def read_google_sheet(
     url: str = google_sheet_csv_export_url,
     header: int = header_row,
-    nrows: int = row_count,
-    usecols: List[int] = None,
+    nrows: Optional[int] = None,
+    usecols: Optional[List[int]] = None,
 ) -> pd.DataFrame:
     """Read the google sheet csv export into a pandas dataframe.
 

--- a/mira/dkg/askemo/askemosw.py
+++ b/mira/dkg/askemo/askemosw.py
@@ -1,10 +1,9 @@
-import json
-import os
 from pathlib import Path
 from typing import List
 
+import click
 import pandas as pd
-from mira.dkg.askemo.api import Term, write
+from mira.dkg.askemo.api import Term, write, HERE
 
 header_row = 1
 row_count = 59
@@ -74,8 +73,13 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
     json_records = sheet_df.to_dict(orient="records")
     terms = {}
     for record in json_records:
+        identifier = record["ASKEMOSW"]
+        if not identifier:
+            click.secho("Missing identifier!")
+            continue
+
         out_record = {
-            "id": record["ASKEMOSW"],
+            "id": identifier,
             "type": "class",
             # TODO: Add these fields to the google sheet
             "physical_min": None,
@@ -119,7 +123,6 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
         # Grounding
         #   - Add 'suggested grounding' column as xrefs - skos:exactMatch
         #   - Add 'xrefs' column as xrefs - skos:exactMatch
-        #   - Add 'parent ASKEMOSW' column as xrefs - skos:broader
         xrefs = []
         if record["suggested grounding"]:
             xrefs.append(
@@ -156,4 +159,4 @@ def export_to_json(sheet_df: pd.DataFrame, path: str = None):
 if __name__ == "__main__":
     # todo: propagate the dimensions to the google sheet
     df = read_google_sheet()
-    export_to_json(df, "askemosw.json")
+    export_to_json(df, HERE.joinpath("askemosw.json"))


### PR DESCRIPTION
This PR starts an initial space weather ontology export. A spreadsheet with curated terms relating to space weather acts as a source for the created `askemosw.json`. The created json file is separately linted by `mira.dkg.askemo.api`.

With this PR the initial identifiers for `askemosw` are set and should not be further changed. New terms added to the source spreadsheet should have their id numbering starting at the highest id number entry currently in the spreadsheet.