### PR TITLE
Update metadata for shared representations

### DIFF
--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from mira.metamodel import expression_to_mathml
 
 from .. import Model
+from .utils import add_metadata_annotations
 
 logger = logging.getLogger(__name__)
 
@@ -189,21 +190,7 @@ class AskeNetPetriNetModel:
                 }
             self.parameters.append(param_dict)
 
-        # There are two ways we can do this. First is to add
-        # the metadata directly into this element. Second is to
-        # have another grouping element in the middle, in case there
-        # are a lot of other parts that live in this element. The
-        # other thing we need to consider is should we put some of
-        # these parts in the base_schema, such as license, authors,
-        # references, time scale, and model types. Some others such
-        # as pathogens, diseases, hosts, locations, start time,
-        # and end time can be optional
-        for k, v in model.template_model.annotations.dict().items():
-            if k in ["name", "description"]:
-                # name and description already have a privileged place
-                # in the petrinet schema so don't get added again
-                continue
-            self.metadata[k] = v
+        add_metadata_annotations(self.metadata, model)
 
     def to_json(self, name=None, description=None, model_version=None):
         """Return a JSON dict structure of the Petri net model."""

--- a/mira/modeling/askenet/regnet.py
+++ b/mira/modeling/askenet/regnet.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from mira.metamodel import *
 
 from .. import Model, is_production, is_degradation
+from .utils import add_metadata_annotations
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ class AskeNetRegNetModel:
             model.template_model.annotations.name else "Model"
         self.model_description = model.template_model.annotations.description \
             if model.template_model.annotations.description else self.model_name
+        self.metadata = {}
         vmap = {}
         for key, var in model.variables.items():
             # Use the variable's concept name if possible but fall back
@@ -146,6 +148,8 @@ class AskeNetRegNetModel:
                 }
             self.parameters.append(param_dict)
 
+        add_metadata_annotations(self.metadata, model)
+
     def to_json(self, name=None, description=None, model_version=None):
         """Return a JSON dict structure of the Petri net model."""
         return {
@@ -158,7 +162,8 @@ class AskeNetRegNetModel:
                 'vertices': self.states,
                 'edges': self.transitions,
                 'parameters': self.parameters,
-            }
+            },
+            'metadata': self.metadata,
         }
 
     def to_pydantic(self, name=None, description=None, model_version=None) -> "ModelSpecification":

--- a/mira/modeling/askenet/utils.py
+++ b/mira/modeling/askenet/utils.py
@@ -1,0 +1,10 @@
+def add_metadata_annotations(metadata, model):
+    annotations_subset = {
+        k: v
+        for k, v in model.template_model.annotations.dict().items()
+        if k not in ["name", "description"]
+        # name and description already have a privileged place
+        # in the petrinet schema so don't get added again
+    }
+    if annotations_subset:
+        metadata['annotations'] = annotations_subset


### PR DESCRIPTION
As a follow-up to https://github.com/indralab/mira/pull/174 and https://github.com/DARPA-ASKEM/Model-Representations/pull/42, this makes updates to the MIRA export for ASKEM petri nets to put the metadata for annotations into an `"annotations"` key in the `"metadata"` dictionary.

This PR also adds the metadata export to the ASKEM regnets. It externalizes the code that does this since it's duplicated in both (and potentially others)