### PR TITLE
Implement units in template model and for shared model representation

### DIFF
--- a/mira/dkg/resources/unit_names.tsv
+++ b/mira/dkg/resources/unit_names.tsv
@@ -1,0 +1,1778 @@
+1
+1593 English statute mile
+Bethesda unit
+Bodansky unit
+Boltzmann constant
+British Imperial fathom
+British Imperial foot
+British Imperial inch
+British Imperial nautical mile
+British Imperial rod
+British Imperial yard
+British thermal unit (39 °F)
+British thermal unit (59 °F)
+British thermal unit (60 °F)
+British thermal unit (IT)
+British thermal unit (mean)
+British thermal unit (thermochemical)
+British thermal unit (thermochemical)
+Didot point
+Dye unit
+ELISA unit
+Ehrlich unit
+French gauge
+Gregorian year
+Gunter's chain (UK)
+Gunter's chain (US survey)
+Hounsfield unit
+Julian year
+Kunkel unit
+Mac Lagan unit
+Paris foot
+Paris inch
+Planck constant
+Printer's pica
+Printer's point
+Ramsden chain
+Roentgen equivalent man
+Somogyi unit
+Todd unit
+US customary cup
+US legal cup
+US survey acre
+US survey furlong
+US survey mil
+US survey yards
+United States Pharmacopeia unit
+United States survey link
+Winchester gallon
+Wood unit
+acre
+ampere
+ampere hour
+ampere hour per cubic decimetre
+ampere hour per kilogram
+ampere minute
+ampere per degree
+ampere per joule
+ampere per kilogram
+ampere per metre
+ampere per radian
+ampere per square metre
+ampere per square metre square kelvin
+ampere per volt
+ampere per volt metre
+ampere second
+ampere second metre
+ampere second per cubic metre
+ampere second per kilogram
+ampere second per metre
+ampere second per square metre
+ampere square metre
+ampere square metre per joule second
+apothecaries' drachm
+apothecaries' ounce
+apothecaries' pound
+apothecaries' scruple
+arbitrary unit
+arcminute
+arcsecond
+are
+astronomical unit
+astronomical unit per year
+atto
+attoampere
+attobecquerel
+attocandela
+attocoulomb
+attodegree Celsius
+attoelectronvolt
+attofarad
+attogram
+attogram per litre
+attogray
+attohenry
+attohertz
+attojoule
+attokatal
+attokelvin
+attolitre
+attolumen
+attolux
+attometre
+attometre per second
+attometre per square second
+attomole
+attonewton
+attoohm
+attoparsec
+attopascal
+attoradian
+attosecond
+attosiemens
+attosievert
+attosteradian
+attotesla
+attovolt
+attowatt
+attoweber
+bar
+barn
+barn per electronvolt
+barn per steradian
+barn per steradian electronvolt
+barrel (US) for petroleum
+barrels per day
+baud
+beats per minute
+becquerel
+becquerel per cubic metre
+becquerel per kilogram
+becquerel per litre
+becquerel per square metre
+bel
+bel 10 nanovolt
+bel kilowatt
+bel microvolt
+bel millivolt
+bel sound pressure level
+bel volt
+bel watt
+biot
+bit
+bit per cubic metre
+bit per metre
+bit per second
+bit per square metre
+board foot
+breath per minute
+bushel (UK)
+bushel (US)
+byte
+byte per second
+calorie (15 °C)
+calorie (20 °C)
+calorie (international table)
+candela
+candela metre
+candela per hertz
+candela per metre
+candela per square centimetre
+candela per square foot
+candela per square metre
+candela square millimetre per square metre
+candela steradian
+candela steradian cubic second per kilogram square metre
+candela steradian per square metre
+candela steradian second
+candela steradian second per square metre
+carat
+carat
+centi
+centiampere
+centibecquerel
+centicandela
+centicoulomb
+centidegree Celsius
+centielectronvolt
+centifarad
+centigram
+centigram per litre
+centigray
+centihenry
+centihertz
+centijoule
+centikatal
+centikelvin
+centilitre
+centilumen
+centilux
+centimetre
+centimetre of mercury
+centimetre of water
+centimetre of water
+centimetre per day
+centimetre per hour
+centimetre per second
+centimetre per square second
+centimole
+centinewton
+centinewton metre
+centiohm
+centipascal
+centipoise
+centiradian
+centisecond
+centisiemens
+centisievert
+centisteradian
+centistokes
+centitesla
+centivolt
+centiwatt
+centiweber
+chain
+cicero
+circle
+circular mil
+cord
+cord
+coulomb
+coulomb metre
+coulomb per cubic centimetre
+coulomb per cubic metre
+coulomb per cubic millimetre
+coulomb per kilogram
+coulomb per kilogram second
+coulomb per metre
+coulomb per mole
+coulomb per second
+coulomb per square centimetre
+coulomb per square metre
+coulomb per square millimetre
+count per litre
+cubic attometre
+cubic centimetre
+cubic centimetre per cubic metre
+cubic centimetre per day
+cubic centimetre per gram
+cubic centimetre per hour
+cubic centimetre per minute
+cubic centimetre per mole
+cubic centimetre per second
+cubic decametre
+cubic decimetre
+cubic decimetre per cubic metre
+cubic decimetre per hour
+cubic decimetre per kilogram
+cubic decimetre per mole
+cubic exametre
+cubic femtometre
+cubic foot
+cubic foot per minute
+cubic foot per pound
+cubic foot per second
+cubic gigametre
+cubic hectometre
+cubic hectometre per year
+cubic inch
+cubic inch per pound
+cubic kilometre
+cubic megametre
+cubic metre
+cubic metre per coulomb
+cubic metre per cubic metre
+cubic metre per day
+cubic metre per hour
+cubic metre per kilogram
+cubic metre per kilogram square second
+cubic metre per minute
+cubic metre per mole
+cubic metre per second
+cubic metre per second ampere
+cubic metre per ton
+cubic metre per year
+cubic micrometre
+cubic millimetre
+cubic millimetre per cubic metre
+cubic millimetre per cubic millimetre
+cubic nanometre
+cubic petametre
+cubic picometre
+cubic second kelvin per kilogram
+cubic second kelvin per kilogram square metre
+cubic second square ampere per kilogram cubic metre
+cubic second square ampere per kilogram mole
+cubic second square ampere per kilogram square metre
+cubic terametre
+cubic yard
+cubic yoctometre
+cubic yottametre
+cubic zeptometre
+cubic zettametre
+curie
+curie per kilogram
+curie per litre
+dalton
+dalton
+dalton
+day
+deca
+decaampere
+decabecquerel
+decacandela
+decacoulomb
+decadegree Celsius
+decaelectronvolt
+decafarad
+decagram
+decagram per litre
+decagray
+decahenry
+decahertz
+decajoule
+decakatal
+decakelvin
+decalitre
+decalumen
+decalux
+decametre
+decametre per second
+decametre per square second
+decamole
+decanewton
+decaohm
+decapascal
+decaradian
+decare
+decasecond
+decasiemens
+decasievert
+decasteradian
+decatesla
+decavolt
+decawatt
+decaweber
+deci
+deciampere
+deciare
+decibar
+decibecquerel
+decibel
+decicandela
+decicoulomb
+decidegree Celsius
+decielectronvolt
+decifarad
+decigram
+decigram per litre
+decigray
+decihenry
+decihertz
+decijoule
+decikatal
+decikelvin
+decilitre
+decilitre per gram
+decilumen
+decilux
+decimetre
+decimetre per second
+decimetre per square second
+decimole
+decinewton
+decinewton metre
+deciohm
+decipascal
+deciradian
+decisecond
+decisiemens
+decisievert
+decisteradian
+decitesla
+decitonne
+decivolt
+deciwatt
+deciweber
+degree
+degree Celsius
+degree Celsius difference
+degree Fahrenheit
+degree Rankine
+degree Réaumur
+degree per metre
+degree per second
+degree per square second
+denier
+dimensionless unit
+dioptre
+dram (avoirdupois)
+drop
+dry pint (US)
+dry quart
+dyne
+dyne per centimetre
+dyne per square centimetre
+e cm
+electron mass
+electronvolt
+electronvolt per metre
+electronvolt per square metre
+electronvolt second
+electronvolt square metre per kilogram
+elementary charge
+elementary charge
+erg
+erg per cubic centimetre
+erg per gram
+erg per gram
+erg per second
+erg per second square centimetre
+exa
+exaampere
+exabecquerel
+exabit
+exabit per second
+exabyte
+exabyte per second
+exacandela
+exacoulomb
+exadegree Celsius
+exaelectronvolt
+exafarad
+exagram
+exagram per litre
+exagray
+exahenry
+exahertz
+exajoule
+exakatal
+exakelvin
+exalitre
+exalumen
+exalux
+exametre
+exametre per second
+exametre per square second
+examole
+exanewton
+exaohm
+exapascal
+exaradian
+exasecond
+exasiemens
+exasievert
+exasteradian
+exatesla
+exavolt
+exawatt
+exaweber
+farad
+farad per metre
+fathom
+femto
+femtoampere
+femtobecquerel
+femtocandela
+femtocoulomb
+femtodegree Celsius
+femtoelectronvolt
+femtofarad
+femtogram
+femtogram per litre
+femtogray
+femtohenry
+femtohertz
+femtojoule
+femtokatal
+femtokelvin
+femtolitre
+femtolumen
+femtolux
+femtometre
+femtometre
+femtometre per second
+femtometre per square second
+femtomole
+femtonewton
+femtoohm
+femtopascal
+femtoradian
+femtosecond
+femtosiemens
+femtosievert
+femtosteradian
+femtotesla
+femtovolt
+femtowatt
+femtoweber
+fluid dram (UK)
+fluid dram (US)
+fluid ounce
+fluid ounce (US customary)
+fluid ounce (US nutrition)
+foot (US survey)
+foot per hour
+gal
+gal
+gallon (UK)
+gallon (UK)
+gauss
+gauss
+gibi
+gibibit
+gibibyte
+giga
+gigaampere
+gigabecquerel
+gigabecquerel per kilogram
+gigabit
+gigabit per second
+gigabyte
+gigabyte per second
+gigacandela
+gigacoulomb
+gigacoulomb per cubic metre
+gigadegree Celsius
+gigaelectronvolt
+gigafarad
+gigagram
+gigagram per litre
+gigagray
+gigahenry
+gigahertz
+gigahertz per volt
+gigajoule
+gigakatal
+gigakelvin
+gigalitre
+gigalumen
+gigalux
+gigametre
+gigametre per second
+gigametre per square second
+gigamole
+giganewton
+gigaohm
+gigaparsec
+gigapascal
+gigaradian
+gigasecond
+gigasiemens
+gigasievert
+gigasteradian
+gigatesla
+gigatonne
+gigatonne per year
+gigavolt
+gigawatt
+gigawatt hour
+gigaweber
+gilbert
+gill
+gill
+grade
+gradian
+gradian
+grain
+gram
+gram per attolitre
+gram per centilitre
+gram per centimetre second
+gram per cubic centimetre
+gram per cubic decimetre
+gram per cubic metre
+gram per day
+gram per decalitre
+gram per decilitre
+gram per exalitre
+gram per femtolitre
+gram per gigalitre
+gram per gram
+gram per hectogram
+gram per hectolitre
+gram per hour
+gram per joule
+gram per kilogram
+gram per kilolitre
+gram per litre
+gram per megajoule
+gram per megalitre
+gram per metre
+gram per microlitre
+gram per millilitre
+gram per millimetre
+gram per minute
+gram per mole
+gram per nanolitre
+gram per petalitre
+gram per picolitre
+gram per second
+gram per square centimetre
+gram per square metre
+gram per square metre day
+gram per square metre second
+gram per square millimetre
+gram per teralitre
+gram per yoctolitre
+gram per yottalitre
+gram per zeptolitre
+gram per zettalitre
+gram percent
+gram-force
+gravitational constant
+gray
+gray per hour
+gray per minute
+gray per second
+hand
+hectare
+hecto
+hectoampere
+hectobar
+hectobecquerel
+hectocandela
+hectocoulomb
+hectodegree Celsius
+hectoelectronvolt
+hectofarad
+hectogram
+hectogram per litre
+hectogray
+hectohenry
+hectohertz
+hectojoule
+hectokatal
+hectokelvin
+hectolitre
+hectolumen
+hectolux
+hectometre
+hectometre per second
+hectometre per square second
+hectomole
+hectonewton
+hectoohm
+hectopascal
+hectoradian
+hectosecond
+hectosiemens
+hectosievert
+hectosteradian
+hectotesla
+hectovolt
+hectowatt
+hectoweber
+henry
+henry per metre
+hertz
+hertz per second
+hertz per tesla
+hertz per volt
+high-power field
+hour
+imperial horsepower
+inch
+inch of mercury
+inch of water
+inch per minute
+inch per square second
+inch per year
+international fathom
+international foot
+international inch
+international mil
+international mile
+international nautical mile
+international unit
+international unit
+international yard
+joule
+joule per ampere metre
+joule per bit
+joule per cubic metre
+joule per cubic metre hertz
+joule per cubic metre kelvin
+joule per cubic metre nanometre
+joule per day
+joule per gram
+joule per hertz mole
+joule per hour
+joule per kelvin
+joule per kelvin difference
+joule per kilogram
+joule per kilogram kelvin
+joule per kilogram kelvin difference
+joule per metre
+joule per metre to the fourth power
+joule per minute
+joule per mole
+joule per mole kelvin
+joule per mole kelvin difference
+joule per nanometre
+joule per second
+joule per square centimetre
+joule per square metre
+joule per square metre hertz
+joule per square metre nanometre
+joule per tesla
+joule second
+joule square metre
+joule square metre per kilogram
+katal
+katal per cubic metre
+kayser
+kelvin
+kelvin difference
+kelvin difference per metre
+kelvin metre per watt
+kelvin metre per watt
+kelvin per pascal
+kelvin per watt
+kibi
+kibibit
+kibibyte
+kilo
+kiloampere
+kiloannum
+kilobar
+kilobecquerel
+kilobecquerel per kilogram
+kilobit
+kilobit per second
+kilobyte
+kilobyte per second
+kilocalorie
+kilocalorie
+kilocalorie
+kilocalorie per mole
+kilocandela
+kilocoulomb
+kilocoulomb per cubic metre
+kilocoulomb per square metre
+kilocurie
+kilodegree Celsius
+kiloelectronvolt
+kilofarad
+kilogram
+kilogram cubic metre per cubic second square ampere
+kilogram cubic metre per square second ampere
+kilogram metre per cubic second
+kilogram metre per cubic second ampere
+kilogram metre per cubic second kelvin
+kilogram metre per cubic second steradian
+kilogram metre per second
+kilogram metre per square second
+kilogram metre per square second ampere
+kilogram metre per square second square ampere
+kilogram per cubic centimetre
+kilogram per cubic decimetre
+kilogram per cubic metre
+kilogram per cubic second
+kilogram per cubic second kelvin
+kilogram per cubic second steradian
+kilogram per day
+kilogram per gigajoule
+kilogram per hectare
+kilogram per hour
+kilogram per joule
+kilogram per kilogram
+kilogram per kilometre
+kilogram per kilomole
+kilogram per litre
+kilogram per metre
+kilogram per metre cubic second
+kilogram per metre cubic second steradian
+kilogram per metre day
+kilogram per metre hour
+kilogram per metre minute
+kilogram per metre second
+kilogram per metre square second
+kilogram per metre square second kelvin
+kilogram per millimetre
+kilogram per minute
+kilogram per mole
+kilogram per quartic metre second
+kilogram per second
+kilogram per square centimetre
+kilogram per square metre
+kilogram per square metre second
+kilogram per square metre square second
+kilogram per square second
+kilogram per square second ampere
+kilogram square centimetre
+kilogram square metre
+kilogram square metre per cubic second
+kilogram square metre per cubic second ampere
+kilogram square metre per cubic second ampere kelvin
+kilogram square metre per cubic second kelvin
+kilogram square metre per cubic second square ampere
+kilogram square metre per cubic second steradian
+kilogram square metre per second
+kilogram square metre per square second
+kilogram square metre per square second ampere
+kilogram square metre per square second kelvin
+kilogram square metre per square second kelvin
+kilogram square metre per square second kelvin mole
+kilogram square metre per square second kelvin mole
+kilogram square metre per square second mole
+kilogram square metre per square second square ampere
+kilogram square millimetre
+kilogram-force
+kilogram-force
+kilogram-force metre
+kilogram-force per square metre
+kilogray
+kilohenry
+kilohertz
+kilojoule
+kilojoule per day
+kilojoule per gram
+kilojoule per hectogram
+kilojoule per hour
+kilojoule per kilogram
+kilojoule per kilogram kelvin difference
+kilojoule per minute
+kilojoule per mole
+kilojoule per second
+kilojoule per square metre
+kilokatal
+kilokelvin
+kilolitre
+kilolitre per hour
+kilolumen
+kilolux
+kilometre
+kilometre per hour
+kilometre per litre
+kilometre per second
+kilometre per second megaparsec
+kilometre per square kilometre
+kilometre per square second
+kilomole
+kilomole per cubic metre
+kilomole per kilogram
+kilonewton
+kilonewton metre
+kilonewton per square metre
+kiloohm
+kiloparsec
+kilopascal
+kiloradian
+kiloroentgen
+kilosecond
+kilosiemens
+kilosiemens per metre
+kilosievert
+kilosteradian
+kilotesla
+kilotonne
+kilotonne
+kilovolt
+kilovolt ampere
+kilovolt-ampere hour
+kilowatt
+kilowatt hour
+kilowatt hour per square metre
+kilowatt hour per square metre per day
+kilowatt hour per square metre per year
+kiloweber
+kiloweber per metre
+knot
+knot (UK)
+lambert
+light-year
+ligne
+line
+link
+link for Ramsden's chain
+liquid pint (US)
+liquid quart
+litre
+litre
+litre atmosphere
+litre per day
+litre per hour
+litre per kilogram
+litre per litre
+litre per minute
+litre per mole
+litre per month
+litre per second
+litre per year
+long hundredweight
+long ton
+low-power field
+lumen
+lumen hour
+lumen per square metre
+lumen per watt
+lumen second
+lux
+lux hour
+lux second
+magnetic constant
+maxwell
+mean Gregorian month
+mean Julian month
+mean calorie
+mebi
+mebibit
+mebibyte
+mega
+megaampere
+megabecquerel
+megabecquerel per kilogram
+megabit
+megabit per second
+megabyte
+megabyte per second
+megacandela
+megacoulomb
+megacoulomb per cubic metre
+megacoulomb per square metre
+megadegree Celsius
+megaelectronvolt
+megaerg
+megafarad
+megagram
+megagram per cubic metre
+megagram per litre
+megagray
+megahenry
+megahertz
+megahertz per tesla
+megajoule
+megajoule per cubic metre
+megajoule per kilogram
+megajoule per square metre
+megakatal
+megakelvin
+megalitre
+megalumen
+megalux
+megametre
+megametre per second
+megametre per square second
+megamole
+meganewton
+meganewton metre
+megaohm
+megaparsec
+megapascal
+megaradian
+megasecond
+megasiemens
+megasiemens per metre
+megasievert
+megasteradian
+megatesla
+megatonne
+megavolt
+megavolt ampere
+megawatt
+megawatt hour
+megaweber
+mesh
+metabolic equivalent
+metre
+metre kelvin
+metre of mercury
+metre of water
+metre per attosecond
+metre per centisecond
+metre per cubic second
+metre per day
+metre per decasecond
+metre per decisecond
+metre per exasecond
+metre per farad
+metre per femtosecond
+metre per gigasecond
+metre per hectosecond
+metre per hour
+metre per kilogram
+metre per kilosecond
+metre per megasecond
+metre per microsecond
+metre per millisecond
+metre per minute
+metre per nanosecond
+metre per petasecond
+metre per picosecond
+metre per radian
+metre per second
+metre per second to the fourth power
+metre per square attosecond
+metre per square centisecond
+metre per square decasecond
+metre per square decisecond
+metre per square exasecond
+metre per square femtosecond
+metre per square gigasecond
+metre per square hectosecond
+metre per square kilosecond
+metre per square megasecond
+metre per square microsecond
+metre per square millisecond
+metre per square nanosecond
+metre per square petasecond
+metre per square picosecond
+metre per square second
+metre per square terasecond
+metre per square yoctosecond
+metre per square yottasecond
+metre per square zeptosecond
+metre per square zettasecond
+metre per terasecond
+metre per yoctosecond
+metre per yottasecond
+metre per zeptosecond
+metre per zettasecond
+metre second
+metre square second kelvin per kilogram
+metre square second per kilogram
+metre to the fourth power
+metre to the power of six
+metric ounce
+mho
+micro
+microampere
+microarcsecond
+microarcsecond per year
+microbar
+microbecquerel
+microcandela
+microcoulomb
+microcoulomb per cubic metre
+microcoulomb per square metre
+microcurie
+microdegree Celsius
+microelectronvolt
+microfarad
+microgram
+microgram per cubic centimetre
+microgram per cubic metre
+microgram per decilitre
+microgram per hectogram
+microgram per joule
+microgram per kilogram
+microgram per litre
+microgram per square metre second
+microgray
+microgray per hour
+microgray per minute
+microgray per second
+microhenry
+microhenry per metre
+microhertz
+microjoule
+microkatal
+microkelvin
+microlitre
+microlitre per litre
+microlumen
+microlux
+micrometre
+micrometre per metre kelvin
+micrometre per second
+micrometre per square second
+micromho
+micromole
+micronewton
+micronewton metre
+microohm
+micropascal
+micropascal second
+microradian
+microsecond
+microsiemens
+microsiemens per centimetre
+microsiemens per metre
+microsievert
+microsievert per hour
+microsievert per minute
+microsievert per second
+microsievert per year
+microsteradian
+microtesla
+microvolt
+microwatt
+microwatt per square metre
+microwatt-hour
+microweber
+mile (US survey)
+mile per minute
+mile per second
+milli
+milliampere
+milliampere hour
+milliampere second
+milliarcsecond
+milliarcsecond per year
+millibar
+millibarn
+millibecquerel
+millicandela
+millicoulomb
+millicoulomb per cubic metre
+millicoulomb per kilogram
+millicoulomb per square metre
+millicurie
+millidegree Celsius
+millielectronvolt
+millifarad
+milligram
+milligram per cubic metre
+milligram per day
+milligram per decilitre
+milligram per gram
+milligram per hectogram
+milligram per kilogram
+milligram per kilometre
+milligram per litre
+milligram per metre
+milligram per minute
+milligram per second
+milligram per square centimetre
+milligram per square metre
+milligray
+milligray per hour
+milligray per minute
+milligray per second
+millihenry
+millihertz
+millijoule
+millikatal
+millikelvin
+millilitre
+millilitre per cubic metre
+millilitre per day
+millilitre per hour
+millilitre per kilogram
+millilitre per litre
+millilitre per minute
+millilitre per second
+millilumen
+millilux
+millimetre
+millimetre of mercury
+millimetre of water
+millimetre per day
+millimetre per hour
+millimetre per minute
+millimetre per second
+millimetre per square second
+millimetre per year
+millimole
+millimole per gram
+millimole per kilogram
+millimole per litre
+millinewton
+millinewton metre
+millinewton per metre
+milliohm
+millipascal
+millipascal second
+milliradian
+millirem
+milliroentgen
+millisecond
+millisiemens
+millisiemens per centimetre
+millisievert
+millisievert per hour
+millisievert per minute
+millisievert per second
+millisteradian
+millitesla
+millivolt
+millivolt per kelvin
+millivolt-ampere
+milliwatt
+milliwatt per square metre
+milliwatt-hour
+milliweber
+minim (UK)
+minim (US)
+minute
+molar equivalent
+mole
+mole per cubic decimetre
+mole per cubic metre
+mole per joule
+mole per kilogram
+mole per litre
+mole per second
+month
+nano
+nanoampere
+nanobecquerel
+nanocandela
+nanocoulomb
+nanodegree Celsius
+nanoelectronvolt
+nanofarad
+nanogram
+nanogram per decilitre
+nanogram per kilogram
+nanogram per litre
+nanogray
+nanogray per hour
+nanogray per minute
+nanogray per second
+nanohenry
+nanohenry per metre
+nanohertz
+nanojoule
+nanokatal
+nanokelvin
+nanolitre
+nanolumen
+nanolux
+nanometre
+nanometre per second
+nanometre per square second
+nanomole
+nanonewton
+nanoohm
+nanopascal
+nanoradian
+nanosecond
+nanosiemens
+nanosiemens per centimetre
+nanosiemens per metre
+nanosievert
+nanosievert per hour
+nanosievert per minute
+nanosievert per second
+nanosteradian
+nanotesla
+nanovolt
+nanowatt
+nanoweber
+nautical mile per hour
+neper
+neper per metre
+neper per second
+newton
+newton centimetre
+newton metre
+newton metre per kilogram
+newton metre per radian
+newton metre per second
+newton metre second
+newton per cubic metre
+newton per metre
+newton per millimetre
+newton per square ampere
+newton per square metre
+newton per square millimetre
+newton second
+newton second per metre
+newton square metre per square kilogram
+oersted
+ohm
+ohm centimeter
+ohm metre
+ohm square metre
+osmole
+ounce
+ounce per square foot
+ounce per square yard
+pace
+parsec
+part per billion
+parts per million
+parts per thousand
+parts per trillion
+pascal
+pascal per kelvin difference
+pascal second
+pascal second per cubic metre
+pascal second per metre
+peck
+peck
+pennyweight
+pennyweight
+per 100 electronvolt
+per cubic centimetre minute
+per cubic metre second
+per kilogram second
+per microlitre
+per second metre
+per second steradian
+per square metre second
+per square metre second steradian
+per tesla second
+percent
+peripheral vascular resistance unit
+permittivity of vacuum
+peta
+petaampere
+petabecquerel
+petabit
+petabyte
+petabyte per second
+petacandela
+petacoulomb
+petadegree Celsius
+petaelectronvolt
+petafarad
+petagram
+petagram per litre
+petagray
+petahenry
+petahertz
+petajoule
+petakatal
+petakelvin
+petalitre
+petalumen
+petalux
+petametre
+petametre per second
+petametre per square second
+petamole
+petanewton
+petaohm
+petapascal
+petaradian
+petasecond
+petasiemens
+petasievert
+petasteradian
+petatesla
+petavolt
+petawatt
+petawatt hour
+petaweber
+phot
+pi
+pica
+pico
+picoampere
+picobecquerel
+picocandela
+picocoulomb
+picodegree Celsius
+picoelectronvolt
+picofarad
+picofarad per metre
+picogram
+picogram per decilitre
+picogram per litre
+picogray
+picohenry
+picohertz
+picojoule
+picokatal
+picokelvin
+picolitre
+picolumen
+picolux
+picometre
+picometre per second
+picometre per square second
+picomole
+piconewton
+picoohm
+picopascal
+picoradian
+picosecond
+picosiemens
+picosiemens per metre
+picosievert
+picosteradian
+picotesla
+picovolt
+picowatt
+picowatt per square metre
+picoweber
+pint
+pint
+plaque-forming unit
+point
+poise
+pound
+pound per cubic foot
+pound per cubic inch
+pound per cubic yard
+pound per pound
+pound per square inch
+pound per square yard
+pound-force
+power of 10
+power of 10
+prism dioptre
+protein nitrogen unit
+proton mass
+quart
+quarter of an hour
+quartic metre per square second
+rad
+radian
+radian per metre
+radian per second
+radian per square second
+radian square metre per kilogram
+radian square metre per mole
+reciprocal angstrom
+reciprocal centimetre
+reciprocal cubic centimetre
+reciprocal cubic metre
+reciprocal day
+reciprocal decimetre
+reciprocal electronvolt cubic metre
+reciprocal farad
+reciprocal henry
+reciprocal hour
+reciprocal joule cubic metre
+reciprocal kelvin
+reciprocal kelvin difference
+reciprocal kilometre
+reciprocal megaannum
+reciprocal megakelvin
+reciprocal metre
+reciprocal millimetre
+reciprocal minute
+reciprocal mole
+reciprocal month
+reciprocal pascal
+reciprocal pascal second
+reciprocal second
+reciprocal square inch
+reciprocal square metre
+reciprocal square second
+reciprocal steradian
+reciprocal week
+reciprocal year
+rem per second
+rod
+roentgen
+roentgen per second
+second
+second per cubic metre
+second to the fourth power ampere squared per kilogram metre squared
+second to the fourth power square ampere per kilogram cubic metre
+section
+short hundredweight
+short ton
+short ton
+siemens
+siemens per centimetre
+siemens per metre
+siemens square metre per mole
+sievert
+sievert per hour
+sievert per minute
+sievert per second
+small calorie
+small calorie
+smoot
+speed of light in vacuum
+sphere
+square arcsecond
+square attometre
+square centimetre
+square centimetre per erg
+square centimetre per gram
+square centimetre per second
+square centimetre per steradian erg
+square decametre
+square decimetre
+square degree
+square exametre
+square femtometre
+square foot
+square foot per hour
+square foot per second
+square gigametre
+square hectometre
+square inch
+square inch per second
+square kilogram per square metre cubic second
+square kilogram quartic metre per sextic second square ampere square kelvin
+square kilometre
+square litre bar per square mole
+square megametre
+square metre
+square metre kelvin per watt
+square metre per cubic second
+square metre per joule
+square metre per kilogram
+square metre per mole
+square metre per second
+square metre per square second
+square metre per square second kelvin
+square metre per square second kelvin
+square metre per steradian
+square metre per steradian joule
+square metre per volt second
+square micrometre
+square micropascal second
+square mile
+square millimetre
+square millimetre per second
+square nanometre
+square pascal second
+square petametre
+square picometre
+square rod
+square second ampere per kilogram
+square second per kilogram
+square second per kilogram quintic metre
+square second square ampere per kilogram square metre
+square terametre
+square tesla metre per henry
+square volt per square kelvin
+square yard
+square yoctometre
+square yottametre
+square zeptometre
+square zettametre
+standard acceleration of free fall
+standard atmosphere
+steradian
+stere
+stilb
+stokes
+stone
+survey township
+svedberg
+synodic month
+tablespoon (US)
+tablespoon (metric)
+teaspoon
+teaspoon (US)
+tebi
+tebibyte
+technical atmosphere
+tera
+teraampere
+terabecquerel
+terabit
+terabit per second
+terabyte
+terabyte per second
+teracandela
+teracoulomb
+teradegree Celsius
+teraelectronvolt
+terafarad
+teragram
+teragram per litre
+teragray
+terahenry
+terahertz
+terajoule
+terakatal
+terakelvin
+teralitre
+teralumen
+teralux
+terametre
+terametre per second
+terametre per square second
+teramole
+teranewton
+teraohm
+terapascal
+teraradian
+terasecond
+terasiemens
+terasievert
+terasteradian
+teratesla
+teravolt
+terawatt
+terawatt hour
+teraweber
+tesla
+tex
+tonne
+tonne per cubic metre
+tonne per cubic metre
+tonne per hectare
+township
+tropical year
+troy ounce
+troy pound
+volt
+volt ampere
+volt metre
+volt per ampere
+volt per kelvin
+volt per metre
+volt second
+volt-ampere hour
+volt-ampere second
+watt
+watt hour
+watt hour per litre
+watt hour per square metre
+watt per cubic metre
+watt per hertz
+watt per kelvin
+watt per kilogram
+watt per metre
+watt per metre kelvin
+watt per nanometre
+watt per square centimetre
+watt per square metre
+watt per square metre hertz
+watt per square metre kelvin
+watt per square metre kelvin to the fourth power
+watt per square metre nanometre
+watt per square metre steradian
+watt per square metre steradian
+watt per steradian
+watt per steradian hertz
+watt per steradian metre
+watt per steradian nanometre
+watt per steradian square metre hertz
+watt per steradian square metre nanometre
+watt second
+watt square metre
+watt year per square metre kilogram
+watt-hour per kilogram
+weber
+weber metre
+weber per metre
+weber per millimetre
+weber per square metre
+week
+white blood cell count
+wine gallon
+yard per hour
+yard per minute
+yard per second
+yard per square second
+year
+yocto
+yoctoampere
+yoctobecquerel
+yoctocandela
+yoctocoulomb
+yoctodegree Celsius
+yoctofarad
+yoctogram
+yoctogram per litre
+yoctogray
+yoctohenry
+yoctohertz
+yoctojoule
+yoctokatal
+yoctokelvin
+yoctolitre
+yoctolumen
+yoctolux
+yoctometre
+yoctometre per second
+yoctometre per square second
+yoctomole
+yoctonewton
+yoctoohm
+yoctopascal
+yoctoradian
+yoctosecond
+yoctosiemens
+yoctosievert
+yoctosteradian
+yoctotesla
+yoctovolt
+yoctowatt
+yoctoweber
+yotta
+yottaampere
+yottabecquerel
+yottabit
+yottabit per second
+yottabyte
+yottabyte per second
+yottacandela
+yottacoulomb
+yottadegree Celsius
+yottaelectronvolt
+yottafarad
+yottagram
+yottagram per litre
+yottagray
+yottahenry
+yottahertz
+yottajoule
+yottakatal
+yottakelvin
+yottalitre
+yottalumen
+yottalux
+yottametre
+yottametre per second
+yottametre per square second
+yottamole
+yottanewton
+yottaohm
+yottapascal
+yottaradian
+yottasecond
+yottasiemens
+yottasievert
+yottasteradian
+yottatesla
+yottavolt
+yottawatt
+yottaweber
+zepto
+zeptoampere
+zeptobecquerel
+zeptocandela
+zeptocoulomb
+zeptodegree Celsius
+zeptofarad
+zeptogram
+zeptogram per litre
+zeptogray
+zeptohenry
+zeptohertz
+zeptojoule
+zeptokatal
+zeptokelvin
+zeptolitre
+zeptolumen
+zeptolux
+zeptometre
+zeptometre per second
+zeptometre per square second
+zeptomole
+zeptonewton
+zeptoohm
+zeptopascal
+zeptoradian
+zeptosecond
+zeptosiemens
+zeptosievert
+zeptosteradian
+zeptotesla
+zeptovolt
+zeptowatt
+zeptoweber
+zetta
+zettaampere
+zettabecquerel
+zettabit
+zettabit per second
+zettabyte
+zettabyte per second
+zettacandela
+zettacoulomb
+zettadegree Celsius
+zettaelectronvolt
+zettafarad
+zettagram
+zettagram per litre
+zettagray
+zettahenry
+zettahertz
+zettajoule
+zettakatal
+zettakelvin
+zettalitre
+zettalumen
+zettalux
+zettametre
+zettametre per second
+zettametre per square second
+zettamole
+zettanewton
+zettaohm
+zettapascal
+zettaradian
+zettasecond
+zettasiemens
+zettasievert
+zettasteradian
+zettatesla
+zettavolt
+zettawatt
+zettaweber
+ångström

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 from typing import List, Mapping, Any
 import logging
 import requests
