### PR TITLE
Add metadata to ASKEM PetriNet export

### DIFF
--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -153,6 +153,22 @@ class AskeNetPetriNetModel:
                 }
             self.parameters.append(param_dict)
 
+        # There are two ways we can do this. First is to add
+        # the metadata directly into this element. Second is to
+        # have another grouping element in the middle, in case there
+        # are a lot of other parts that live in this element. The
+        # other thing we need to consider is should we put some of
+        # these parts in the base_schema, such as license, authors,
+        # references, time scale, and model types. Some others such
+        # as pathogens, diseases, hosts, locations, start time,
+        # and end time can be optional
+        for k, v in model.template_model.annotations.dict().items():
+            if k in ["name", "description"]:
+                # name and description already have a privileged place
+                # in the petrinet schema so don't get added again
+                continue
+            self.metadata[k] = v
+
     def to_json(self, name=None, description=None, model_version=None):
         """Return a JSON dict structure of the Petri net model."""
         return {


### PR DESCRIPTION
This pull requests improves the `mira.modeling.askenet.petrinet` export to include the annotations (e.g., license, author, references) from a given template model into the `metadata` key in the Petri Net shared representation (defined [here](https://github.com/DARPA-ASKEM/Model-Representations/blob/main/petrinet/petrinet_schema.json)).


There are two ways we can do this:

1. Add the metadata directly into the `metadata` element.
2. Have another grouping element inside the `metadata` element, in case there are a lot of other parts that live in this element, such as in the [SIR example](https://github.com/DARPA-ASKEM/Model-Representations/blob/main/petrinet/examples/sir.json).

The other thing we need to consider is should we put some of these parts in the [base_schema.json](https://github.com/DARPA-ASKEM/Model-Representations/blob/main/base_schema.json). Some metadata are always relevant for all models such as license, authors, references, and model types (but again remain optional, since this isn't always available). Some others such as time scale, start time, end time, pathogens, diseases, hosts, locations are sometimes use-case-specific so maybe it makes sense not to add them to the schema.