### PR TITLE
Encapsulate template models inside AskeNetPetriNetModel 

### DIFF
--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -36,6 +36,7 @@ class AskeNetPetriNetModel:
         model:
             The pre-compiled transition model
         """
+        self.model = model
         self.states = []
         self.transitions = []
         self.parameters = []


### PR DESCRIPTION
Encapsulated template models inside `AskeNetPetriNetModel` so that the template model can be obtained from the AskeNetPetriNetModel