+from .resources import get_resource_path
 
 __all__ = [
     "get_unit_terms",
@@ -61,3 +62,11 @@ def get_unit_terms():
             xrefs,
         ))
     return rv
+
+
+def update_unit_names_resource():
+    """Update a resource file with all unit names."""
+    path = get_resource_path("unit_names.tsv")
+    unit_names = sorted([unit_row[1] for unit_row in get_unit_terms()])
+    with open(path, "w") as file:
+        file.write("\n".join(unit_names))

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -4,6 +4,22 @@
   "title": "MIRA Metamodel Template Schema",
   "description": "MIRA metamodel templates give a high-level abstraction of modeling appropriate for many domains.",
   "definitions": {
+    "Unit": {
+      "title": "Unit",
+      "description": "A unit of measurement.",
+      "type": "object",
+      "properties": {
+        "expression": {
+          "title": "Expression",
+          "description": "The expression for the unit.",
+          "type": "string",
+          "example": "2*x"
+        }
+      },
+      "required": [
+        "expression"
+      ]
+    },
     "Concept": {
       "title": "Concept",
       "description": "A concept is specified by its identifier(s), name, and - optionally -\nits context.",
@@ -34,6 +50,15 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "units": {
+          "title": "Units",
+          "description": "The units of the concept.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Unit"
+            }
+          ]
         }
       },
       "required": [
@@ -466,6 +491,15 @@
             "type": "string"
           }
         },
