### PR TITLE
List entities endpoint

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -93,7 +93,7 @@ def get_entities(
     request: Request,
     curies: str = Path(
         ...,
-        description="A comma-separetared list of compact URIs (CURIEs) for an "
+        description="A comma-separated list of compact URIs (CURIEs) for an "
         "entity in the form of ``<prefix>:<local unique identifier>,...``",
         example="ido:0000511,ido:0000512",
     ),

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -14,7 +14,7 @@ import networkx
 import pystow
 import requests
 from neo4j import GraphDatabase, Transaction, unit_of_work
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from tqdm import tqdm
 from typing_extensions import Literal, TypeAlias
 
@@ -32,6 +32,9 @@ logger = logging.getLogger(__name__)
 #: See documentation for query action at
 #: https://www.wikidata.org/w/api.php?action=help&modules=query
 WIKIDATA_API = "https://www.wikidata.org/w/api.php"
+
+#: Base URL for the metaregistry, used in creating links
+METAREGISTRY_BASE = "http://34.230.33.149:8772"
 
 Node: TypeAlias = Mapping[str, Any]
 
@@ -76,6 +79,15 @@ class Entity(BaseModel):
         description="A mapping of properties to their values",
         example={},
     )
+    # Gets auto-populated
+    link: Optional[str] = None
+
+    @validator("link")
+    def set_link(cls, value, values):
+        # disregard the name of this function,
+        # see: https://stackoverflow.com/questions/54023782/pydantic-make-field-none-in-validator-based-on-other-fields-value
+        curie = values["id"]
+        return f"{METAREGISTRY_BASE}/{curie}"
 
     @property
     def prefix(self) -> str:

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -84,8 +84,13 @@ class Entity(BaseModel):
 
     @validator("link")
     def set_link(cls, value, values):
-        # disregard the name of this function,
-        # see: https://stackoverflow.com/questions/54023782/pydantic-make-field-none-in-validator-based-on-other-fields-value
+        """
+        Set the value of the ``link`` field based on the value of the ``id``
+        field. This gets run as a post-init hook by Pydantic
+
+        See also:
+        https://stackoverflow.com/questions/54023782/pydantic-make-field-none-in-validator-based-on-other-fields-value
+        """
         curie = values["id"]
         return f"{METAREGISTRY_BASE}/{curie}"
 

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -155,6 +155,13 @@ class TestDKG(unittest.TestCase):
         self.assertIsInstance(e.physical_min, float)
         self.assertEqual(0.0, e.physical_min)
 
+    def test_entities(self):
+        """Test getting multiple entities."""
+        res = self.client.get("/api/entities/ido:0000463,askemo:0000008")
+        entities = [Entity.from_data(**record) for record in res.json()]
+        self.assertEqual("ido:0000463", entities[0].id)
+        self.assertEqual("askemo:0000008", entities[1].id)
+
     def test_entity_missing(self):
         """Test what happens when an entity is requested that's not in the DKG."""
         # Scenario 1: invalid prefix

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from gilda.grounder import Grounder
 
 from mira.dkg.api import get_relations
-from mira.dkg.client import AskemEntity, Entity
+from mira.dkg.client import AskemEntity, Entity, METAREGISTRY_BASE
 from mira.dkg.utils import MiraState
 
 MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
@@ -150,6 +150,7 @@ class TestDKG(unittest.TestCase):
         self.assertEqual("unitless", e.suggested_unit)
 
         res = self.client.get("/api/entity/askemo:0000010")
+        self.assertIn("link", res.json())
         e = AskemEntity(**res.json())
         self.assertTrue(hasattr(e, "physical_min"))
         self.assertIsInstance(e.physical_min, float)
@@ -160,6 +161,7 @@ class TestDKG(unittest.TestCase):
         res = self.client.get("/api/entities/ido:0000463,askemo:0000008")
         entities = [Entity.from_data(**record) for record in res.json()]
         self.assertEqual("ido:0000463", entities[0].id)
+        self.assertEqual(f"{METAREGISTRY_BASE}/ido:0000463", entities[0].link)
         self.assertEqual("askemo:0000008", entities[1].id)
 
     def test_entity_missing(self):


### PR DESCRIPTION
Requested by @YohannParis for https://github.com/DARPA-ASKEM/Terarium/pull/867. This PR does the following:

1. Implements the `/api/entities` endpoint, which is the same as `/api/entity` except it takes a comma-separated list of CURIEs and returns a list. Example: `/api/entities/ido:0000463,askemo:0000008`
2. Adds links to output in both of these queries that can be used in the front-end. This is constructed using the metaregistry's base URL, which is currently hard-coded.