### PR TITLE
Enforce search terms have names

### DIFF
--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -468,16 +468,20 @@ class Neo4jClient:
             f"""\
             MATCH (n)
             WHERE
-                replace(replace(toLower(n.name), '-', ''), '_', '') CONTAINS '{query_lower}'
-                OR any(
-                    synonym IN n.synonyms 
-                    WHERE replace(replace(toLower(synonym), '-', ''), '_', '') CONTAINS '{query_lower}'
+                EXISTS(n.name)
+                AND (
+                    replace(replace(toLower(n.name), '-', ''), '_', '') CONTAINS '{query_lower}'
+                    OR any(
+                        synonym IN n.synonyms 
+                        WHERE replace(replace(toLower(synonym), '-', ''), '_', '') CONTAINS '{query_lower}'
+                    )
                 )
             RETURN n
         """
         )
         entities = [Entity.from_data(n) for n in self.query_nodes(cypher)]
         rv = sorted(entities, key=lambda x: similarity_score(query, x))
+        rv = [x for x in rv if x.prefix not in {"oboinowl", "rdf", "rdfs", "bfo", "cob"}]
         return rv
 
     @staticmethod

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -479,10 +479,15 @@ class Neo4jClient:
             RETURN n
         """
         )
+        skip_prefixes = {"oboinowl", "rdf", "rdfs", "bfo", "cob", "ro"}
         entities = [Entity.from_data(n) for n in self.query_nodes(cypher)]
-        rv = sorted(entities, key=lambda x: similarity_score(query, x))
-        rv = [x for x in rv if x.prefix not in {"oboinowl", "rdf", "rdfs", "bfo", "cob"}]
-        return rv
+        entities = [
+            entity
+            for entity in entities
+            if entity.name is not None and entity.prefix not in skip_prefixes
+        ]
+        entities = sorted(entities, key=lambda x: similarity_score(query, x))
+        return entities
 
     @staticmethod
     def neo4j_to_node(neo4j_node: neo4j.graph.Node):

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -128,6 +128,14 @@ class TestDKG(unittest.TestCase):
         res5 = self.client.get("/api/search", params={"q": "hasdbxref"})
         self.assertEqual(0, len(res5.json()))
 
+        # Test entries with synonyms but no name, such as fbbt:00000008
+        res6 = self.client.get("/api/search", params={"q": "clypeo-labrum"})
+        e6 = [Entity(**e) for e in res6.json()]
+        self.assertTrue(all(
+            e.id != "fbbt:00000008"
+            for e in e6
+        ))
+
     def test_entity(self):
         """Test getting entities."""
         res = self.client.get("/api/entity/ido:0000463")

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -124,6 +124,10 @@ class TestDKG(unittest.TestCase):
             for e in e4
         ))
 
+        # Test not returning restricted prefixes
+        res5 = self.client.get("/api/search", params={"q": "hasdbxref"})
+        self.assertEqual(0, len(res5.json()))
+
     def test_entity(self):
         """Test getting entities."""
         res = self.client.get("/api/entity/ido:0000463")


### PR DESCRIPTION
This PR makes two improvements to the DKG search:

1. Filters out all entities that don't have a `name` attribute that exists
2. Filters out all entries whose prefixes are from a specific list of high-level modeling vocabularies that aren't typically useful for search. This list is oboInOwl, RDF, RDFS, BFO, and COB.

Interestingly, I ran a query `MATCH (:n) WHERE NOT EXISTS(n.name) AND EXISTS(n.synonyms) RETURN n` to identify some examples where this happened. The first results were from FBbt, which isn't an ontology we import directly so it might be due to some errors in how terms are included upstream.