+        "units": {
+          "title": "Units",
+          "description": "The units of the concept.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Unit"
+            }
+          ]
+        },
         "value": {
           "title": "Value",
           "description": "Value of the parameter.",
@@ -534,6 +568,15 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "units": {
+          "title": "Units",
+          "description": "The units of the concept.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Unit"
+            }
+          ]
         },
         "expression": {
           "title": "Expression",

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -751,6 +751,15 @@
           "description": "The symbol of the time variable in the model.",
           "default": "t",
           "type": "string"
+        },
+        "units": {
+          "title": "Units",
+          "description": "The units of the time variable.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Unit"
+            }
+          ]
         }
       }
     },

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -74,6 +74,7 @@ class Time(BaseModel):
         default="t", description="The symbol of the time variable in the model."
     )
 
+
 class Author(BaseModel):
     """A metadata model for an author."""
 

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -73,6 +73,9 @@ class Time(BaseModel):
     name: str = Field(
         default="t", description="The symbol of the time variable in the model."
     )
+    units: Optional[Unit] = Field(
+        description="The units of the time variable."
+    )
 
 
 class Author(BaseModel):

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -20,10 +20,12 @@ __all__ = [
     "SpecifiedTemplate",
     "SympyExprStr",
     "templates_equal",
-    "context_refinement"
+    "context_refinement",
+    "UNIT_SYMBOLS"
 ]
 
 import logging
