### PR TITLE
Add additional triggers for integration label

### DIFF
--- a/.github/workflows/integration-issues.yml
+++ b/.github/workflows/integration-issues.yml
@@ -9,6 +9,8 @@ on:
     types:
       - reopened
       - opened
+      - labeled
+      - edited
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Pick up integration label even if applied retroactively.