### PR TITLE
Configurable DKG build and Space Weather DKG

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ graft mira/resources
 graft mira/dkg/templates
 graft mira/dkg/resources
 include mira/dkg/metaregistry/epi.json
-include mira/resources/mapped_biomodels_groundings.csv

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ graft mira/resources
 graft mira/dkg/templates
 graft mira/dkg/resources
 include mira/dkg/metaregistry/epi.json
+include mira/resources/mapped_biomodels_groundings.csv

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MIRA is a framework for representing systems using ontology-grounded **meta-mode
 
 * Template JSON schema: [schema.json](https://github.com/indralab/mira/blob/main/mira/metamodel/schema.json)
 * Epidemiology Domain Knowledge Graph (DKG) service: [DKG service](http://34.230.33.149:8771/)
-* Epidemiology DKG Metaregistry service: [Metaregistry service](http://34.230.33.149:8772/) 
+* MIRA Metaregistry service: [Metaregistry service](http://34.230.33.149:8772/) 
 
 ## Example notebooks
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,15 +1,17 @@
 # Docker
 
 This folder contains Docker build procedures for various aspects of MIRA.
+By default, these docker images build the epidemiology use case artifacts.
 
 ## MIRA Front-end
 
 This folder implements a Docker build procedure for building a neo4j instance
 of MIRA's domain knowledge graph from a given node and edge dump. The node
-and edge dumps are pulled from S3.
+and edge dumps are pulled from S3. Note that by default, this builds for the
+epidemiology use case.
 
 ```shell
-docker build --tag mira_dkg:latest .
+docker build --tag mira_epi_dkg:latest .
 ```
 
 If you want to test with local files, put `nodes.tsv.gz` and `edges.tsv.gz` in
@@ -22,25 +24,26 @@ cp ~/.data/mira/$DOMAIN/nodes.tsv.gz nodes.tsv.gz
 cp ~/.data/mira/$DOMAIN/edges.tsv.gz edges.tsv.gz
 
 # Build docker
-docker build --file Dockerfile.local --tag mira_dkg:latest .
+docker build --file Dockerfile.local --tag mira_$DOMAIN_dkg:latest .
 ```
 
-Once the build finished, you can run the container locally as
+Once the build finished, you can run the container locally as:
 
 ```shell
 # Option 1: run in the background
-docker run --detach -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 --name mira_dkg mira_dkg:latest
+docker run --detach -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 --name mira_$DOMAIN_dkg mira_$DOMAIN_dkg:latest
 
 # Option 2: run ephemerally
-docker run -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
+docker run -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_$DOMAIN_dkg:latest
 ```
 
 This exposes a REST API at `http://localhost:8771`. Note that the `--detach` flag
 runs the container in the background. If you want to expose Neo4j's bolt port, also
-add `-p 7687:7687`.
+add `-p 7687:7687`. Note that 
 
 ## MIRA Metaregistry
 
+The MIRA metaregistry contains the prefixes and their associated metadata for all use cases.
 You can build the metaregistry with:
 
 ```shell

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,10 +28,14 @@ docker build --file Dockerfile.local --tag mira_dkg:latest .
 Once the build finished, you can run the container locally as
 
 ```shell
-docker run -d -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 --name mira_dkg mira_dkg:latest
+# Option 1: run in the background
+docker run --detach -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 --name mira_dkg mira_dkg:latest
+
+# Option 2: run ephemerally
+docker run -p 8771:8771 -e MIRA_NEO4J_URL=bolt://0.0.0.0:7687 mira_dkg:latest
 ```
 
-This exposes a REST API at `http://localhost:8771`. Note that the `-d` flag
+This exposes a REST API at `http://localhost:8771`. Note that the `--detach` flag
 runs the container in the background. If you want to expose Neo4j's bolt port, also
 add `-p 7687:7687`.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,8 +17,9 @@ this folder and use:
 
 ```shell
 # Get graph data
-cp ~/.data/mira/demo/import/nodes.tsv.gz nodes.tsv.gz
-cp ~/.data/mira/demo/import/edges.tsv.gz edges.tsv.gz
+export DOMAIN=epi
+cp ~/.data/mira/$DOMAIN/nodes.tsv.gz nodes.tsv.gz
+cp ~/.data/mira/$DOMAIN/edges.tsv.gz edges.tsv.gz
 
 # Build docker
 docker build --file Dockerfile.local --tag mira_dkg:latest .

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -106,7 +106,7 @@ class UseCasePaths:
             prefix: self.module.join("sources", name=f"edges_{prefix}.tsv")
             for prefix in prefixes
         }
-        self.METAREGISTRY_PATH = METAREGISTRY_PATH
+        self.RDF_TTL_PATH = self.module.join(name="dkg.ttl.gz")
 
 
 EDGE_HEADER = (

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -716,7 +716,6 @@ def main(
         nodes_path=use_case_paths.NODES_PATH,
         edges_path=use_case_paths.EDGES_PATH,
         upload=do_upload,
-        use_case_paths=use_case_paths,
     )
 
     from .construct_embeddings import _construct_embeddings

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -21,7 +21,6 @@ Then, restart the neo4j service with homebrew ``brew services neo4j restart``
 
 import csv
 import gzip
-import itertools as itt
 import json
 import pickle
 from collections import Counter, defaultdict
@@ -34,12 +33,12 @@ import bioontologies
 import click
 import pystow
 from bioontologies import obograph
-from bioregistry import Manager, manager
+from bioregistry import manager
 from tabulate import tabulate
 from tqdm import tqdm
 from typing_extensions import Literal
 
-from mira.dkg.askemo import get_askemo_terms
+from mira.dkg.askemo import get_askemo_terms, get_askemosw_terms
 from mira.dkg.models import EntityType
 from mira.dkg.resources import SLIMS
 from mira.dkg.units import get_unit_terms
@@ -48,22 +47,51 @@ from mira.dkg.utils import PREFIXES
 MODULE = pystow.module("mira")
 DEMO_MODULE = MODULE.module("demo", "import")
 EDGE_NAMES_PATH = DEMO_MODULE.join(name="relation_info.json")
-UNSTANDARDIZED_NODES_PATH = DEMO_MODULE.join(name="unstandardized_nodes.tsv")
-UNSTANDARDIZED_EDGES_PATH = DEMO_MODULE.join(name="unstandardized_edges.tsv")
-SUB_EDGE_COUNTER_PATH = DEMO_MODULE.join(name="count_subject_prefix_predicate.tsv")
-SUB_EDGE_TARGET_COUNTER_PATH = DEMO_MODULE.join(
-    name="count_subject_prefix_predicate_target_prefix.tsv"
-)
-EDGE_OBJ_COUNTER_PATH = DEMO_MODULE.join(name="count_predicate_object_prefix.tsv")
-EDGE_COUNTER_PATH = DEMO_MODULE.join(name="count_predicate.tsv")
-NODES_PATH = DEMO_MODULE.join(name="nodes.tsv.gz")
-EDGES_PATH = DEMO_MODULE.join(name="edges.tsv.gz")
-EMBEDDINGS_PATH = DEMO_MODULE.join(name="embeddings.tsv.gz")
 METAREGISTRY_PATH = DEMO_MODULE.join(name="metaregistry.json")
+
 OBSOLETE = {"oboinowl:ObsoleteClass", "oboinowl:ObsoleteProperty"}
-EDGES_PATHS: Dict[str, Path] = {
-    prefix: DEMO_MODULE.join("sources", name=f"edges_{prefix}.tsv") for prefix in [*PREFIXES, "askemo"]
+
+GraphName = Literal["epi", "space"]
+cases = {
+    "epi": (
+        "askemo",
+        get_askemo_terms,
+        "https://github.com/indralab/mira/blob/main/mira/dkg/askemo/askemo.json",
+        PREFIXES,
+    ),
+    "space": (
+        "askemosw",
+        get_askemosw_terms,
+        "https://github.com/indralab/mira/blob/main/mira/dkg/askemo/askemosw.json",
+        ["uat"],
+    ),
 }
+
+class UseCasePaths:
+    """A configuration containing the file paths for use case-specific files."""
+
+    def __init__(self, use_case: GraphName):
+        self.use_case = use_case
+        self.module = MODULE.module(self.use_case)
+        self.UNSTANDARDIZED_NODES_PATH = self.module.join(name="unstandardized_nodes.tsv")
+        self.UNSTANDARDIZED_EDGES_PATH = self.module.join(name="unstandardized_edges.tsv")
+        self.SUB_EDGE_COUNTER_PATH = self.module.join(name="count_subject_prefix_predicate.tsv")
+        self.SUB_EDGE_TARGET_COUNTER_PATH = self.module.join(
+            name="count_subject_prefix_predicate_target_prefix.tsv"
+        )
+        self.EDGE_OBJ_COUNTER_PATH = self.module.join(name="count_predicate_object_prefix.tsv")
+        self.EDGE_COUNTER_PATH = self.module.join(name="count_predicate.tsv")
+        self.NODES_PATH = self.module.join(name="nodes.tsv.gz")
+        self.EDGES_PATH = self.module.join(name="edges.tsv.gz")
+        self.EMBEDDINGS_PATH = self.module.join(name="embeddings.tsv.gz")
+        self.askemo_prefix, self.askemo_getter, self.askemp_url, self.prefixes = cases[self.use_case]
+        self.EDGES_PATHS: Dict[str, Path] = {
+            prefix: self.module.join("sources", name=f"edges_{prefix}.tsv")
+            for prefix in [*self.prefixes, self.askemo_prefix]
+        }
+        self.METAREGISTRY_PATH = METAREGISTRY_PATH
+
+
 EDGE_HEADER = (
     ":START_ID",
     ":END_ID",
@@ -153,8 +181,11 @@ class NodeInfo(NamedTuple):
 )
 @click.option("--do-upload", is_flag=True, help="Upload to S3 on completion")
 @click.option("--refresh", is_flag=True, help="Refresh caches")
-def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
+@click.option("--use-case", type=click.Choice(["epi", "space"]), default="epi")
+def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool, use_case: GraphName):
     """Generate the node and edge files."""
+    use_case_paths = UseCasePaths(use_case)
+
     if EDGE_NAMES_PATH.is_file():
         edge_names = json.loads(EDGE_NAMES_PATH.read_text())
     else:
@@ -192,9 +223,9 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
     subject_edge_target_usage_counter = Counter()
     edge_target_usage_counter = Counter()
 
-    click.secho(f"ASKEM Ontology", fg="green", bold=True)
     askemo_edges = []
-    for term in tqdm(get_askemo_terms().values(), unit="term"):
+    click.secho(f"ASKEM custom: {use_case_paths.askemo_prefix}", fg="green", bold=True)
+    for term in tqdm(use_case_paths.askemo_getter().values(), unit="term"):
         property_predicates = []
         property_values = []
         if term.suggested_unit:
@@ -216,7 +247,7 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
             property_predicates.append("typical_max")
             property_values.append(str(term.typical_max))
 
-        node_sources[term.id].add("askemo")
+        node_sources[term.id].add(use_case_paths.askemo_prefix)
         nodes[term.id] = NodeInfo(
             curie=term.id,
             prefix=term.prefix,
@@ -244,12 +275,12 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
                     parent_curie,
                     "subclassof",
                     "rdfs:subClassOf",
-                    "askemo",
-                    "https://github.com/indralab/mira/blob/main/mira/dkg/askemo/askemo.json",
+                    use_case_paths.askemo_prefix,
+                    use_case_paths.askemp_url,
                     "",
                 )
             )
-    with EDGES_PATHS["askemo"].open("w") as file:
+    with use_case_paths.EDGES_PATHS[use_case_paths.askemo_prefix].open("w") as file:
         writer = csv.writer(file, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
         writer.writerow(EDGE_HEADER)
         writer.writerows(askemo_edges)
@@ -289,7 +320,7 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
         else:
             return curie_
 
-    for prefix in PREFIXES:
+    for prefix in use_case_paths.prefixes:
         edges = []
 
         _results_pickle_path = DEMO_MODULE.join("parsed", name=f"{prefix}.pkl")
@@ -366,10 +397,10 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
                         if node.lbl
                         else "",
                         synonyms=";".join(synonym.val for synonym in node.synonyms),
-                        deprecated="true" if node.deprecated else "false",
+                        deprecated="true" if node.deprecated else "false",  # type:ignore
                         # TODO better way to infer type based on hierarchy
                         #  (e.g., if rdfs:type available, consider as instance)
-                        type=node.type.lower() if node.type else "unknown",
+                        type=node.type.lower() if node.type else "unknown",  # type:ignore
                         definition=(node.definition or "")
                         .replace('"', "")
                         .replace("\n", " ")
@@ -546,14 +577,14 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
             ] += 1
             edge_usage_counter[pred, pred_label] += 1
 
-        edges_path = EDGES_PATHS[prefix]
+        edges_path = use_case_paths.EDGES_PATHS[prefix]
         with edges_path.open("w") as file:
             writer = csv.writer(file, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
             writer.writerow(EDGE_HEADER)
             writer.writerows(edges)
         tqdm.write(f"output edges to {edges_path}")
 
-    with gzip.open(NODES_PATH, "wt") as file:
+    with gzip.open(use_case_paths.NODES_PATH, "wt") as file:
         writer = csv.writer(file, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
         writer.writerow(NODE_HEADER)
         writer.writerows(
@@ -562,69 +593,70 @@ def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool):
                 for curie, node in tqdm(sorted(nodes.items()), unit="node", unit_scale=True)
             )
         )
-    tqdm.write(f"output edges to {NODES_PATH}")
+    tqdm.write(f"output edges to {use_case_paths.NODES_PATH}")
 
     # CAT edge files together
-    with gzip.open(EDGES_PATH, "wt") as file:
+    with gzip.open(use_case_paths.EDGES_PATH, "wt") as file:
         writer = csv.writer(file, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
         writer.writerow(EDGE_HEADER)
-        for prefix, edge_path in tqdm(sorted(EDGES_PATHS.items()), desc="cat edges"):
+        for prefix, edge_path in tqdm(sorted(use_case_paths.EDGES_PATHS.items()), desc="cat edges"):
             with edge_path.open() as edge_file:
                 reader = csv.reader(edge_file, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
                 _header = next(reader)
                 writer.writerows(reader)
 
     unstandardized_nodes_counter = Counter(unstandardized_nodes)
-    _write_counter(UNSTANDARDIZED_NODES_PATH, unstandardized_nodes_counter, title="url")
+    _write_counter(use_case_paths.UNSTANDARDIZED_NODES_PATH, unstandardized_nodes_counter, title="url")
 
     unstandardized_edges_counter = Counter(unstandardized_edges)
-    _write_counter(UNSTANDARDIZED_EDGES_PATH, unstandardized_edges_counter, title="url")
+    _write_counter(use_case_paths.UNSTANDARDIZED_EDGES_PATH, unstandardized_edges_counter, title="url")
 
     _write_counter(
-        EDGE_OBJ_COUNTER_PATH,
+        use_case_paths.EDGE_OBJ_COUNTER_PATH,
         edge_target_usage_counter,
         unpack=True,
         title=("predicate", "predicate_label", "object_prefix"),
     )
     _write_counter(
-        SUB_EDGE_COUNTER_PATH,
+        use_case_paths.SUB_EDGE_COUNTER_PATH,
         subject_edge_usage_counter,
         unpack=True,
         title=("subject_prefix", "predicate", "predicate_label"),
     )
     _write_counter(
-        SUB_EDGE_TARGET_COUNTER_PATH,
+        use_case_paths.SUB_EDGE_TARGET_COUNTER_PATH,
         subject_edge_target_usage_counter,
         unpack=True,
         title=("subject_prefix", "predicate", "predicate_label", "object_prefix"),
     )
     _write_counter(
-        EDGE_COUNTER_PATH,
+        use_case_paths.EDGE_COUNTER_PATH,
         edge_usage_counter,
         unpack=True,
         title=("predicate", "predicate_label"),
     )
 
     if do_upload:
-        upload_neo4j_s3()
+        upload_neo4j_s3(use_case_paths=use_case_paths)
 
     from .construct_rdf import _construct_rdf
 
-    _construct_rdf(upload=do_upload)
+    _construct_rdf(upload=do_upload, use_case_paths=use_case_paths)
 
     from .construct_registry import EPI_CONF_PATH, _construct_registry
 
     _construct_registry(
         config_path=EPI_CONF_PATH,
-        output_path=METAREGISTRY_PATH,
-        nodes_path=NODES_PATH,
-        edges_path=EDGES_PATH,
+        output_path=use_case_paths.METAREGISTRY_PATH,
+        nodes_path=use_case_paths.NODES_PATH,
+        edges_path=use_case_paths.EDGES_PATH,
         upload=do_upload,
+        use_case_paths=use_case_paths,
     )
 
     from .construct_embeddings import _construct_embeddings
 
-    _construct_embeddings(upload=do_upload)
+    _construct_embeddings(upload=do_upload, use_case_paths=use_case_paths)
 
 
 def _write_counter(
@@ -646,7 +678,7 @@ def _write_counter(
                 print(key, count, sep="\t", file=file)
 
 
-def upload_s3(path: Path, *, bucket: str = "askem-mira", s3_client=None) -> None:
+def upload_s3(path: Path, *, graph: GraphName, bucket: str = "askem-mira", s3_client=None) -> None:
     """Upload the nodes and edges to S3."""
     if s3_client is None:
         import boto3
@@ -655,7 +687,7 @@ def upload_s3(path: Path, *, bucket: str = "askem-mira", s3_client=None) -> None
 
     today = datetime.today().strftime("%Y-%m-%d")
     # don't include a preceding or trailing slash
-    key = f"dkg/epi/build/{today}/"
+    key = f"dkg/{graph}/build/{today}/"
     config = {
         # https://stackoverflow.com/questions/41904806/how-to-upload-a-file-to-s3-and-make-it-public-using-boto3
         "ACL": "public-read",
@@ -670,25 +702,25 @@ def upload_s3(path: Path, *, bucket: str = "askem-mira", s3_client=None) -> None
     )
 
 
-def upload_neo4j_s3() -> None:
+def upload_neo4j_s3(use_case_paths: UseCasePaths) -> None:
     """Upload the nodes and edges to S3."""
     import boto3
 
     s3_client = boto3.client("s3")
 
     paths = [
-        UNSTANDARDIZED_EDGES_PATH,
-        UNSTANDARDIZED_NODES_PATH,
-        NODES_PATH,
-        EDGES_PATH,
-        SUB_EDGE_COUNTER_PATH,
-        SUB_EDGE_TARGET_COUNTER_PATH,
-        EDGE_OBJ_COUNTER_PATH,
-        EDGE_COUNTER_PATH,
+        use_case_paths.UNSTANDARDIZED_EDGES_PATH,
+        use_case_paths.UNSTANDARDIZED_NODES_PATH,
+        use_case_paths.NODES_PATH,
+        use_case_paths.EDGES_PATH,
+        use_case_paths.SUB_EDGE_COUNTER_PATH,
+        use_case_paths.SUB_EDGE_TARGET_COUNTER_PATH,
+        use_case_paths.EDGE_OBJ_COUNTER_PATH,
+        use_case_paths.EDGE_COUNTER_PATH,
     ]
     for path in tqdm(paths):
         tqdm.write(f"uploading {path}")
-        upload_s3(path=path, s3_client=s3_client)
+        upload_s3(path=path, s3_client=s3_client, graph=use_case_paths.use_case)
 
 
 if __name__ == "__main__":

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -67,24 +67,38 @@ cases = {
     ),
 }
 
+
 class UseCasePaths:
     """A configuration containing the file paths for use case-specific files."""
 
     def __init__(self, use_case: GraphName):
         self.use_case = use_case
         self.module = MODULE.module(self.use_case)
-        self.UNSTANDARDIZED_NODES_PATH = self.module.join(name="unstandardized_nodes.tsv")
-        self.UNSTANDARDIZED_EDGES_PATH = self.module.join(name="unstandardized_edges.tsv")
-        self.SUB_EDGE_COUNTER_PATH = self.module.join(name="count_subject_prefix_predicate.tsv")
+        self.UNSTANDARDIZED_NODES_PATH = self.module.join(
+            name="unstandardized_nodes.tsv"
+        )
+        self.UNSTANDARDIZED_EDGES_PATH = self.module.join(
+            name="unstandardized_edges.tsv"
+        )
+        self.SUB_EDGE_COUNTER_PATH = self.module.join(
+            name="count_subject_prefix_predicate.tsv"
+        )
         self.SUB_EDGE_TARGET_COUNTER_PATH = self.module.join(
             name="count_subject_prefix_predicate_target_prefix.tsv"
         )
-        self.EDGE_OBJ_COUNTER_PATH = self.module.join(name="count_predicate_object_prefix.tsv")
+        self.EDGE_OBJ_COUNTER_PATH = self.module.join(
+            name="count_predicate_object_prefix.tsv"
+        )
         self.EDGE_COUNTER_PATH = self.module.join(name="count_predicate.tsv")
         self.NODES_PATH = self.module.join(name="nodes.tsv.gz")
         self.EDGES_PATH = self.module.join(name="edges.tsv.gz")
         self.EMBEDDINGS_PATH = self.module.join(name="embeddings.tsv.gz")
-        self.askemo_prefix, self.askemo_getter, self.askemp_url, self.prefixes = cases[self.use_case]
+        (
+            self.askemo_prefix,
+            self.askemo_getter,
+            self.askemp_url,
+            self.prefixes,
+        ) = cases[self.use_case]
         prefixes = [*self.prefixes, self.askemo_prefix]
         if self.use_case == "space":
             prefixes.append("uat")
@@ -185,7 +199,13 @@ class NodeInfo(NamedTuple):
 @click.option("--do-upload", is_flag=True, help="Upload to S3 on completion")
 @click.option("--refresh", is_flag=True, help="Refresh caches")
 @click.option("--use-case", type=click.Choice(["epi", "space"]), default="epi")
-def main(add_xref_edges: bool, summaries: bool, do_upload: bool, refresh: bool, use_case: GraphName):
+def main(
+    add_xref_edges: bool,
+    summaries: bool,
+    do_upload: bool,
+    refresh: bool,
+    use_case: GraphName,
+):
     """Generate the node and edge files."""
     use_case_paths = UseCasePaths(use_case)
 
@@ -723,7 +743,9 @@ def _write_counter(
                 print(key, count, sep="\t", file=file)
 
 
-def upload_s3(path: Path, *, graph: GraphName, bucket: str = "askem-mira", s3_client=None) -> None:
+def upload_s3(
+    path: Path, *, graph: GraphName, bucket: str = "askem-mira", s3_client=None
+) -> None:
     """Upload the nodes and edges to S3."""
     if s3_client is None:
         import boto3

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -712,9 +712,7 @@ def main(
 
     _construct_registry(
         config_path=EPI_CONF_PATH,
-        output_path=use_case_paths.METAREGISTRY_PATH,
-        nodes_path=use_case_paths.NODES_PATH,
-        edges_path=use_case_paths.EDGES_PATH,
+        output_path=METAREGISTRY_PATH,
         upload=do_upload,
     )
 

--- a/mira/dkg/construct_embeddings.py
+++ b/mira/dkg/construct_embeddings.py
@@ -9,13 +9,13 @@ import click
 from embiggen.embedders import SecondOrderLINEEnsmallen
 from ensmallen import Graph
 
-from mira.dkg.construct import EDGES_PATH, EMBEDDINGS_PATH, upload_s3
+from mira.dkg.construct import upload_s3, UseCasePaths, GraphName
 
 
-def _construct_embeddings(upload: bool) -> None:
+def _construct_embeddings(upload: bool, use_case_paths: UseCasePaths) -> None:
     with TemporaryDirectory() as directory:
-        path = os.path.join(directory, EDGES_PATH.stem)
-        with gzip.open(EDGES_PATH, "rb") as f_in, open(path, "wb") as f_out:
+        path = os.path.join(directory, use_case_paths.EDGES_PATH.stem)
+        with gzip.open(use_case_paths.EDGES_PATH, "rb") as f_in, open(path, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
         graph = Graph.from_csv(
             edge_path=path,
@@ -29,15 +29,16 @@ def _construct_embeddings(upload: bool) -> None:
     embedding = SecondOrderLINEEnsmallen(embedding_size=32).fit_transform(graph)
     df = embedding.get_all_node_embedding()[0].sort_index()
     df.index.name = "node"
-    df.to_csv(EMBEDDINGS_PATH, sep="\t")
+    df.to_csv(use_case_paths.EMBEDDINGS_PATH, sep="\t")
     if upload:
-        upload_s3(EMBEDDINGS_PATH)
+        upload_s3(use_case_paths.EMBEDDINGS_PATH, graph=use_case_paths.use_case)
 
 
 @click.command()
 @click.option("--upload", is_flag=True)
-def main(upload: bool):
-    _construct_embeddings(upload=upload)
+@click.option("--use-case", type=click.Choice(["epi", "space"]))
+def main(upload: bool, use_case: GraphName):
+    _construct_embeddings(upload=upload, use_case_paths=UseCasePaths(use_case))
 
 
 if __name__ == "__main__":

--- a/mira/dkg/construct_rdf.py
+++ b/mira/dkg/construct_rdf.py
@@ -10,9 +10,7 @@ from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
 from mira.dkg.askemo.api import REFERENCED_BY_LATEX, REFERENCED_BY_SYMBOL
-from mira.dkg.construct import DEMO_MODULE, upload_s3, UseCasePaths, GraphName
-
-RDF_TTL_PATH = DEMO_MODULE.join(name="dkg.ttl.gz")
+from mira.dkg.construct import upload_s3, UseCasePaths, GraphName
 
 NAMESPACES = {
     "owl": OWL,
@@ -128,12 +126,12 @@ def _construct_rdf(upload: bool, *, use_case_paths: UseCasePaths):
             graph.add((_ref(s), p_ref, _ref(o)))
 
     tqdm.write("serializing to turtle")
-    with gzip.open(RDF_TTL_PATH, "wb") as file:
+    with gzip.open(use_case_paths.RDF_TTL_PATH, "wb") as file:
         graph.serialize(file, format="turtle")
     tqdm.write("done")
 
     if upload:
-        upload_s3(RDF_TTL_PATH, graph=use_case_paths.use_case)
+        upload_s3(use_case_paths.RDF_TTL_PATH, graph=use_case_paths.use_case)
 
 
 @click.command()

--- a/mira/dkg/construct_rdf.py
+++ b/mira/dkg/construct_rdf.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
 from mira.dkg.askemo.api import REFERENCED_BY_LATEX, REFERENCED_BY_SYMBOL
-from mira.dkg.construct import DEMO_MODULE, EDGES_PATH, NODES_PATH, upload_s3
+from mira.dkg.construct import DEMO_MODULE, upload_s3, UseCasePaths, GraphName
 
 RDF_TTL_PATH = DEMO_MODULE.join(name="dkg.ttl.gz")
 
@@ -45,13 +45,13 @@ def _ref(s: str):
     return rdflib.URIRef(f"https://bioregistry.io/{s}")
 
 
-def _construct_rdf(upload: bool):
+def _construct_rdf(upload: bool, *, use_case_paths: UseCasePaths):
     graph = rdflib.Graph()
     for prefix, namespace in NAMESPACES.items():
         graph.namespace_manager.bind(prefix, namespace)
 
     prefixes = {"bioregistry"}
-    with gzip.open(NODES_PATH, "rt") as file:
+    with gzip.open(use_case_paths.NODES_PATH, "rt") as file:
         reader = csv.reader(file, delimiter="\t")
         _header = next(reader)
         it = tqdm(reader, unit="node", unit_scale=True)
@@ -114,7 +114,7 @@ def _construct_rdf(upload: bool):
         if prefix not in NAMESPACES:
             graph.bind(prefix, rdflib.Namespace(f"https://bioregistry.io/{prefix}:"))
 
-    with gzip.open(EDGES_PATH, "rt") as file:
+    with gzip.open(use_case_paths.EDGES_PATH, "rt") as file:
         reader = csv.reader(file, delimiter="\t")
         _header = next(reader)
         it = tqdm(reader, unit="edge", unit_scale=True)
@@ -133,15 +133,16 @@ def _construct_rdf(upload: bool):
     tqdm.write("done")
 
     if upload:
-        upload_s3(RDF_TTL_PATH)
+        upload_s3(RDF_TTL_PATH, graph=use_case_paths.use_case)
 
 
 @click.command()
 @click.option("--upload", is_flag=True)
-def main(upload: bool):
+@click.option("--use-case", type=click.Choice(["epi", "space"]), default="epi")
+def main(upload: bool, use_case: GraphName):
     """Create an RDF dump and upload to S3."""
     with logging_redirect_tqdm():
-        _construct_rdf(upload)
+        _construct_rdf(upload, use_case_paths=UseCasePaths(use_case))
 
 
 if __name__ == "__main__":

--- a/mira/dkg/construct_registry.py
+++ b/mira/dkg/construct_registry.py
@@ -58,11 +58,7 @@ def get_dkg_prefixes(
 ) -> Set[str]:
     prefixes: Set[str] = set()
 
-    # Note we just consider the epi graph as default, and bolt on some
-    # space weather stuff to it
-    use_case_paths = UseCasePaths("epi")
-
-    with gzip.open(nodes_path or use_case_paths.NODES_PATH, "rt") as file:
+    with gzip.open(nodes_path or NODES_PATH, "rt") as file:
         reader = csv.reader(file, delimiter="\t")
         _header = next(reader)
         it = tqdm(reader, unit="node", unit_scale=True)
@@ -91,7 +87,7 @@ def get_dkg_prefixes(
                 if xref:
                     prefixes.add(xref.split(":", 1)[0])
 
-    with gzip.open(edges_path or use_case_paths.EDGES_PATH, "rt") as file:
+    with gzip.open(edges_path or EDGES_PATH, "rt") as file:
         reader = csv.reader(file, delimiter="\t")
         _header = next(reader)
         it = tqdm(reader, unit="edge", unit_scale=True)

--- a/mira/dkg/metaregistry/epi.json
+++ b/mira/dkg/metaregistry/epi.json
@@ -1,8 +1,8 @@
 {
   "web": {
-    "METAREGISTRY_TITLE": "MIRA Epi Metaregistry",
-    "METAREGISTRY_FOOTER": "MIRA Metaregistry for epidemiology modeling",
-    "METAREGISTRY_HEADER": "<p>This is a MIRA Metaregistry instance to support epidemiology modeling in ASKEM. It catalogues identifiers resources that are used in the MIRA DKG and other systems making use of identifiers.</p>",
+    "METAREGISTRY_TITLE": "MIRA Metaregistry",
+    "METAREGISTRY_FOOTER": "MIRA Metaregistry for epidemiology and space weather modeling",
+    "METAREGISTRY_HEADER": "<p>This is a MIRA Metaregistry instance to support epidemiology and space weather modeling in ASKEM. It catalogues identifiers resources that are used in the MIRA DKG and other systems making use of identifiers.</p>",
     "METAREGISTRY_RESOURCES_SUBHEADER": "",
     "METAREGISTRY_VERSION": "",
     "METAREGISTRY_HOST": "http://localhost:8772",
@@ -23,6 +23,36 @@
       "pattern": "^\\d{7}$",
       "uri_format": "https://indralab.github.io/mira/ontology/$1",
       "example": "0000001"
+    },
+    "askemosw": {
+    	"prefix": "askemosw",
+        "contributor": {
+          "email": "cthoyt@gmail.com",
+          "github": "cthoyt",
+          "name": "Charles Tapley Hoyt",
+          "orcid": "0000-0003-4423-4370"
+        },
+        "homepage": "https://indralab.github.io/mira/swo/",
+        "name": "ASKEM Space Weather Ontology",
+        "description": "A custom ontology to support the space weather use case in ASKEM.",
+        "pattern": "^\\d{7}$",
+        "uri_format": "https://indralab.github.io/mira/swo/$1",
+        "example": "0000001"
+    },
+    "opb": {
+    	"prefix": "opb",
+        "contributor": {
+          "email": "cthoyt@gmail.com",
+          "github": "cthoyt",
+          "name": "Charles Tapley Hoyt",
+          "orcid": "0000-0003-4423-4370"
+        },
+		"homepage": "https://bioportal.bioontology.org/ontologies/OPB",
+        "name": "Ontology of Physics for Biology",
+        "description": "The OPB is a reference ontology of classical physics and thermodynamics as applied to the dynamics of biological systems. It is designed to encompass the multiple structural scales (atoms to organisms) and multiple physical domains (fluid dynamics, chemical kinetics, particle diffusion, etc.) that are encountered in the study and analysis of biological organisms. [from BioPortal]",
+        "pattern": "^\\d+$",
+        "uri_format": "https://bioportal.bioontology.org/ontologies/OPB?p=classes&conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23OPB_$1",
+        "example": "01412"
     }
   }
 }

--- a/mira/dkg/resources/__init__.py
+++ b/mira/dkg/resources/__init__.py
@@ -20,4 +20,5 @@ SLIMS = {
     "ncit": Path(get_resource_path("ncit_slim.json")),
     "covoc": Path(get_resource_path("covoc_slim.json")),
     "efo": Path(get_resource_path("efo_slim.json")),
+    "uat": Path(get_resource_path("uat.json")),
 }

--- a/mira/dkg/resources/uat.py
+++ b/mira/dkg/resources/uat.py
@@ -57,7 +57,8 @@ def make_term(d, *, parent: Optional[Term] = None, terms):
         make_term(child, parent=term, terms=terms)
 
 
-def main():
+def get_uat() -> Obo:
+    """Get a UAT ontology object."""
     data = requests.get(url).json()
     terms = {}
     for c in data["children"]:
@@ -72,11 +73,18 @@ def main():
         static_version = "5.0"
         check_bioregistry_prefix = False
         term_sort_key = func
+        idspaces = {
+            "uat": "https://astrothesaurus.org/uat/1",
+        }
 
         def iter_terms(self, force: bool = False):
             return terms.values()
 
-    obo = UAT()
+    return UAT()
+
+
+def main():
+    obo = get_uat()
     obo_path = HERE.joinpath("uat.obo")
     obograph_path = HERE.joinpath("uat.json")
     obo.write_obo(obo_path)

--- a/mira/dkg/ui.py
+++ b/mira/dkg/ui.py
@@ -12,12 +12,9 @@ ui_blueprint = Blueprint("ui", __name__)
 @ui_blueprint.route("/", methods=["GET"])
 def home():
     """Render the home page."""
-    # key = random.choice(list(grounder.entries))
     return render_template(
         "home.html",
         number_terms=len(grounder.entries),
-        # example_key=key,
-        # example_term=grounder.entries[key][0].to_json(),
         node_counter=client.get_node_counter(),
     )
 

--- a/mira/dkg/ui.py
+++ b/mira/dkg/ui.py
@@ -12,12 +12,12 @@ ui_blueprint = Blueprint("ui", __name__)
 @ui_blueprint.route("/", methods=["GET"])
 def home():
     """Render the home page."""
-    key = random.choice(list(grounder.entries))
+    # key = random.choice(list(grounder.entries))
     return render_template(
         "home.html",
         number_terms=len(grounder.entries),
-        example_key=key,
-        example_term=grounder.entries[key][0].to_json(),
+        # example_key=key,
+        # example_term=grounder.entries[key][0].to_json(),
         node_counter=client.get_node_counter(),
     )
 


### PR DESCRIPTION
This PR does the following:

1. Makes the DKG build parametrizable for use case
2. Rewires paths accordingly
3. The Metaregistry is now including the relevant vocabularies for Space Weather, but gets built with the epi build. We can make this more streamlined later.
4. Hacks in the UAT ontology build, there are some issues with the UAT OBO->JSON due to some assumptions ROBOT makes that all ontologies should have OBO PURLs that would take a lot more effort to overcome in general

This is working! There are still a few ongoing questions, but since the first consumers will be TA1 on the lookup/search/grounding functionality, some other improvements can be saved for follow-up

## Files

- Nodes: https://askem-mira.s3.amazonaws.com/dkg/space/build/2023-03-10/nodes.tsv.gz
- Edges: https://askem-mira.s3.amazonaws.com/dkg/space/build/2023-03-10/edges.tsv.gz

## Follow-up

1. Keep thinking about whether we want to be able to deploy 2 different KGs in one app
2. Better configurability of text on DKG app
3. Better configurability of functionality on DKG app (e.g., the petri net modeling doesn't make a lot of sense for SW - turn off that blueprint)