+import os
 import sys
 from collections import ChainMap
 from itertools import product
@@ -159,6 +161,7 @@ class Concept(BaseModel):
             name=name,
             identifiers=self.identifiers,
             context=dict(ChainMap(context, self.context)),
+            units=self.units,
         )
         concept._base_name = self._base_name
         return concept
@@ -1074,3 +1077,17 @@ def has_controller(template: Template, controller: Concept) -> bool:
         return template.controller == controller
     else:
         raise NotImplementedError
+
+
+def load_units():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        os.pardir, 'dkg', 'resources', 'unit_names.tsv')
+    with open(path, 'r') as fh:
+        units = {}
+        for line in fh.readlines():
+            symbol = line.strip()
+            units[symbol] = sympy.Symbol(symbol)
+    return units
+
+
+UNIT_SYMBOLS = load_units()

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -29,11 +29,13 @@ class Variable:
 
 
 class ModelParameter:
-    def __init__(self, key, value=None, distribution=None, placeholder=None):
+    def __init__(self, key, value=None, distribution=None, placeholder=None,
+                 concept=None):
         self.key = key
         self.value = value
         self.distribution = distribution
         self.placeholder = placeholder
+        self.concept = concept
 
 
 class ModelObservable:
@@ -112,12 +114,12 @@ class Model:
         if rate_parameters:
             model_parameters = []
             for key in rate_parameters:
