### PR TITLE
Configure routers based on use case

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && \
 
 ARG version=2023-02-02
 ARG domain=epi
+# This latter is used in the code
+ENV MIRA_DOMAIN=${domain}
 
 # Download graph content and ingest into neo4j
 RUN wget -O /sw/nodes.tsv.gz https://askem-mira.s3.amazonaws.com/dkg/$domain/build/$version/nodes.tsv.gz && \
@@ -29,4 +31,4 @@ RUN python -m pip install git+https://github.com/indralab/mira.git@main#egg=mira
     python -m pip install bootstrap_flask
 
 COPY startup.sh startup.sh
-ENTRYPOINT ["/bin/bash", "/sw/startup.sh", "$domain"]
+ENTRYPOINT ["/bin/bash", "/sw/startup.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,4 +29,4 @@ RUN python -m pip install git+https://github.com/indralab/mira.git@main#egg=mira
     python -m pip install bootstrap_flask
 
 COPY startup.sh startup.sh
-ENTRYPOINT ["/bin/bash", "/sw/startup.sh"]
+ENTRYPOINT ["/bin/bash", "/sw/startup.sh", "$domain"]

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -2,6 +2,9 @@
 neo4j start
 sleep 100
 neo4j status
+
+export MIRA_DOMAIN=$1
+
 if [ "${ROOT_PATH}" ]; then
   echo "Running with root path set to ${ROOT_PATH}"
   uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app --root-path "${ROOT_PATH}"

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -3,8 +3,6 @@ neo4j start
 sleep 100
 neo4j status
 
-export MIRA_DOMAIN=$1
-
 if [ "${ROOT_PATH}" ]; then
   echo "Running with root path set to ${ROOT_PATH}"
   uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app --root-path "${ROOT_PATH}"

--- a/mira/dkg/wsgi.py
+++ b/mira/dkg/wsgi.py
@@ -1,5 +1,7 @@
 """Neo4j client module."""
+
 import logging
+import os
 from textwrap import dedent
 
 import flask
@@ -10,7 +12,6 @@ from flask_bootstrap import Bootstrap5
 from mira.dkg.api import api_blueprint
 from mira.dkg.client import Neo4jClient
 from mira.dkg.grounding import grounding_blueprint
-from mira.dkg.model import model_blueprint
 from mira.dkg.ui import ui_blueprint
 from mira.dkg.utils import PREFIXES, MiraState
 from mira.metamodel import RefinementClosure
@@ -22,6 +23,8 @@ __all__ = [
     "flask_app",
     "app",
 ]
+
+DOMAIN = os.getenv("MIRA_DOMAIN")
 
 tags_metadata = [
     {
@@ -69,7 +72,11 @@ app = FastAPI(
 )
 app.include_router(api_blueprint, prefix="/api")
 app.include_router(grounding_blueprint, prefix="/api")
-app.include_router(model_blueprint, prefix="/api")
+
+if DOMAIN != "space":
+    from mira.dkg.model import model_blueprint
+
+    app.include_router(model_blueprint, prefix="/api")
 
 flask_app = flask.Flask(__name__)
 


### PR DESCRIPTION
This PR makes it possible to configure which routers get mounted based on the use case. The main reason for this at the moment is not to mount the template model API to the space weather deployment.

It does this by passing the `domain` set in the dockerfile through to `startup.sh` then setting it as an environment variable so it can get read by the WSGI script inside python. There's probably a  better way to do this - @kkaris can you advise?