### PR TITLE
Improve xref types for ProbOnto

### DIFF
--- a/docs/ontology/0000016/index.html
+++ b/docs/ontology/0000016/index.html
@@ -1,0 +1,75 @@
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">    <link
+        rel="stylesheet"
+        href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
+        integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+        crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.6.12/c3.min.css"/>
+    <style>
+        h2 {
+            margin-top: 35px;
+        }
+
+        html, body {
+            height: 100%;
+        }
+
+        body {
+            display: flex;
+            flex-flow: column;
+        }
+
+        .footer {
+            margin-top: auto;
+            padding-top: 1em;
+            background-color: #f5f5f5;
+        }
+    </style>    <title>equivalent distribution</title></head>
+
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <span class="navbar-brand">
+        ASKEM Ontology
+    </span>
+</nav>
+
+<div class="container" style="margin-top: 50px; margin-bottom: 50px">
+<div class="card">
+        <h5 class="card-header">
+            <span class="badge badge-info">Term</span>
+            equivalent distribution
+        </h5>
+        <div class="card-body">
+                <p>Two distributions that are equivalent but parametrized differently.</p>
+            <dl>
+                <dt>Local Unique Identifier</dt>
+                <dd>
+                    <a href="http://34.230.33.149:8772/askemo:0000016">0000016</a>
+                </dd>
+
+                
+                
+                
+                
+            </dl>
+        </div>
+    </div></div>
+
+<footer class="footer">
+    <p class="small text-center text-muted">
+        Generated with PyOBO
+    </p>
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+        integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+        crossorigin="anonymous"></script></body>
+</html>

--- a/docs/ontology/index.html
+++ b/docs/ontology/index.html
@@ -47,7 +47,7 @@
             <p>A custom ontology to support the epidemiology use case in ASKEM.</p>
             <dl>
                 <dt>Number of Terms</dt>
-                <dd>15</dd>
+                <dd>16</dd>
                 <dt>MIRA Epi Metaregistry</dt>
                 <dd>
                     <a href="http://34.230.33.149:8772/askemo">
@@ -218,6 +218,14 @@
                         <td align="right"><a href="0000015">0000015</a></td>
                         <td>masking</td>
                         <td>The practice of wearing a protective face mask.</td>
+                    </tr>
+                    <tr>
+                        <td>
+                                Term
+                        </td>
+                        <td align="right"><a href="0000016">0000016</a></td>
+                        <td>equivalent distribution</td>
+                        <td>Two distributions that are equivalent but parametrized differently.</td>
                     </tr>
                 </tbody>
             </table>

--- a/mira/dkg/askemo/askemo.json
+++ b/mira/dkg/askemo/askemo.json
@@ -321,5 +321,11 @@
       }
     ],
     "type": "class"
+  },
+  {
+    "description": "Two distributions that are equivalent but parametrized differently.",
+    "id": "askemo:0000016",
+    "name": "equivalent distribution",
+    "type": "property"
   }
 ]

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -383,7 +383,7 @@ def construct(
             version="2.5",
             property_predicates=";".join(property_predicates),
             property_values=";".join(property_values),
-            xref_types=";".join("oboinowl:hasDbXref" for _eq in term.get("equivalent", [])),
+            xref_types=";".join("reparameterization" for _eq in term.get("equivalent", [])),
             synonym_types="",
         )
         # Add equivalents?

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -383,7 +383,7 @@ def construct(
             version="2.5",
             property_predicates=";".join(property_predicates),
             property_values=";".join(property_values),
-            xref_types=";".join("reparameterization" for _eq in term.get("equivalent", [])),
+            xref_types=";".join("askemo:0000016" for _eq in term.get("equivalent", [])),
             synonym_types="",
         )
         # Add equivalents?


### PR DESCRIPTION
This pull request introduces a more specific relation than `oboinowl:hasDbXref` to describe the relationship between two alternate parametrizations of the same distribution. This is encoded as a new term `askemo:0000016` "equivalent distribution" in the ASKEM Ontology.

Accordingly, this PR updates the construction of the DKG to use this relation when processing ProbOnto.