-                value = self.template_model.parameters[key].value
-                distribution = self.template_model.parameters[key].distribution
+                param = self.template_model.parameters[key]
                 model_parameters.append(
                     self.get_create_parameter(
-                        ModelParameter(key, value, distribution,
-                                       placeholder=False)))
+                        ModelParameter(key, param.value, param.distribution,
+                                       placeholder=False,
+                                       concept=param.concept)))
             if len(model_parameters) == 1:
                 return model_parameters[0]
 

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -119,7 +119,7 @@ class Model:
                     self.get_create_parameter(
                         ModelParameter(key, param.value, param.distribution,
                                        placeholder=False,
-                                       concept=param.concept)))
+                                       concept=param)))
             if len(model_parameters) == 1:
                 return model_parameters[0]
 

--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -70,6 +70,13 @@ class AskeNetPetriNetModel:
                     'modifiers': var.concept.context,
                 },
             }
+            if var.concept.units:
+                states_dict['units'] = {
+                    'expression': str(var.concept.units.expression),
+                    'expression_mathml': expression_to_mathml(
+                        var.concept.units.expression),
+                }
+
             self.states.append(states_dict)
             # 'initial' object structure
             # {
@@ -166,6 +173,12 @@ class AskeNetPetriNetModel:
                 param_dict['distribution'] = {
                     'type': param.distribution.type,
                     'parameters': param.distribution.parameters,
+                }
+            if param.concept and param.concept.units:
+                param_dict['units'] = {
+                    'expression': str(param.concept.units.expression),
+                    'expression_mathml': expression_to_mathml(
+                        param.concept.units.expression),
                 }
             self.parameters.append(param_dict)
 

--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -105,9 +105,16 @@ class AskeNetPetriNetModel:
             }
             self.observables.append(obs_data)
 
-        self.time = {
-            'id': model.template_model.time.name,
-        } if model.template_model.time else None
+        if model.template_model.time:
+            self.time = {'id': model.template_model.time.name}
+            if model.template_model.time.units:
+                self.time['units'] = {
+                    'expression': str(model.template_model.time.units.expression),
+                    'expression_mathml': expression_to_mathml(
+                        model.template_model.time.units.expression),
+                }
+        else:
+            self.time = None
 
         # Transition structure
         # {
@@ -292,10 +299,16 @@ class Distribution(BaseModel):
     parameters: Dict
 
 
+class Units(BaseModel):
+    expression: str
+    expression_mathml: str
+
+
 class State(BaseModel):
     id: str
     name: Optional[str] = None
     grounding: Optional[Dict]
+    units: Optional[Units] = None
 
 
 class Transition(BaseModel):
@@ -312,6 +325,7 @@ class Parameter(BaseModel):
     value: Optional[float] = None
     grounding: Optional[Dict]
     distribution: Optional[Distribution] = None
+    units: Optional[Units] = None
 
     @classmethod
     def from_dict(cls, d):
@@ -322,6 +336,7 @@ class Parameter(BaseModel):
 
 class Time(BaseModel):
     id: str
+    units: Optional[Units] = None
 
 
 class Observable(BaseModel):

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -222,9 +222,18 @@ def state_to_concept(state):
     grounding = state.get('grounding', {})
     identifiers = grounding.get('identifiers', {})
     context = grounding.get('modifiers', {})
+    units = state.get('units')
+    units_obj = None
+    if units:
+        # TODO: if sympy expression isn't given, parse MathML
+        expr = units.get('expression')
+        if expr:
+            # TODO: get list of all units as symbols
+            units_obj = sympy.parse_expr(expr)
     return Concept(name=name,
                    identifiers=identifiers,
-                   context=context)
+                   context=context,
+                   units=units_obj)
 
 
 def parameter_to_mira(parameter):

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -138,7 +138,13 @@ def template_model_from_askenet_json(model_json) -> TemplateModel:
     # We get the time variable from the semantics
     time = ode_semantics.get("time")
     if time:
-        model_time = Time(name=time['id'])
+        time_units = time.get('units')
+        time_units_obj = None
+        if time_units:
+            time_expr = time_units.get('expression')
+            time_units_obj = sympy.parse_expr(time_expr,
+                                              local_dict=UNIT_SYMBOLS)
+        model_time = Time(name=time['id'], units=time_units_obj)
     else:
         model_time = None
 
@@ -228,8 +234,7 @@ def state_to_concept(state):
         # TODO: if sympy expression isn't given, parse MathML
         expr = units.get('expression')
         if expr:
-            # TODO: get list of all units as symbols
-            units_obj = sympy.parse_expr(expr)
+            units_obj = sympy.parse_expr(expr, local_dict=UNIT_SYMBOLS)
     return Concept(name=name,
                    identifiers=identifiers,
                    context=context,

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -142,8 +142,9 @@ def template_model_from_askenet_json(model_json) -> TemplateModel:
         time_units_obj = None
         if time_units:
             time_expr = time_units.get('expression')
-            time_units_obj = sympy.parse_expr(time_expr,
-                                              local_dict=UNIT_SYMBOLS)
+            time_units_expr = sympy.parse_expr(time_expr,
+                                               local_dict=UNIT_SYMBOLS)
+            time_units_obj = Unit(expression=time_units_expr)
         model_time = Time(name=time['id'], units=time_units_obj)
     else:
         model_time = None
@@ -234,7 +235,8 @@ def state_to_concept(state):
         # TODO: if sympy expression isn't given, parse MathML
         expr = units.get('expression')
         if expr:
-            units_obj = sympy.parse_expr(expr, local_dict=UNIT_SYMBOLS)
+            units_expr = sympy.parse_expr(expr, local_dict=UNIT_SYMBOLS)
+            units_obj = Unit(expression=units_expr)
     return Concept(name=name,
                    identifiers=identifiers,
                    context=context,


### PR DESCRIPTION
This PR implements units associated with Concepts, Parameters and Time for TemplateModels. It also implements input and output processing towards the shared model representation to pick up and generate appropriate unit representations.

@cthoyt in this process I noticed multiple issues with units in the DKG. One issue is that Sympy isn't able to handle symbols with spaces making it impossible to represent any units that have space in their names as expression objects. We would ideally have a name for units in the DKG that are human readable but also parseable e.g., instead of "metric ounce" we would have something like "metric_ounce". I noticed a couple of other weird properties of Wikidata units:
- They use British spelling e.g., "metre" instead of "meter" - in fact we currently aren't able to ground "meter" correctly with the DKG
- There is an entry with name "1" to represent something dimensionless - this could create parsing issues.
- Some units have parentheses in them again causing parsing problems
- There are three entries with the identical "dalton" name
- Some unit expressions e.g., "cubic second kelvin per kilogram" are defined as atomic concepts. These may be redundant with the same unit defined via an expression over simpler unit concepts and this will be difficult to detect automatically. It's possible we should remove any non-atomic units from the DKG.