### PR TITLE
Improve units in the DKG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ docs/_site
 docker/edges.tsv.gz
 docker/nodes.tsv.gz
 mira/dkg/resources/ncit.obo
+docker/epi.sh

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -486,14 +486,14 @@ def construct(
             writer.writerows(uat_edges)
 
     click.secho("Units", fg="green", bold=True)
-    for wikidata_id, label, description, xrefs in tqdm(get_unit_terms(), unit="unit", desc="Units"):
+    for wikidata_id, label, description, synonyms, xrefs in tqdm(get_unit_terms(), unit="unit", desc="Units"):
         curie = f"wikidata:{wikidata_id}"
         node_sources[curie].add("wikidata")
         nodes[curie] = NodeInfo(
             curie=curie,
             prefix="wikidata;unit",
             label=label,
-            synonyms="",
+            synonyms=";".join(synonyms),
             deprecated="false",
             type="class",
             definition=description,

--- a/mira/dkg/resources/unit_names.tsv
+++ b/mira/dkg/resources/unit_names.tsv
@@ -1,1016 +1,1016 @@
-1
-1593_english_statute_mile
-acre
-ampere
-ampere_hour
-ampere_minute
-ampere_second
-ampere_second_metre
-apothecaries_drachm
-apothecaries_ounce
-apothecaries_pound
-apothecaries_scruple
-arbitrary_unit
-arcminute
-arcsecond
-are
-astronomical_unit
-atto
-attoampere
-attobecquerel
-attocandela
-attocoulomb
-attodegree_celsius
-attoelectronvolt
-attofarad
-attogram
-attogray
-attohenry
-attohertz
-attojoule
-attokatal
-attokelvin
-attoliter
-attolumen
-attolux
-attometer
-attomole
-attonewton
-attoohm
-attoparsec
-attopascal
-attoradian
-attosecond
-attosiemens
-attosievert
-attosteradian
-attotesla
-attovolt
-attowatt
-attoweber
-bar
-barn
-baud
-becquerel
-bel
-bel_10_nanovolt
-bel_kilowatt
-bel_microvolt
-bel_millivolt
-bel_sound_pressure_level
-bel_volt
-bel_watt
-bethesda_unit
-biot
-bit
-board_foot
-bodansky_unit
-boltzmann_constant
-british_imperial_fathom
-british_imperial_foot
-british_imperial_inch
-british_imperial_nautical_mile
-british_imperial_rod
-british_imperial_yard
-byte
-candela
-candela_metre
-candela_steradian
-candela_steradian_second
-carat
-carat
-centi
-centiampere
-centibecquerel
-centicandela
-centicoulomb
-centidegree_celsius
-centielectronvolt
-centifarad
-centigram
-centigray
-centihenry
-centihertz
-centijoule
-centikatal
-centikelvin
-centiliter
-centilumen
-centilux
-centimeter
-centimetre_of_mercury
-centimetre_of_water
-centimole
-centinewton
-centinewton_metre
-centiohm
-centipascal
-centipoise
-centiradian
-centisecond
-centisiemens
-centisievert
-centisteradian
-centistokes
-centitesla
-centivolt
-centiwatt
-centiweber
-chain
-cicero
-circle
-circular_mil
-cord
-coulomb
-coulomb_meter
-curie
-dalton
-day
-deca
-decaampere
-decabecquerel
-decacandela
-decacoulomb
-decadegree_celsius
-decaelectronvolt
-decafarad
-decagram
-decagray
-decahenry
-decahertz
-decajoule
-decakatal
-decakelvin
-decaliter
-decalumen
-decalux
-decameter
-decamole
-decanewton
-decaohm
-decapascal
-decaradian
-decare
-decasecond
-decasiemens
-decasievert
-decasteradian
-decatesla
-decavolt
-decawatt
-decaweber
-deci
-deciampere
-deciare
-decibar
-decibecquerel
-decibel
-decicandela
-decicoulomb
-decidegree_celsius
-decielectronvolt
-decifarad
-decigram
-decigray
-decihenry
-decihertz
-decijoule
-decikatal
-decikelvin
-deciliter
-decilumen
-decilux
-decimeter
-decimole
-decinewton
-decinewton_meter
-deciohm
-decipascal
-deciradian
-decisecond
-decisiemens
-decisievert
-decisteradian
-decitesla
-decitonne
-decivolt
-deciwatt
-deciweber
-degree
-degree_celsius
-degree_celsius_difference
-degree_fahrenheit
-degree_rankine
-degree_réaumur
-denier
-didot_point
-dimensionless_unit
-dioptre
-drop
-dry_quart
-dye_unit
-dyne
-e_cm
-ehrlich_unit
-electron_mass
-electronvolt
-electronvolt_second
-elementary_charge
-elisa_unit
-erg
-exa
-exaampere
-exabecquerel
-exabit
-exabyte
-exacandela
-exacoulomb
-exadegree_celsius
-exaelectronvolt
-exafarad
-exagram
-exagray
-exahenry
-exahertz
-exajoule
-exakatal
-exakelvin
-exaliter
-exalumen
-exalux
-exameter
-examole
-exanewton
-exaohm
-exapascal
-exaradian
-exasecond
-exasiemens
-exasievert
-exasteradian
-exatesla
-exavolt
-exawatt
-exaweber
-farad
-fathom
-femto
-femtoampere
-femtobecquerel
-femtocandela
-femtocoulomb
-femtodegree_celsius
-femtoelectronvolt
-femtofarad
-femtogram
-femtogray
-femtohenry
-femtohertz
-femtojoule
-femtokatal
-femtokelvin
-femtoliter
-femtolumen
-femtolux
-femtometer
-femtomole
-femtonewton
-femtoohm
-femtopascal
-femtoradian
-femtosecond
-femtosiemens
-femtosievert
-femtosteradian
-femtotesla
-femtovolt
-femtowatt
-femtoweber
-fluid_ounce
-french_gauge
-gal
-gauss
-gibi
-gibibit
-gibibyte
-giga
-gigaampere
-gigabecquerel
-gigabit
-gigabyte
-gigacandela
-gigacoulomb
-gigadegree_celsius
-gigaelectronvolt
-gigafarad
-gigagram
-gigagray
-gigahenry
-gigahertz
-gigajoule
-gigakatal
-gigakelvin
-gigaliter
-gigalumen
-gigalux
-gigameter
-gigamole
-giganewton
-gigaohm
-gigaparsec
-gigapascal
-gigaradian
-gigasecond
-gigasiemens
-gigasievert
-gigasteradian
-gigatesla
-gigatonne
-gigavolt
-gigawatt
-gigawatt_hour
-gigaweber
-gilbert
-gill
-gill
-grade
-gradian
-grain
-gram
-gram_force
-gram_percent
-gravitational_constant
-gray
-gregorian_year
-hand
-hectare
-hecto
-hectoampere
-hectobar
-hectobecquerel
-hectocandela
-hectocoulomb
-hectodegree_celsius
-hectoelectronvolt
-hectofarad
-hectogram
-hectogray
-hectohenry
-hectohertz
-hectojoule
-hectokatal
-hectokelvin
-hectoliter
-hectolumen
-hectolux
-hectometer
-hectomole
-hectonewton
-hectoohm
-hectopascal
-hectoradian
-hectosecond
-hectosiemens
-hectosievert
-hectosteradian
-hectotesla
-hectovolt
-hectowatt
-hectoweber
-henry
-hertz
-high_power_field
-hounsfield_unit
-hour
-imperial_horsepower
-inch
-inch_of_mercury
-inch_of_water
-international_fathom
-international_foot
-international_inch
-international_mil
-international_mile
-international_nautical_mile
-international_unit
-international_yard
-joule
-joule_second
-julian_year
-katal
-kayser
-kelvin
-kelvin_difference
-kibi
-kibibit
-kibibyte
-kilo
-kiloampere
-kiloannum
-kilobar
-kilobecquerel
-kilobit
-kilobyte
-kilocalorie
-kilocandela
-kilocoulomb
-kilocurie
-kilodegree_celsius
-kiloelectronvolt
-kilofarad
-kilogram
-kilogram_force
-kilogram_force_meter
-kilogray
-kilohenry
-kilohertz
-kilojoule
-kilokatal
-kilokelvin
-kiloliter
-kilolumen
-kilolux
-kilometer
-kilomole
-kilonewton
-kilonewton_meter
-kiloohm
-kiloparsec
-kilopascal
-kiloradian
-kiloroentgen
-kilosecond
-kilosiemens
-kilosievert
-kilosteradian
-kilotesla
-kilotonne
-kilovolt
-kilovolt_ampere
-kilovolt_ampere_hour
-kilowatt
-kilowatt_hour
-kiloweber
-knot
-kunkel_unit
-lambert
-light_year
-ligne
-line
-link
-link_for_ramsdens_chain
-liquid_quart
-liter
-liter_atmosphere
-long_hundredweight
-long_ton
-low_power_field
-lumen
-lumen_hour
-lumen_second
-lux
-lux_hour
-lux_second
-mac_lagan_unit
-magnetic_constant
-maxwell
-mean_calorie
-mean_gregorian_month
-mean_julian_month
-mebi
-mebibit
-mebibyte
-mega
-megaampere
-megabecquerel
-megabit
-megabyte
-megacandela
-megacoulomb
-megadegree_celsius
-megaelectronvolt
-megaerg
-megafarad
-megagram
-megagray
-megahenry
-megahertz
-megajoule
-megakatal
-megakelvin
-megaliter
-megalumen
-megalux
-megameter
-megamole
-meganewton
-meganewton_meter
-megaohm
-megaparsec
-megapascal
-megaradian
-megasecond
-megasiemens
-megasievert
-megasteradian
-megatesla
-megatonne
-megavolt
-megavolt_ampere
-megawatt
-megawatt_hour
-megaweber
-mesh
-metabolic_equivalent
-meter
-metre_kelvin
-metre_of_mercury
-metre_of_water
-metre_second
-metre_to_the_fourth_power
-metre_to_the_power_of_six
-metric_ounce
-metric_ton
-mho
-micro
-microampere
-microarcsecond
-microbar
-microbecquerel
-microcandela
-microcoulomb
-microcurie
-microdegree_celsius
-microelectronvolt
-microfarad
-microgram
-microgray
-microhenry
-microhertz
-microjoule
-microkatal
-microkelvin
-microliter
-microlumen
-microlux
-micrometer
-micromho
-micromole
-micronewton
-micronewton_meter
-microohm
-micropascal
-micropascal_second
-microradian
-microsecond
-microsiemens
-microsievert
-microsteradian
-microtesla
-microvolt
-microwatt
-microwatt_hour
-microweber
-milli
-milliampere
-milliampere_hour
-milliampere_second
-milliarcsecond
-millibar
-millibarn
-millibecquerel
-millicandela
-millicoulomb
-millicurie
-millidegree_celsius
-millielectronvolt
-millifarad
-milligram
-milligray
-millihenry
-millihertz
-millijoule
-millikatal
-millikelvin
-milliliter
-millilumen
-millilux
-millimeter
-millimeter_of_mercury
-millimetre_of_water
-millimole
-millinewton
-millinewton_meter
-milliohm
-millipascal
-millipascal_second
-milliradian
-millirem
-milliroentgen
-millisecond
-millisiemens
-millisievert
-millisteradian
-millitesla
-millivolt
-millivolt_ampere
-milliwatt
-milliwatt_hour
-milliweber
-minute
-molar_equivalent
-mole
-month
-nano
-nanoampere
-nanobecquerel
-nanocandela
-nanocoulomb
-nanodegree_celsius
-nanoelectronvolt
-nanofarad
-nanogram
-nanogray
-nanohenry
-nanohertz
-nanojoule
-nanokatal
-nanokelvin
-nanoliter
-nanolumen
-nanolux
-nanometer
-nanomole
-nanonewton
-nanoohm
-nanopascal
-nanoradian
-nanosecond
-nanosiemens
-nanosievert
-nanosteradian
-nanotesla
-nanovolt
-nanowatt
-nanoweber
-neper
-newton
-newton_centimetre
-newton_meter
-newton_metre_second
-newton_second
-oersted
-ohm
-ohm_centimeter
-ohm_meter
-osmole
-ounce
-pace
-paris_foot
-paris_inch
-parsec
-pascal
-pascal_second
-peck
-peck
-pennyweight
-percent
-peripheral_vascular_resistance_unit
-permittivity_of_vacuum
-peta
-petaampere
-petabecquerel
-petabit
-petabyte
-petacandela
-petacoulomb
-petadegree_celsius
-petaelectronvolt
-petafarad
-petagram
-petagray
-petahenry
-petahertz
-petajoule
-petakatal
-petakelvin
-petaliter
-petalumen
-petalux
-petameter
-petamole
-petanewton
-petaohm
-petapascal
-petaradian
-petasecond
-petasiemens
-petasievert
-petasteradian
-petatesla
-petavolt
-petawatt
-petawatt_hour
-petaweber
-phot
-pi
-pica
-pico
-picoampere
-picobecquerel
-picocandela
-picocoulomb
-picodegree_celsius
-picoelectronvolt
-picofarad
-picogram
-picogray
-picohenry
-picohertz
-picojoule
-picokatal
-picokelvin
-picoliter
-picolumen
-picolux
-picometer
-picomole
-piconewton
-picoohm
-picopascal
-picoradian
-picosecond
-picosiemens
-picosievert
-picosteradian
-picotesla
-picovolt
-picowatt
-picoweber
-pint
-planck_constant
-plaque_forming_unit
-point
-poise
-pound
-pound_force
-power_of_10
-printers_pica
-printers_point
-prism_dioptre
-protein_nitrogen_unit
-proton_mass
-quart
-quarter_of_an_hour
-rad
-radian
-ramsden_chain
-reciprocal_angstrom
-reciprocal_centimeter
-reciprocal_day
-reciprocal_decimeter
-reciprocal_farad
-reciprocal_henry
-reciprocal_hour
-reciprocal_kelvin
-reciprocal_kelvin_difference
-reciprocal_kilometer
-reciprocal_megaannum
-reciprocal_megakelvin
-reciprocal_meter
-reciprocal_millimeter
-reciprocal_minute
-reciprocal_mole
-reciprocal_month
-reciprocal_pascal
-reciprocal_pascal_second
-reciprocal_second
-reciprocal_steradian
-reciprocal_week
-reciprocal_year
-rod
-roentgen
-roentgen_equivalent_man
-second
-section
-short_hundredweight
-short_ton
-siemens
-sievert
-small_calorie
-smoot
-somogyi_unit
-speed_of_light_in_vacuum
-sphere
-standard_acceleration_of_free_fall
-standard_atmosphere
-steradian
-stere
-stilb
-stokes
-stone
-survey_township
-svedberg
-synodic_month
-teaspoon
-tebi
-tebibyte
-technical_atmosphere
-tera
-teraampere
-terabecquerel
-terabit
-terabyte
-teracandela
-teracoulomb
-teradegree_celsius
-teraelectronvolt
-terafarad
-teragram
-teragray
-terahenry
-terahertz
-terajoule
-terakatal
-terakelvin
-teraliter
-teralumen
-teralux
-terameter
-teramole
-teranewton
-teraohm
-terapascal
-teraradian
-terasecond
-terasiemens
-terasievert
-terasteradian
-teratesla
-teravolt
-terawatt
-terawatt_hour
-teraweber
-tesla
-tex
-todd_unit
-township
-tropical_year
-troy_ounce
-troy_pound
-united_states_pharmacopeia_unit
-united_states_survey_link
-us_customary_cup
-us_legal_cup
-us_survey_acre
-us_survey_furlong
-us_survey_mil
-us_survey_yards
-volt
-volt_ampere
-volt_ampere_hour
-volt_ampere_second
-volt_meter
-volt_second
-watt
-watt_hour
-watt_second
-weber
-weber_meter
-week
-white_blood_cell_count
-winchester_gallon
-wine_gallon
-wood_unit
-year
-yocto
-yoctoampere
-yoctobecquerel
-yoctocandela
-yoctocoulomb
-yoctodegree_celsius
-yoctofarad
-yoctogram
-yoctogray
-yoctohenry
-yoctohertz
-yoctojoule
-yoctokatal
-yoctokelvin
-yoctoliter
-yoctolumen
-yoctolux
-yoctometer
-yoctomole
-yoctonewton
-yoctoohm
-yoctopascal
-yoctoradian
-yoctosecond
-yoctosiemens
-yoctosievert
-yoctosteradian
-yoctotesla
-yoctovolt
-yoctowatt
-yoctoweber
-yotta
-yottaampere
-yottabecquerel
-yottabit
-yottabyte
-yottacandela
-yottacoulomb
-yottadegree_celsius
-yottaelectronvolt
-yottafarad
-yottagram
-yottagray
-yottahenry
-yottahertz
-yottajoule
-yottakatal
-yottakelvin
-yottaliter
-yottalumen
-yottalux
-yottameter
-yottamole
-yottanewton
-yottaohm
-yottapascal
-yottaradian
-yottasecond
-yottasiemens
-yottasievert
-yottasteradian
-yottatesla
-yottavolt
-yottawatt
-yottaweber
-zepto
-zeptoampere
-zeptobecquerel
-zeptocandela
-zeptocoulomb
-zeptodegree_celsius
-zeptofarad
-zeptogram
-zeptogray
-zeptohenry
-zeptohertz
-zeptojoule
-zeptokatal
-zeptokelvin
-zeptoliter
-zeptolumen
-zeptolux
-zeptometer
-zeptomole
-zeptonewton
-zeptoohm
-zeptopascal
-zeptoradian
-zeptosecond
-zeptosiemens
-zeptosievert
-zeptosteradian
-zeptotesla
-zeptovolt
-zeptowatt
-zeptoweber
-zetta
-zettaampere
-zettabecquerel
-zettabit
-zettabyte
-zettacandela
-zettacoulomb
-zettadegree_celsius
-zettaelectronvolt
-zettafarad
-zettagram
-zettagray
-zettahenry
-zettahertz
-zettajoule
-zettakatal
-zettakelvin
-zettaliter
-zettalumen
-zettalux
-zettameter
-zettamole
-zettanewton
-zettaohm
-zettapascal
-zettaradian
-zettasecond
-zettasiemens
-zettasievert
-zettasteradian
-zettatesla
-zettavolt
-zettawatt
-zettaweber
-ångström
+1	I;unit;+1;unity;one;①;Ⅰ;₁;¹;١;১;๑;1 (number);ⅰ;multiplicative identity;number 1;number one
+1593_english_statute_mile	British Imperial mile;English statute mile;1593 English statute mile
+acre	ac;acres
+ampere	A;amp
+ampere_hour	Ah;A h;A⋅h;amp hour;ampere-hour;ampere hour
+ampere_minute	ampere minute
+ampere_second	ampere-second;ampere second
+ampere_second_metre	ampere second meter;ampere second metre
+apothecaries_drachm	dram;drachm;apothecaries' dram;apothecaries' drachm
+apothecaries_ounce	apothecaries' ounce
+apothecaries_pound	apothecaries' pound
+apothecaries_scruple	scruple;apothecary scruple;apothecaries' scruple
+arbitrary_unit	arb. unit;p.d.u.;procedure defined unit;arbitrary unit
+arcminute	′;MOA;arc minute;arcmin;minute;minute of arc;minuit;minuits;min.;mins.;minutes of arc
+arcsecond	second;″;arc second;arc-sec;arcsec;second of arc
+are	
+astronomical_unit	AU;astronomic unit;ua;astronomical unit
+atto	a
+attoampere	aA
+attobecquerel	aBq
+attocandela	
+attocoulomb	
+attodegree_celsius	a°C;attodegree Celsius
+attoelectronvolt	aeV
+attofarad	aF
+attogram	ag
+attogray	aGy
+attohenry	aH
+attohertz	
+attojoule	
+attokatal	
+attokelvin	
+attoliter	attoliter
+attolumen	
+attolux	
+attometer	am;attometer
+attomole	amol
+attonewton	aN
+attoohm	aΩ
+attoparsec	apc
+attopascal	
+attoradian	
+attosecond	as
+attosiemens	
+attosievert	
+attosteradian	
+attotesla	aT
+attovolt	
+attowatt	
+attoweber	
+bar	bar (pressure)
+barn	
+baud	Bd
+becquerel	Bq
+bel	B
+bel_10_nanovolt	bel 10 nanovolt
+bel_kilowatt	bel kilowatt
+bel_microvolt	bel microvolt
+bel_millivolt	bel millivolt
+bel_sound_pressure_level	SPL;B SPL;B(SPL);dBSPL;bel sound pressure level
+bel_volt	bel volt
+bel_watt	bel watt
+bethesda_unit	BU;Bethesda unit
+biot	
+bit	b
+board_foot	board-foot;Mfbm;Mmfbm;Super foot;Superficial foot;board foot
+bodansky_unit	Bodansky unit
+boltzmann_constant	Boltzmann constant
+british_imperial_fathom	fathom;fathom (UK);imperial fathom;British Imperial fathom
+british_imperial_foot	foot (British Imperial);foot (UK);British Imperial foot
+british_imperial_inch	British inch;inch (UK);UK inch;British Imperial inch
+british_imperial_nautical_mile	British Imperial nautical mile
+british_imperial_rod	rod (UK);British Imperial rod
+british_imperial_yard	British Imperial yard
+byte	B;octet;8-bit byte;eight-bit byte;u8
+candela	cd
+candela_metre	candela metre
+candela_steradian	candela steradian
+candela_steradian_second	candela steradian second
+carat	CD;ct;karat;metric carat
+carat	K;karat;kt
+centi	c
+centiampere	
+centibecquerel	cBq
+centicandela	
+centicoulomb	cC
+centidegree_celsius	c°C;centidegree Celsius
+centielectronvolt	ceV
+centifarad	cF
+centigram	cg
+centigray	cGy
+centihenry	cH
+centihertz	cHz
+centijoule	
+centikatal	
+centikelvin	cK
+centiliter	centiliter;cL
+centilumen	clm
+centilux	clx
+centimeter	cm;centimeter;㎝
+centimetre_of_mercury	centimetre of mercury
+centimetre_of_water	centimeter of water;centimetre of water
+centimole	cmol
+centinewton	cN
+centinewton_metre	centinewton metre
+centiohm	cΩ
+centipascal	
+centipoise	cP
+centiradian	crad
+centisecond	1 E-2 s
+centisiemens	cS
+centisievert	cSv
+centisteradian	csr
+centistokes	cSt
+centitesla	cT
+centivolt	
+centiwatt	
+centiweber	cWb
+chain	ch;Gunter's chain;surveyor's chain;chains
+cicero	
+circle	⭕;⚪;round shape
+circular_mil	circular thou;circular mil
+cord	
+coulomb	
+coulomb_meter	C m;C·m;coulomb-meter;coulomb meter
+curie	Ci
+dalton	u;Da;amu;atomic mass unit;unified atomic mass unit
+day	d;Earth day;days
+deca	da
+decaampere	
+decabecquerel	daBq
+decacandela	
+decacoulomb	daC
+decadegree_celsius	da°C;decadegree Celsius
+decaelectronvolt	daeV;dekaelectronvolt
+decafarad	daF
+decagram	dag
+decagray	daGy
+decahenry	daH
+decahertz	daHz
+decajoule	
+decakatal	
+decakelvin	daK;dekakelvin
+decaliter	dal;decaliter
+decalumen	dalm
+decalux	dalx
+decameter	dam;decameter;dekameter
+decamole	damol;dekamole
+decanewton	daN
+decaohm	daΩ;dekaohm
+decapascal	daPa
+decaradian	darad
+decare	daa
+decasecond	1 E1 s
+decasiemens	daS
+decasievert	daSv
+decasteradian	dasr
+decatesla	daT
+decavolt	
+decawatt	
+decaweber	daWb
+deci	d
+deciampere	
+deciare	
+decibar	
+decibecquerel	dBq
+decibel	dB
+decicandela	
+decicoulomb	dC
+decidegree_celsius	d°C;decidegree Celsius
+decielectronvolt	deV
+decifarad	dF
+decigram	dg
+decigray	dGy
+decihenry	dH
+decihertz	dHz
+decijoule	
+decikatal	
+decikelvin	dK
+deciliter	dL;deciliter
+decilumen	dlm
+decilux	dlx
+decimeter	decimeter;dm
+decimole	
+decinewton	dN
+decinewton_meter	decinewton meter
+deciohm	dΩ
+decipascal	
+deciradian	drad
+decisecond	ds;1 E-1 s
+decisiemens	dS
+decisievert	dSv
+decisteradian	dsr
+decitesla	dT
+decitonne	
+decivolt	
+deciwatt	
+deciweber	dWb
+degree	°;angular degree;arcdegree;degree of arc
+degree_celsius	°C;℃;Celsius;centigrade;degree centigrade;degrees Celsius;degrees centigrade;degree Celsius
+degree_celsius_difference	Celsius degree difference;degree Celsius difference
+degree_fahrenheit	Fahrenheit;°F;degree Fahrenheit
+degree_rankine	degrees Rankine;degree Rankine
+degree_réaumur	degree Réaumur
+denier	
+didot_point	Didot point
+dimensionless_unit	dimensionless unit
+dioptre	diopter
+drop	metric drop
+dry_quart	quart (US dry);US dry quart;dry quart
+dye_unit	Dye unit
+dyne	
+e_cm	ecm;e cm
+ehrlich_unit	Ehrlich unit
+electron_mass	electron rest mass;electron mass
+electronvolt	electron volt;eV
+electronvolt_second	electronvolt-second;electronvolt second
+elementary_charge	elementary electric charge;elementary positive charge;elementary charge
+elisa_unit	ELISA unit
+erg	
+exa	E
+exaampere	
+exabecquerel	EBq
+exabit	Eb;Ebit
+exabyte	EB
+exacandela	
+exacoulomb	EC
+exadegree_celsius	E°C;exadegree Celsius
+exaelectronvolt	EeV
+exafarad	EF
+exagram	Eg
+exagray	EGy
+exahenry	EH
+exahertz	
+exajoule	
+exakatal	
+exakelvin	EK
+exaliter	exaliter
+exalumen	Elm
+exalux	Elx
+exameter	Em;exameter
+examole	
+exanewton	EN
+exaohm	EΩ
+exapascal	
+exaradian	Erad
+exasecond	1 E18 s
+exasiemens	ES
+exasievert	ESv
+exasteradian	Esr
+exatesla	ET
+exavolt	
+exawatt	
+exaweber	EWb
+farad	F
+fathom	U.S. survey fathom;US survey fathom
+femto	f
+femtoampere	
+femtobecquerel	fBq
+femtocandela	
+femtocoulomb	fC
+femtodegree_celsius	f°C;femtodegree Celsius
+femtoelectronvolt	feV
+femtofarad	fF
+femtogram	fg
+femtogray	fGy
+femtohenry	fH
+femtohertz	
+femtojoule	fJ
+femtokatal	
+femtokelvin	fK
+femtoliter	fl;femtoliter;fL
+femtolumen	flm
+femtolux	flx
+femtometer	fm;femtometer;fermi
+femtomole	fmol
+femtonewton	fN
+femtoohm	fΩ
+femtopascal	
+femtoradian	frad
+femtosecond	fs;1 E-15 s
+femtosiemens	fS
+femtosievert	fSv
+femtosteradian	fsr
+femtotesla	fT
+femtovolt	
+femtowatt	
+femtoweber	fWb
+fluid_ounce	Imp.fl.oz.;imperial fluid ounce;UK fluid ounce;fluid ounce
+french_gauge	Charrière;French gauge
+gal	galileo
+gauss	Gs
+gibi	Gi
+gibibit	Gib;Gibit
+gibibyte	GiB
+giga	G;giga-
+gigaampere	
+gigabecquerel	GBq
+gigabit	Gib;Gb;Gbit
+gigabyte	G;GB;Gbyte
+gigacandela	
+gigacoulomb	GC
+gigadegree_celsius	G°C;gigadegree Celsius
+gigaelectronvolt	GeV
+gigafarad	GF
+gigagram	Gg;kiloton
+gigagray	GGy
+gigahenry	GH
+gigahertz	GHz;㎓
+gigajoule	
+gigakatal	
+gigakelvin	GK
+gigaliter	gigaliter
+gigalumen	Glm
+gigalux	Glx
+gigameter	Gm;gigameter
+gigamole	Gmol
+giganewton	GN
+gigaohm	GΩ
+gigaparsec	Gpc
+gigapascal	GPa
+gigaradian	Grad
+gigasecond	1 E9 s
+gigasiemens	GS
+gigasievert	GSv
+gigasteradian	Gsr
+gigatesla	GT
+gigatonne	gigaton
+gigavolt	GV
+gigawatt	GW
+gigawatt_hour	gigawatt-hour;GWh;gigawatt hour
+gigaweber	GWb
+gilbert	Gb
+gill	US gill
+gill	imperial gill
+grade	gradient;pitch;incline;rise;slope
+gradian	gon;grad;grade
+grain	wheat grain
+gram	g;gm;gramme;grams
+gram_force	gram-force
+gram_percent	gram percent
+gravitational_constant	G;Newton's gravitational constant;Newtonian constant of gravitation;gravitational constant
+gray	Gy
+gregorian_year	average Gregorian year;mean Gregorian year;Gregorian year
+hand	
+hectare	ha;㏊
+hecto	h
+hectoampere	
+hectobar	
+hectobecquerel	hBq
+hectocandela	
+hectocoulomb	hC
+hectodegree_celsius	h°C;hectodegree Celsius
+hectoelectronvolt	heV
+hectofarad	hF
+hectogram	hg
+hectogray	hGy
+hectohenry	hH
+hectohertz	hHz
+hectojoule	
+hectokatal	
+hectokelvin	hK
+hectoliter	hl;hectoliter
+hectolumen	hlm
+hectolux	hlx
+hectometer	hm;hectometer
+hectomole	hmol
+hectonewton	hN
+hectoohm	hΩ
+hectopascal	hPa
+hectoradian	hrad
+hectosecond	1 E2 s
+hectosiemens	hS
+hectosievert	hSv
+hectosteradian	hsr
+hectotesla	hT
+hectovolt	
+hectowatt	
+hectoweber	hWb
+henry	H
+hertz	Hz
+high_power_field	HPF;high power field;high-power field
+hounsfield_unit	Hounsfield unit
+hour	hr;h;60 minutes;hours;hrs;sixty minutes
+imperial_horsepower	bhp;British horsepower;Horse-power;horsepower;mechanical horsepower;imperial horsepower
+inch	U.S. survey inch;US survey inch
+inch_of_mercury	″Hg;inch of mercury column;inches of mercury;inHg;inch of mercury
+inch_of_water	Aq;wc;in H20;inAq;inch of water column;inch of water gauge;inch water column;inches of water;inch of water
+international_fathom	fathom;international fathom
+international_foot	′;foot;ft;feet;imperial feet;imperial foot;international feet;international foot
+international_inch	in;″;imperial inch;imperial inches;inch;inches;international inches;international inch
+international_mil	mil;international mil
+international_mile	statute mile;imperial mile;imperial miles;international miles;mile;miles;international mile
+international_nautical_mile	international nautical mile
+international_unit	IU;international unit
+international_yard	yard;imperial yard;imperial yards;international yards;yards;yd;international yard
+joule	J
+joule_second	joule-second;Js;joule second
+julian_year	year;a;mean Julian year;Julian year
+katal	
+kayser	rydberg
+kelvin	K;Kelvin degrees
+kelvin_difference	kelvin difference
+kibi	Ki
+kibibit	Kib
+kibibyte	kilobyte;KiB
+kilo	k;kilo-
+kiloampere	kA;kiloamp
+kiloannum	ka;kiloyear;kyr;thousand years ago
+kilobar	
+kilobecquerel	kBq
+kilobit	kb;kbit;Kbit;Kilobit
+kilobyte	kB
+kilocalorie	calorie;food calorie;kilogram calorie;large calorie;thermochemical kilocalorie
+kilocandela	kcd
+kilocoulomb	kC
+kilocurie	
+kilodegree_celsius	k°C;kilodegree Celsius
+kiloelectronvolt	keV
+kilofarad	kF
+kilogram	kg;kilo;kilogramme;kilograms
+kilogram_force	kg force;kg-f;kg-force;kg-w;kgf;kilogram force;kilogram weight;kilogram-weight;kilopond;kp;kilogram-force
+kilogram_force_meter	kilogram-force meter
+kilogray	kGy
+kilohenry	kH
+kilohertz	kHz;㎑
+kilojoule	J;kJ
+kilokatal	
+kilokelvin	kK
+kiloliter	kiloliter;kL
+kilolumen	
+kilolux	klx
+kilometer	kilometer;km
+kilomole	
+kilonewton	kN
+kilonewton_meter	kilonewton meter
+kiloohm	kΩ;kilohm
+kiloparsec	kpc
+kilopascal	kPa
+kiloradian	krad
+kiloroentgen	kiloröntgen
+kilosecond	1 E3 s
+kilosiemens	kS
+kilosievert	kSv
+kilosteradian	ksr
+kilotesla	kT
+kilotonne	metric kilotonne
+kilovolt	kV
+kilovolt_ampere	kilovolt-ampere;kVA;kilovolt ampere
+kilovolt_ampere_hour	kilovolt ampere hour;kilovolt-ampere hour
+kilowatt	kW
+kilowatt_hour	kilowatt-hour;kilowatthour;kWh;kilowatt hour
+kiloweber	kWb
+knot	kn;kt;node;international knot;kts
+kunkel_unit	Kunkel unit
+lambert	L
+light_year	l.y.;light year;light years;light-years;lightyear;lightyears;ly;light-year
+ligne	line;Paris line
+line	
+link	link for Gunter's chain;Gunter's link
+link_for_ramsdens_chain	link for Ramden's chain;link for Ramsden's chain
+liquid_quart	quart (US);US liquid quart;liquid quart
+liter	l;L;liter;liters;litres
+liter_atmosphere	liter atmosphere;liter atmosphere
+long_hundredweight	cwt;British hundredweight;cwt long;hundred weight (UK);hundredweight (British);hundredweight (UK);imperial hundredweight;long hunderdweight;long hundredweights;long hundredweight
+long_ton	ton;displacement ton;gross ton;imperial ton;long tons;long tons (UK);UK t;weight ton;long ton
+low_power_field	LPF;low power field;low-power field
+lumen	lm
+lumen_hour	lumen hour
+lumen_second	lumen second
+lux	lx
+lux_hour	lux hour
+lux_second	lux second
+mac_lagan_unit	Mac Lagan unit
+magnetic_constant	permeability of free space;permeability of vacuum;vacuum permeability;magnetic constant
+maxwell	Mx
+mean_calorie	calorie;calorie (mean);mean calorie
+mean_gregorian_month	mean Gregorian month
+mean_julian_month	Julian month;mean Julian month
+mebi	Mi
+mebibit	Mib;Mibit
+mebibyte	MiB
+mega	M;mega-
+megaampere	mA;mega amp
+megabecquerel	MBq
+megabit	Mb;Mbit
+megabyte	MB;Mbyte
+megacandela	
+megacoulomb	MC
+megadegree_celsius	M°C;megadegree Celsius
+megaelectronvolt	MeV
+megaerg	
+megafarad	MF
+megagram	Mg;ton
+megagray	MGy
+megahenry	MH
+megahertz	MHz;㎒
+megajoule	MJ
+megakatal	
+megakelvin	MK
+megaliter	megaliter
+megalumen	Mlm
+megalux	Mlx
+megameter	megameter;Mm
+megamole	Mmol
+meganewton	MN
+meganewton_meter	meganewton meter
+megaohm	MΩ;megohm
+megaparsec	Mpc
+megapascal	MPa;㎫;N/mm²;Mega Pascal;Newton per millimeter squared
+megaradian	Mrad
+megasecond	1 E6 s
+megasiemens	MS
+megasievert	MSv
+megasteradian	Msr
+megatesla	MT
+megatonne	
+megavolt	MV
+megavolt_ampere	MVA;megavolt-ampere;megavolt ampere
+megawatt	MW
+megawatt_hour	megawatt-hour;megawatthour;MWh;megawatt hour
+megaweber	MWb
+mesh	
+metabolic_equivalent	MET;Metabolic Equivalent of Task;metabolic equivalent
+meter	m;meter;meters;mètre;metres
+metre_kelvin	m.K;meter kelvin;meter-kelvin;metre kelvin
+metre_of_mercury	meter of mercury;meter of mercury column;metre of mercury column;metre of mercury
+metre_of_water	conventional metre of water;meter of water;meter of water column;metre of water column;metre of water
+metre_second	meter second;metre second
+metre_to_the_fourth_power	m⁴;metre to the power four;metre to the power of four;quartic meter;metre to the fourth power
+metre_to_the_power_of_six	m⁶;metre to the power of six
+metric_ounce	metric ounce
+metric_ton	t;metric ton;ton;metric ton
+mho	
+micro	10^-6;µ
+microampere	µA;㎂
+microarcsecond	microarcsec
+microbar	
+microbecquerel	µBq
+microcandela	
+microcoulomb	µC
+microcurie	
+microdegree_celsius	µ°C;microdegree Celsius
+microelectronvolt	µeV
+microfarad	μF;microfarads;uf
+microgram	mcg;microgramme;micrograms;µg
+microgray	µGy
+microhenry	µH
+microhertz	µHz
+microjoule	µJ
+microkatal	
+microkelvin	µK
+microliter	microliter;µL
+microlumen	µlm
+microlux	µlx
+micrometer	micrometer;micron;um;µm
+micromho	
+micromole	umol;μmol
+micronewton	µN
+micronewton_meter	micronewton meter
+microohm	µΩ
+micropascal	μPa
+micropascal_second	μPa·s;micropascal second
+microradian	µrad
+microsecond	1 E-6 s;μs
+microsiemens	µS
+microsievert	µSv
+microsteradian	µsr
+microtesla	µT
+microvolt	
+microwatt	µW
+microwatt_hour	microwatt hour;µWh;microwatt-hour
+microweber	
+milli	m
+milliampere	mA;㎃;milliamperes
+milliampere_hour	mA h;mA⋅h;mAh;milliamp hour;milliampere-hour;milliampere hour
+milliampere_second	milliampere-second;milliampere second
+milliarcsecond	mas
+millibar	mbar
+millibarn	
+millibecquerel	mBq
+millicandela	mcd
+millicoulomb	mC
+millicurie	
+millidegree_celsius	m°C;millidegree Celsius
+millielectronvolt	meV
+millifarad	mF
+milligram	mg;milligramme
+milligray	mGy
+millihenry	mH
+millihertz	mHz
+millijoule	
+millikatal	
+millikelvin	mK
+milliliter	milliliter;mL
+millilumen	mlm
+millilux	mlx
+millimeter	mil;mm;millimeter
+millimeter_of_mercury	millimeter of mercury;mm Hg;mmHg;millimeter of mercury
+millimetre_of_water	millimeter of water;millimeters of water;millimetres of water;mm h20;mm H2O;mm wc;mm wg;mmH2O;mmwc;mmwg;millimetre of water
+millimole	mmol
+millinewton	mN
+millinewton_meter	millinewton meter
+milliohm	mΩ
+millipascal	
+millipascal_second	millipascal-second;mPa·s;millipascal second
+milliradian	mil;mils;mrad
+millirem	milliroentgen aequivalent men
+milliroentgen	milliröntgen
+millisecond	ms
+millisiemens	mS
+millisievert	mSv
+millisteradian	msr
+millitesla	mT
+millivolt	mV
+millivolt_ampere	millivolt-ampere
+milliwatt	mW
+milliwatt_hour	milliwatt hour;milliwatt-hour
+milliweber	mWb
+minute	min;minutes;mins;minuit;minuits;min.;mins.
+molar_equivalent	eq;equivalent;chemical equivalent;molar equivalent
+mole	mol
+month	months
+nano	n
+nanoampere	nA;nanoamp
+nanobecquerel	nBq
+nanocandela	
+nanocoulomb	nC
+nanodegree_celsius	n°C;nanodegree Celsius
+nanoelectronvolt	neV
+nanofarad	nF
+nanogram	ng
+nanogray	nGy
+nanohenry	nH
+nanohertz	
+nanojoule	
+nanokatal	
+nanokelvin	nK
+nanoliter	nanoliter;nL
+nanolumen	nlm
+nanolux	nlx
+nanometer	nm;nanometer
+nanomole	nmol
+nanonewton	nN
+nanoohm	nΩ
+nanopascal	
+nanoradian	nrad
+nanosecond	ns
+nanosiemens	nS
+nanosievert	nSv
+nanosteradian	nsr
+nanotesla	nT
+nanovolt	
+nanowatt	
+nanoweber	nWb
+neper	Np
+newton	N
+newton_centimetre	newton centimetre
+newton_meter	newton meter;N m;N·m;newton-meter;newton-metre;Nm;newton meter
+newton_metre_second	newton metre second
+newton_second	N s;N·s;newton-second;newton second
+oersted	Oe
+ohm	Ω
+ohm_centimeter	ohm centimeter
+ohm_meter	ohm meter;ohm meter
+osmole	
+ounce	oz;℥;avoirdupois ounce;ounce (avoirdupois);ounces;oz.
+pace	
+paris_foot	pied;French foot;Parisian foot;Paris foot
+paris_inch	French inch;pouce;Paris inch
+parsec	pc;parallax of one second;parallax second
+pascal	Pa
+pascal_second	pascal second
+peck	
+peck	imperial peck
+pennyweight	dwt;pennyweights;Troy pennyweight
+percent	%;pct.;percentage
+peripheral_vascular_resistance_unit	PRU;P.R.U.;peripheral vascular resistance unit
+permittivity_of_vacuum	electric constant;permittivity of free space;vacuum electric permittivity;vacuum permittivity;permittivity of vacuum
+peta	P
+petaampere	
+petabecquerel	PBq
+petabit	Pb;Pbit
+petabyte	PB
+petacandela	
+petacoulomb	PC
+petadegree_celsius	P°C;petadegree Celsius
+petaelectronvolt	PeV
+petafarad	PF
+petagram	Pg
+petagray	
+petahenry	PH
+petahertz	
+petajoule	
+petakatal	
+petakelvin	PK
+petaliter	petaliter
+petalumen	Plm
+petalux	Plx
+petameter	Pm;petameter
+petamole	Pmol
+petanewton	PN
+petaohm	PΩ
+petapascal	
+petaradian	Prad
+petasecond	1 E15 s
+petasiemens	PS
+petasievert	PSv
+petasteradian	Psr
+petatesla	PT
+petavolt	
+petawatt	
+petawatt_hour	petawatt hour
+petaweber	PWb
+phot	ph
+pi	π;Archimedes' constant;pi number;ratio of circumference to diameter;3.14...
+pica	
+pico	p
+picoampere	pA;picoamp
+picobecquerel	pBq
+picocandela	
+picocoulomb	pC
+picodegree_celsius	p°C;picodegree Celsius
+picoelectronvolt	peV
+picofarad	pF
+picogram	pg
+picogray	pGy
+picohenry	pH
+picohertz	
+picojoule	
+picokatal	
+picokelvin	pK
+picoliter	picoliter;pL
+picolumen	plm
+picolux	plx
+picometer	pm;picometer
+picomole	pmol
+piconewton	pN
+picoohm	pΩ
+picopascal	
+picoradian	prad
+picosecond	ps
+picosiemens	pS
+picosievert	pSv
+picosteradian	psr
+picotesla	pT
+picovolt	
+picowatt	
+picoweber	pWb
+pint	imperial pint
+planck_constant	h;𝒉;Planck's constant;Planck constant
+plaque_forming_unit	PFU;plaque-forming unit
+point	pt
+poise	
+pound	avoirdupois pound;lb;lbm;lbs;pound (avoirdupois);pound (mass);pound mass;pound-mass;pounds
+pound_force	lb;pound;lbf;pound (weight);pound force;pound of force;pound weight;pound-weight;poundforce;pound-force
+power_of_10	power of ten;powers of ten;power of 10
+printers_pica	Printer's pica
+printers_point	Printer's point
+prism_dioptre	prism diopter;prism dioptre
+protein_nitrogen_unit	protein nitrogen unit
+proton_mass	proton rest mass;proton mass
+quart	imperial quart
+quarter_of_an_hour	quarter of an hour
+rad	Radiation Absorbed Dose
+radian	rad
+ramsden_chain	engineer's chain;Ramden's chain;Ramsden chain
+reciprocal_angstrom	inverse angstrom;per angstrom;reciprocal angstrom
+reciprocal_centimeter	inverse centimetre;reciprocal centimeter
+reciprocal_day	inverse day;per day;reciprocal day
+reciprocal_decimeter	inverse decimetre;reciprocal decimeter
+reciprocal_farad	inverse farad;per farad;reciprocal farad
+reciprocal_henry	henry to the power minus one;inverse henry;per henry;yrneh;reciprocal henry
+reciprocal_hour	inverse hour;per hour;reciprocal hour
+reciprocal_kelvin	inverse kelvin;per kelvin;reciprocal kelvin
+reciprocal_kelvin_difference	inverse kelvin difference;kelvin difference to the power minus one;reciprocal kelvin difference
+reciprocal_kilometer	inverse kilometre;reciprocal kilometer
+reciprocal_megaannum	inverse megaannum;inverse megayear;per megaannum;per megayear;reciprocal megayear;reciprocal megaannum
+reciprocal_megakelvin	reciprocal megakelvin
+reciprocal_meter	1/m;inverse meter;inverse metre;m^-1;m⁻¹;metre to the power minus one;per meter;per metre;permeter;permetre;reciprocal meter;reciprocal meter
+reciprocal_millimeter	inverse millimetre;reciprocal millimeter
+reciprocal_minute	inverse minute;per minute;reciprocal minute
+reciprocal_mole	per mole;inverse mole;reciprocal of mole;reciprocal mole
+reciprocal_month	inverse month;per month;reciprocal month
+reciprocal_pascal	inverse pascal;pascal to the power minus one;per pascal;reciprocal pascal
+reciprocal_pascal_second	reciprocal pascal second
+reciprocal_second	1 per second;1/s;inverse second;per second;s^-1;s⁻¹;second to the power minus one;reciprocal second
+reciprocal_steradian	inverse steradian;sr⁻¹;steradian to the power minus one;reciprocal steradian
+reciprocal_week	inverse week;per week;reciprocal week
+reciprocal_year	inverse year;per year;reciprocal year
+rod	rod (US survey);rods;U.S. survey rod;U.S. survey rods;United States survey rod;United States survey rods;US survey rod;US survey rods
+roentgen	R;röntgen
+roentgen_equivalent_man	rem;Roentgen equivalent man
+second	s;sec;sec.;seconds
+section	survey section;township section
+short_hundredweight	cental;cwt;hundredweight (US);sh cwt;short hundredweights;short hundredweight
+short_ton	ton;U.S. ton;US t;US ton;short ton
+siemens	S
+sievert	Sv
+small_calorie	cal;calorie (thermochemical);gram calorie;thermochemical calorie;small calorie
+smoot	
+somogyi_unit	Somogyi unit
+speed_of_light_in_vacuum	speed of light;light speed;lightspeed;Planck speed;speed of electromagnetic waves in vacuum;speed of light in a vacuum;vacuum speed of light;velocity of light;luminal speed;light speed in vacuum;speed of light in vacuum
+sphere	2-sphere
+standard_acceleration_of_free_fall	g;g-force;acceleration due to gravity on Earth;g_0;g_n;g's;gee;gravities;standard acceleration of gravity;standard gravity;standard acceleration of free fall
+standard_atmosphere	atmosphere;atm;standard atmosphere
+steradian	sr;square radian
+stere	st;stère
+stilb	candela per square centimeter;candela per square centimetre;sb
+stokes	St;stoke
+stone	st;stone (UK);stones
+survey_township	township;congressional township;survey township
+svedberg	S;Sv
+synodic_month	synodal month;synodic month
+teaspoon	metric teaspoon;teaspoonful
+tebi	Ti
+tebibyte	TB;TiB
+technical_atmosphere	at;technical atmosphere
+tera	T;tera-
+teraampere	
+terabecquerel	TBq
+terabit	Tb
+terabyte	TB;TByte
+teracandela	
+teracoulomb	TC
+teradegree_celsius	T°C;teradegree Celsius
+teraelectronvolt	teraelectron volt;TeV
+terafarad	TF
+teragram	Tg;megaton
+teragray	TGy
+terahenry	TH
+terahertz	THz
+terajoule	
+terakatal	
+terakelvin	TK
+teraliter	teraliter
+teralumen	Tlm
+teralux	Tlx
+terameter	Tm;terameter
+teramole	Tmol
+teranewton	TN
+teraohm	TΩ
+terapascal	
+teraradian	Trad
+terasecond	1 E12 s
+terasiemens	TS
+terasievert	TSv
+terasteradian	Tsr
+teratesla	TT
+teravolt	
+terawatt	TW
+terawatt_hour	terawatt-hour;terawatthour;TWh;terawatt hour
+teraweber	TWb
+tesla	T
+tex	
+todd_unit	Todd unit
+township	
+tropical_year	solar year;tropical year
+troy_ounce	oz t;t oz;troy ounce
+troy_pound	t lb;troy pounds;troy pound
+united_states_pharmacopeia_unit	United States Pharmacopeia unit
+united_states_survey_link	link;link for Gunter's chain;links;U.S. survey link;U.S. survey links;United States survey links;US survey link;US survey links;United States survey link
+us_customary_cup	cup;US cup;customary cup;US customary cup
+us_legal_cup	cup;legal cup;US cup;US legal cup
+us_survey_acre	acre (US survey);U.S. survey acre;US survey acre
+us_survey_furlong	U.S. survey furlong;US survey furlong
+us_survey_mil	U.S. survey mil;US survey mil
+us_survey_yards	1893 Mendenhall yard;Mendenhall yard;Mendenhall yards;statue yard;statue yards;U.S. survey yard;U.S. survey yards;United States survey yard;United States survey yards;US survey yard;US survey yards
+volt	V;KV
+volt_ampere	VA;V·A;volt-ampere;voltampere;volt ampere
+volt_ampere_hour	volt-ampere hour
+volt_ampere_second	volt-ampere second
+volt_meter	volt meter;volt meter
+volt_second	volt second
+watt	W
+watt_hour	Wh;watt-hour;watt hour
+watt_second	W s;W·s;watt-second;watt second
+weber	Wb
+weber_meter	weber meter;weber meter
+week	weekly;week duration;weeks
+white_blood_cell_count	WBC;leucocyte;leucocyte count;leucocyte number;Leukocyte Count;white blood cell;white blood cell number;white blood cell count
+winchester_gallon	historical Winchester gallon;Winchester gallon
+wine_gallon	gallon;Queen Anne's gallon;Queen Anne's wine gallon;wine gallon
+wood_unit	Wood U.;Wood unit
+year	a;anno;annum
+yocto	y
+yoctoampere	
+yoctobecquerel	yBq
+yoctocandela	
+yoctocoulomb	yC
+yoctodegree_celsius	y°C;yoctodegree Celsius
+yoctofarad	yF
+yoctogram	yg
+yoctogray	yGy
+yoctohenry	yH
+yoctohertz	
+yoctojoule	
+yoctokatal	
+yoctokelvin	yK
+yoctoliter	yoctoliter
+yoctolumen	ylm
+yoctolux	ylx
+yoctometer	ym;yoctometer
+yoctomole	ymol
+yoctonewton	yN
+yoctoohm	yΩ
+yoctopascal	
+yoctoradian	yrad
+yoctosecond	ys
+yoctosiemens	yS
+yoctosievert	ySv
+yoctosteradian	ysr
+yoctotesla	yT
+yoctovolt	
+yoctowatt	
+yoctoweber	yWb
+yotta	Y
+yottaampere	
+yottabecquerel	YBq
+yottabit	Yb;Ybit
+yottabyte	YB
+yottacandela	
+yottacoulomb	YC
+yottadegree_celsius	Y°C;yottadegree Celsius
+yottaelectronvolt	YeV
+yottafarad	YF
+yottagram	Yg
+yottagray	YGy
+yottahenry	YH
+yottahertz	
+yottajoule	YJ
+yottakatal	
+yottakelvin	YK
+yottaliter	yottaliter
+yottalumen	Ylm
+yottalux	Ylx
+yottameter	Ym;yottameter
+yottamole	
+yottanewton	YN
+yottaohm	YΩ
+yottapascal	
+yottaradian	Yrad
+yottasecond	
+yottasiemens	YS
+yottasievert	YSv
+yottasteradian	ysr
+yottatesla	YT
+yottavolt	
+yottawatt	
+yottaweber	YWb
+zepto	z
+zeptoampere	
+zeptobecquerel	zBq
+zeptocandela	
+zeptocoulomb	
+zeptodegree_celsius	zeptodegree Celsius
+zeptofarad	
+zeptogram	zg
+zeptogray	zGy
+zeptohenry	zH
+zeptohertz	
+zeptojoule	
+zeptokatal	
+zeptokelvin	
+zeptoliter	zeptoliter;zL
+zeptolumen	
+zeptolux	
+zeptometer	zm;zeptometer
+zeptomole	zmol
+zeptonewton	zN
+zeptoohm	zΩ
+zeptopascal	
+zeptoradian	
+zeptosecond	
+zeptosiemens	zS
+zeptosievert	zSv
+zeptosteradian	
+zeptotesla	
+zeptovolt	
+zeptowatt	
+zeptoweber	
+zetta	Z
+zettaampere	
+zettabecquerel	
+zettabit	Zb;Zbit
+zettabyte	ZB
+zettacandela	
+zettacoulomb	
+zettadegree_celsius	Z°C;zettadegree Celsius
+zettaelectronvolt	ZeV
+zettafarad	ZF
+zettagram	Zg
+zettagray	
+zettahenry	
+zettahertz	
+zettajoule	ZJ
+zettakatal	
+zettakelvin	
+zettaliter	zettaliter
+zettalumen	Zlm
+zettalux	
+zettameter	zettameter;Zm
+zettamole	
+zettanewton	ZN
+zettaohm	ZΩ
+zettapascal	
+zettaradian	Zrad
+zettasecond	
+zettasiemens	ZS
+zettasievert	ZSv
+zettasteradian	Zsr
+zettatesla	ZT
+zettavolt	
+zettawatt	
+zettaweber	ZWb
+ångström	angstrom

--- a/mira/dkg/resources/unit_names.tsv
+++ b/mira/dkg/resources/unit_names.tsv
@@ -1,1016 +1,1016 @@
-1	I;unit;+1;unity;one;①;Ⅰ;₁;¹;١;১;๑;1 (number);ⅰ;multiplicative identity;number 1;number one
-1593_english_statute_mile	British Imperial mile;English statute mile;1593 English statute mile
-acre	ac;acres
-ampere	A;amp
-ampere_hour	Ah;A h;A⋅h;amp hour;ampere-hour;ampere hour
-ampere_minute	ampere minute
-ampere_second	ampere-second;ampere second
-ampere_second_metre	ampere second meter;ampere second metre
-apothecaries_drachm	dram;drachm;apothecaries' dram;apothecaries' drachm
-apothecaries_ounce	apothecaries' ounce
-apothecaries_pound	apothecaries' pound
-apothecaries_scruple	scruple;apothecary scruple;apothecaries' scruple
-arbitrary_unit	arb. unit;p.d.u.;procedure defined unit;arbitrary unit
-arcminute	′;MOA;arc minute;arcmin;minute;minute of arc;minuit;minuits;min.;mins.;minutes of arc
-arcsecond	second;″;arc second;arc-sec;arcsec;second of arc
-are	
-astronomical_unit	AU;astronomic unit;ua;astronomical unit
-atto	a
-attoampere	aA
-attobecquerel	aBq
-attocandela	
-attocoulomb	
-attodegree_celsius	a°C;attodegree Celsius
-attoelectronvolt	aeV
-attofarad	aF
-attogram	ag
-attogray	aGy
-attohenry	aH
-attohertz	
-attojoule	
-attokatal	
-attokelvin	
-attoliter	attoliter
-attolumen	
-attolux	
-attometer	am;attometer
-attomole	amol
-attonewton	aN
-attoohm	aΩ
-attoparsec	apc
-attopascal	
-attoradian	
-attosecond	as
-attosiemens	
-attosievert	
-attosteradian	
-attotesla	aT
-attovolt	
-attowatt	
-attoweber	
-bar	bar (pressure)
-barn	
-baud	Bd
-becquerel	Bq
-bel	B
-bel_10_nanovolt	bel 10 nanovolt
-bel_kilowatt	bel kilowatt
-bel_microvolt	bel microvolt
-bel_millivolt	bel millivolt
-bel_sound_pressure_level	SPL;B SPL;B(SPL);dBSPL;bel sound pressure level
-bel_volt	bel volt
-bel_watt	bel watt
-bethesda_unit	BU;Bethesda unit
-biot	
-bit	b
-board_foot	board-foot;Mfbm;Mmfbm;Super foot;Superficial foot;board foot
-bodansky_unit	Bodansky unit
-boltzmann_constant	Boltzmann constant
-british_imperial_fathom	fathom;fathom (UK);imperial fathom;British Imperial fathom
-british_imperial_foot	foot (British Imperial);foot (UK);British Imperial foot
-british_imperial_inch	British inch;inch (UK);UK inch;British Imperial inch
-british_imperial_nautical_mile	British Imperial nautical mile
-british_imperial_rod	rod (UK);British Imperial rod
-british_imperial_yard	British Imperial yard
-byte	B;octet;8-bit byte;eight-bit byte;u8
-candela	cd
-candela_metre	candela metre
-candela_steradian	candela steradian
-candela_steradian_second	candela steradian second
-carat	CD;ct;karat;metric carat
-carat	K;karat;kt
-centi	c
-centiampere	
-centibecquerel	cBq
-centicandela	
-centicoulomb	cC
-centidegree_celsius	c°C;centidegree Celsius
-centielectronvolt	ceV
-centifarad	cF
-centigram	cg
-centigray	cGy
-centihenry	cH
-centihertz	cHz
-centijoule	
-centikatal	
-centikelvin	cK
-centiliter	centiliter;cL
-centilumen	clm
-centilux	clx
-centimeter	cm;centimeter;㎝
-centimetre_of_mercury	centimetre of mercury
-centimetre_of_water	centimeter of water;centimetre of water
-centimole	cmol
-centinewton	cN
-centinewton_metre	centinewton metre
-centiohm	cΩ
-centipascal	
-centipoise	cP
-centiradian	crad
-centisecond	1 E-2 s
-centisiemens	cS
-centisievert	cSv
-centisteradian	csr
-centistokes	cSt
-centitesla	cT
-centivolt	
-centiwatt	
-centiweber	cWb
-chain	ch;Gunter's chain;surveyor's chain;chains
-cicero	
-circle	⭕;⚪;round shape
-circular_mil	circular thou;circular mil
-cord	
-coulomb	
-coulomb_meter	C m;C·m;coulomb-meter;coulomb meter
-curie	Ci
-dalton	u;Da;amu;atomic mass unit;unified atomic mass unit
-day	d;Earth day;days
-deca	da
-decaampere	
-decabecquerel	daBq
-decacandela	
-decacoulomb	daC
-decadegree_celsius	da°C;decadegree Celsius
-decaelectronvolt	daeV;dekaelectronvolt
-decafarad	daF
-decagram	dag
-decagray	daGy
-decahenry	daH
-decahertz	daHz
-decajoule	
-decakatal	
-decakelvin	daK;dekakelvin
-decaliter	dal;decaliter
-decalumen	dalm
-decalux	dalx
-decameter	dam;decameter;dekameter
-decamole	damol;dekamole
-decanewton	daN
-decaohm	daΩ;dekaohm
-decapascal	daPa
-decaradian	darad
-decare	daa
-decasecond	1 E1 s
-decasiemens	daS
-decasievert	daSv
-decasteradian	dasr
-decatesla	daT
-decavolt	
-decawatt	
-decaweber	daWb
-deci	d
-deciampere	
-deciare	
-decibar	
-decibecquerel	dBq
-decibel	dB
-decicandela	
-decicoulomb	dC
-decidegree_celsius	d°C;decidegree Celsius
-decielectronvolt	deV
-decifarad	dF
-decigram	dg
-decigray	dGy
-decihenry	dH
-decihertz	dHz
-decijoule	
-decikatal	
-decikelvin	dK
-deciliter	dL;deciliter
-decilumen	dlm
-decilux	dlx
-decimeter	decimeter;dm
-decimole	
-decinewton	dN
-decinewton_meter	decinewton meter
-deciohm	dΩ
-decipascal	
-deciradian	drad
-decisecond	ds;1 E-1 s
-decisiemens	dS
-decisievert	dSv
-decisteradian	dsr
-decitesla	dT
-decitonne	
-decivolt	
-deciwatt	
-deciweber	dWb
-degree	°;angular degree;arcdegree;degree of arc
-degree_celsius	°C;℃;Celsius;centigrade;degree centigrade;degrees Celsius;degrees centigrade;degree Celsius
-degree_celsius_difference	Celsius degree difference;degree Celsius difference
-degree_fahrenheit	Fahrenheit;°F;degree Fahrenheit
-degree_rankine	degrees Rankine;degree Rankine
-degree_réaumur	degree Réaumur
-denier	
-didot_point	Didot point
-dimensionless_unit	dimensionless unit
-dioptre	diopter
-drop	metric drop
-dry_quart	quart (US dry);US dry quart;dry quart
-dye_unit	Dye unit
-dyne	
-e_cm	ecm;e cm
-ehrlich_unit	Ehrlich unit
-electron_mass	electron rest mass;electron mass
-electronvolt	electron volt;eV
-electronvolt_second	electronvolt-second;electronvolt second
-elementary_charge	elementary electric charge;elementary positive charge;elementary charge
-elisa_unit	ELISA unit
-erg	
-exa	E
-exaampere	
-exabecquerel	EBq
-exabit	Eb;Ebit
-exabyte	EB
-exacandela	
-exacoulomb	EC
-exadegree_celsius	E°C;exadegree Celsius
-exaelectronvolt	EeV
-exafarad	EF
-exagram	Eg
-exagray	EGy
-exahenry	EH
-exahertz	
-exajoule	
-exakatal	
-exakelvin	EK
-exaliter	exaliter
-exalumen	Elm
-exalux	Elx
-exameter	Em;exameter
-examole	
-exanewton	EN
-exaohm	EΩ
-exapascal	
-exaradian	Erad
-exasecond	1 E18 s
-exasiemens	ES
-exasievert	ESv
-exasteradian	Esr
-exatesla	ET
-exavolt	
-exawatt	
-exaweber	EWb
-farad	F
-fathom	U.S. survey fathom;US survey fathom
-femto	f
-femtoampere	
-femtobecquerel	fBq
-femtocandela	
-femtocoulomb	fC
-femtodegree_celsius	f°C;femtodegree Celsius
-femtoelectronvolt	feV
-femtofarad	fF
-femtogram	fg
-femtogray	fGy
-femtohenry	fH
-femtohertz	
-femtojoule	fJ
-femtokatal	
-femtokelvin	fK
-femtoliter	fl;femtoliter;fL
-femtolumen	flm
-femtolux	flx
-femtometer	fm;femtometer;fermi
-femtomole	fmol
-femtonewton	fN
-femtoohm	fΩ
-femtopascal	
-femtoradian	frad
-femtosecond	fs;1 E-15 s
-femtosiemens	fS
-femtosievert	fSv
-femtosteradian	fsr
-femtotesla	fT
-femtovolt	
-femtowatt	
-femtoweber	fWb
-fluid_ounce	Imp.fl.oz.;imperial fluid ounce;UK fluid ounce;fluid ounce
-french_gauge	Charrière;French gauge
-gal	galileo
-gauss	Gs
-gibi	Gi
-gibibit	Gib;Gibit
-gibibyte	GiB
-giga	G;giga-
-gigaampere	
-gigabecquerel	GBq
-gigabit	Gib;Gb;Gbit
-gigabyte	G;GB;Gbyte
-gigacandela	
-gigacoulomb	GC
-gigadegree_celsius	G°C;gigadegree Celsius
-gigaelectronvolt	GeV
-gigafarad	GF
-gigagram	Gg;kiloton
-gigagray	GGy
-gigahenry	GH
-gigahertz	GHz;㎓
-gigajoule	
-gigakatal	
-gigakelvin	GK
-gigaliter	gigaliter
-gigalumen	Glm
-gigalux	Glx
-gigameter	Gm;gigameter
-gigamole	Gmol
-giganewton	GN
-gigaohm	GΩ
-gigaparsec	Gpc
-gigapascal	GPa
-gigaradian	Grad
-gigasecond	1 E9 s
-gigasiemens	GS
-gigasievert	GSv
-gigasteradian	Gsr
-gigatesla	GT
-gigatonne	gigaton
-gigavolt	GV
-gigawatt	GW
-gigawatt_hour	gigawatt-hour;GWh;gigawatt hour
-gigaweber	GWb
-gilbert	Gb
-gill	US gill
-gill	imperial gill
-grade	gradient;pitch;incline;rise;slope
-gradian	gon;grad;grade
-grain	wheat grain
-gram	g;gm;gramme;grams
-gram_force	gram-force
-gram_percent	gram percent
-gravitational_constant	G;Newton's gravitational constant;Newtonian constant of gravitation;gravitational constant
-gray	Gy
-gregorian_year	average Gregorian year;mean Gregorian year;Gregorian year
-hand	
-hectare	ha;㏊
-hecto	h
-hectoampere	
-hectobar	
-hectobecquerel	hBq
-hectocandela	
-hectocoulomb	hC
-hectodegree_celsius	h°C;hectodegree Celsius
-hectoelectronvolt	heV
-hectofarad	hF
-hectogram	hg
-hectogray	hGy
-hectohenry	hH
-hectohertz	hHz
-hectojoule	
-hectokatal	
-hectokelvin	hK
-hectoliter	hl;hectoliter
-hectolumen	hlm
-hectolux	hlx
-hectometer	hm;hectometer
-hectomole	hmol
-hectonewton	hN
-hectoohm	hΩ
-hectopascal	hPa
-hectoradian	hrad
-hectosecond	1 E2 s
-hectosiemens	hS
-hectosievert	hSv
-hectosteradian	hsr
-hectotesla	hT
-hectovolt	
-hectowatt	
-hectoweber	hWb
-henry	H
-hertz	Hz
-high_power_field	HPF;high power field;high-power field
-hounsfield_unit	Hounsfield unit
-hour	hr;h;60 minutes;hours;hrs;sixty minutes
-imperial_horsepower	bhp;British horsepower;Horse-power;horsepower;mechanical horsepower;imperial horsepower
-inch	U.S. survey inch;US survey inch
-inch_of_mercury	″Hg;inch of mercury column;inches of mercury;inHg;inch of mercury
-inch_of_water	Aq;wc;in H20;inAq;inch of water column;inch of water gauge;inch water column;inches of water;inch of water
-international_fathom	fathom;international fathom
-international_foot	′;foot;ft;feet;imperial feet;imperial foot;international feet;international foot
-international_inch	in;″;imperial inch;imperial inches;inch;inches;international inches;international inch
-international_mil	mil;international mil
-international_mile	statute mile;imperial mile;imperial miles;international miles;mile;miles;international mile
-international_nautical_mile	international nautical mile
-international_unit	IU;international unit
-international_yard	yard;imperial yard;imperial yards;international yards;yards;yd;international yard
-joule	J
-joule_second	joule-second;Js;joule second
-julian_year	year;a;mean Julian year;Julian year
-katal	
-kayser	rydberg
-kelvin	K;Kelvin degrees
-kelvin_difference	kelvin difference
-kibi	Ki
-kibibit	Kib
-kibibyte	kilobyte;KiB
-kilo	k;kilo-
-kiloampere	kA;kiloamp
-kiloannum	ka;kiloyear;kyr;thousand years ago
-kilobar	
-kilobecquerel	kBq
-kilobit	kb;kbit;Kbit;Kilobit
-kilobyte	kB
-kilocalorie	calorie;food calorie;kilogram calorie;large calorie;thermochemical kilocalorie
-kilocandela	kcd
-kilocoulomb	kC
-kilocurie	
-kilodegree_celsius	k°C;kilodegree Celsius
-kiloelectronvolt	keV
-kilofarad	kF
-kilogram	kg;kilo;kilogramme;kilograms
-kilogram_force	kg force;kg-f;kg-force;kg-w;kgf;kilogram force;kilogram weight;kilogram-weight;kilopond;kp;kilogram-force
-kilogram_force_meter	kilogram-force meter
-kilogray	kGy
-kilohenry	kH
-kilohertz	kHz;㎑
-kilojoule	J;kJ
-kilokatal	
-kilokelvin	kK
-kiloliter	kiloliter;kL
-kilolumen	
-kilolux	klx
-kilometer	kilometer;km
-kilomole	
-kilonewton	kN
-kilonewton_meter	kilonewton meter
-kiloohm	kΩ;kilohm
-kiloparsec	kpc
-kilopascal	kPa
-kiloradian	krad
-kiloroentgen	kiloröntgen
-kilosecond	1 E3 s
-kilosiemens	kS
-kilosievert	kSv
-kilosteradian	ksr
-kilotesla	kT
-kilotonne	metric kilotonne
-kilovolt	kV
-kilovolt_ampere	kilovolt-ampere;kVA;kilovolt ampere
-kilovolt_ampere_hour	kilovolt ampere hour;kilovolt-ampere hour
-kilowatt	kW
-kilowatt_hour	kilowatt-hour;kilowatthour;kWh;kilowatt hour
-kiloweber	kWb
-knot	kn;kt;node;international knot;kts
-kunkel_unit	Kunkel unit
-lambert	L
-light_year	l.y.;light year;light years;light-years;lightyear;lightyears;ly;light-year
-ligne	line;Paris line
-line	
-link	link for Gunter's chain;Gunter's link
-link_for_ramsdens_chain	link for Ramden's chain;link for Ramsden's chain
-liquid_quart	quart (US);US liquid quart;liquid quart
-liter	l;L;liter;liters;litres
-liter_atmosphere	liter atmosphere;liter atmosphere
-long_hundredweight	cwt;British hundredweight;cwt long;hundred weight (UK);hundredweight (British);hundredweight (UK);imperial hundredweight;long hunderdweight;long hundredweights;long hundredweight
-long_ton	ton;displacement ton;gross ton;imperial ton;long tons;long tons (UK);UK t;weight ton;long ton
-low_power_field	LPF;low power field;low-power field
-lumen	lm
-lumen_hour	lumen hour
-lumen_second	lumen second
-lux	lx
-lux_hour	lux hour
-lux_second	lux second
-mac_lagan_unit	Mac Lagan unit
-magnetic_constant	permeability of free space;permeability of vacuum;vacuum permeability;magnetic constant
-maxwell	Mx
-mean_calorie	calorie;calorie (mean);mean calorie
-mean_gregorian_month	mean Gregorian month
-mean_julian_month	Julian month;mean Julian month
-mebi	Mi
-mebibit	Mib;Mibit
-mebibyte	MiB
-mega	M;mega-
-megaampere	mA;mega amp
-megabecquerel	MBq
-megabit	Mb;Mbit
-megabyte	MB;Mbyte
-megacandela	
-megacoulomb	MC
-megadegree_celsius	M°C;megadegree Celsius
-megaelectronvolt	MeV
-megaerg	
-megafarad	MF
-megagram	Mg;ton
-megagray	MGy
-megahenry	MH
-megahertz	MHz;㎒
-megajoule	MJ
-megakatal	
-megakelvin	MK
-megaliter	megaliter
-megalumen	Mlm
-megalux	Mlx
-megameter	megameter;Mm
-megamole	Mmol
-meganewton	MN
-meganewton_meter	meganewton meter
-megaohm	MΩ;megohm
-megaparsec	Mpc
-megapascal	MPa;㎫;N/mm²;Mega Pascal;Newton per millimeter squared
-megaradian	Mrad
-megasecond	1 E6 s
-megasiemens	MS
-megasievert	MSv
-megasteradian	Msr
-megatesla	MT
-megatonne	
-megavolt	MV
-megavolt_ampere	MVA;megavolt-ampere;megavolt ampere
-megawatt	MW
-megawatt_hour	megawatt-hour;megawatthour;MWh;megawatt hour
-megaweber	MWb
-mesh	
-metabolic_equivalent	MET;Metabolic Equivalent of Task;metabolic equivalent
-meter	m;meter;meters;mètre;metres
-metre_kelvin	m.K;meter kelvin;meter-kelvin;metre kelvin
-metre_of_mercury	meter of mercury;meter of mercury column;metre of mercury column;metre of mercury
-metre_of_water	conventional metre of water;meter of water;meter of water column;metre of water column;metre of water
-metre_second	meter second;metre second
-metre_to_the_fourth_power	m⁴;metre to the power four;metre to the power of four;quartic meter;metre to the fourth power
-metre_to_the_power_of_six	m⁶;metre to the power of six
-metric_ounce	metric ounce
-metric_ton	t;metric ton;ton;metric ton
-mho	
-micro	10^-6;µ
-microampere	µA;㎂
-microarcsecond	microarcsec
-microbar	
-microbecquerel	µBq
-microcandela	
-microcoulomb	µC
-microcurie	
-microdegree_celsius	µ°C;microdegree Celsius
-microelectronvolt	µeV
-microfarad	μF;microfarads;uf
-microgram	mcg;microgramme;micrograms;µg
-microgray	µGy
-microhenry	µH
-microhertz	µHz
-microjoule	µJ
-microkatal	
-microkelvin	µK
-microliter	microliter;µL
-microlumen	µlm
-microlux	µlx
-micrometer	micrometer;micron;um;µm
-micromho	
-micromole	umol;μmol
-micronewton	µN
-micronewton_meter	micronewton meter
-microohm	µΩ
-micropascal	μPa
-micropascal_second	μPa·s;micropascal second
-microradian	µrad
-microsecond	1 E-6 s;μs
-microsiemens	µS
-microsievert	µSv
-microsteradian	µsr
-microtesla	µT
-microvolt	
-microwatt	µW
-microwatt_hour	microwatt hour;µWh;microwatt-hour
-microweber	
-milli	m
-milliampere	mA;㎃;milliamperes
-milliampere_hour	mA h;mA⋅h;mAh;milliamp hour;milliampere-hour;milliampere hour
-milliampere_second	milliampere-second;milliampere second
-milliarcsecond	mas
-millibar	mbar
-millibarn	
-millibecquerel	mBq
-millicandela	mcd
-millicoulomb	mC
-millicurie	
-millidegree_celsius	m°C;millidegree Celsius
-millielectronvolt	meV
-millifarad	mF
-milligram	mg;milligramme
-milligray	mGy
-millihenry	mH
-millihertz	mHz
-millijoule	
-millikatal	
-millikelvin	mK
-milliliter	milliliter;mL
-millilumen	mlm
-millilux	mlx
-millimeter	mil;mm;millimeter
-millimeter_of_mercury	millimeter of mercury;mm Hg;mmHg;millimeter of mercury
-millimetre_of_water	millimeter of water;millimeters of water;millimetres of water;mm h20;mm H2O;mm wc;mm wg;mmH2O;mmwc;mmwg;millimetre of water
-millimole	mmol
-millinewton	mN
-millinewton_meter	millinewton meter
-milliohm	mΩ
-millipascal	
-millipascal_second	millipascal-second;mPa·s;millipascal second
-milliradian	mil;mils;mrad
-millirem	milliroentgen aequivalent men
-milliroentgen	milliröntgen
-millisecond	ms
-millisiemens	mS
-millisievert	mSv
-millisteradian	msr
-millitesla	mT
-millivolt	mV
-millivolt_ampere	millivolt-ampere
-milliwatt	mW
-milliwatt_hour	milliwatt hour;milliwatt-hour
-milliweber	mWb
-minute	min;minutes;mins;minuit;minuits;min.;mins.
-molar_equivalent	eq;equivalent;chemical equivalent;molar equivalent
-mole	mol
-month	months
-nano	n
-nanoampere	nA;nanoamp
-nanobecquerel	nBq
-nanocandela	
-nanocoulomb	nC
-nanodegree_celsius	n°C;nanodegree Celsius
-nanoelectronvolt	neV
-nanofarad	nF
-nanogram	ng
-nanogray	nGy
-nanohenry	nH
-nanohertz	
-nanojoule	
-nanokatal	
-nanokelvin	nK
-nanoliter	nanoliter;nL
-nanolumen	nlm
-nanolux	nlx
-nanometer	nm;nanometer
-nanomole	nmol
-nanonewton	nN
-nanoohm	nΩ
-nanopascal	
-nanoradian	nrad
-nanosecond	ns
-nanosiemens	nS
-nanosievert	nSv
-nanosteradian	nsr
-nanotesla	nT
-nanovolt	
-nanowatt	
-nanoweber	nWb
-neper	Np
-newton	N
-newton_centimetre	newton centimetre
-newton_meter	newton meter;N m;N·m;newton-meter;newton-metre;Nm;newton meter
-newton_metre_second	newton metre second
-newton_second	N s;N·s;newton-second;newton second
-oersted	Oe
-ohm	Ω
-ohm_centimeter	ohm centimeter
-ohm_meter	ohm meter;ohm meter
-osmole	
-ounce	oz;℥;avoirdupois ounce;ounce (avoirdupois);ounces;oz.
-pace	
-paris_foot	pied;French foot;Parisian foot;Paris foot
-paris_inch	French inch;pouce;Paris inch
-parsec	pc;parallax of one second;parallax second
-pascal	Pa
-pascal_second	pascal second
-peck	
-peck	imperial peck
-pennyweight	dwt;pennyweights;Troy pennyweight
-percent	%;pct.;percentage
-peripheral_vascular_resistance_unit	PRU;P.R.U.;peripheral vascular resistance unit
-permittivity_of_vacuum	electric constant;permittivity of free space;vacuum electric permittivity;vacuum permittivity;permittivity of vacuum
-peta	P
-petaampere	
-petabecquerel	PBq
-petabit	Pb;Pbit
-petabyte	PB
-petacandela	
-petacoulomb	PC
-petadegree_celsius	P°C;petadegree Celsius
-petaelectronvolt	PeV
-petafarad	PF
-petagram	Pg
-petagray	
-petahenry	PH
-petahertz	
-petajoule	
-petakatal	
-petakelvin	PK
-petaliter	petaliter
-petalumen	Plm
-petalux	Plx
-petameter	Pm;petameter
-petamole	Pmol
-petanewton	PN
-petaohm	PΩ
-petapascal	
-petaradian	Prad
-petasecond	1 E15 s
-petasiemens	PS
-petasievert	PSv
-petasteradian	Psr
-petatesla	PT
-petavolt	
-petawatt	
-petawatt_hour	petawatt hour
-petaweber	PWb
-phot	ph
-pi	π;Archimedes' constant;pi number;ratio of circumference to diameter;3.14...
-pica	
-pico	p
-picoampere	pA;picoamp
-picobecquerel	pBq
-picocandela	
-picocoulomb	pC
-picodegree_celsius	p°C;picodegree Celsius
-picoelectronvolt	peV
-picofarad	pF
-picogram	pg
-picogray	pGy
-picohenry	pH
-picohertz	
-picojoule	
-picokatal	
-picokelvin	pK
-picoliter	picoliter;pL
-picolumen	plm
-picolux	plx
-picometer	pm;picometer
-picomole	pmol
-piconewton	pN
-picoohm	pΩ
-picopascal	
-picoradian	prad
-picosecond	ps
-picosiemens	pS
-picosievert	pSv
-picosteradian	psr
-picotesla	pT
-picovolt	
-picowatt	
-picoweber	pWb
-pint	imperial pint
-planck_constant	h;𝒉;Planck's constant;Planck constant
-plaque_forming_unit	PFU;plaque-forming unit
-point	pt
-poise	
-pound	avoirdupois pound;lb;lbm;lbs;pound (avoirdupois);pound (mass);pound mass;pound-mass;pounds
-pound_force	lb;pound;lbf;pound (weight);pound force;pound of force;pound weight;pound-weight;poundforce;pound-force
-power_of_10	power of ten;powers of ten;power of 10
-printers_pica	Printer's pica
-printers_point	Printer's point
-prism_dioptre	prism diopter;prism dioptre
-protein_nitrogen_unit	protein nitrogen unit
-proton_mass	proton rest mass;proton mass
-quart	imperial quart
-quarter_of_an_hour	quarter of an hour
-rad	Radiation Absorbed Dose
-radian	rad
-ramsden_chain	engineer's chain;Ramden's chain;Ramsden chain
-reciprocal_angstrom	inverse angstrom;per angstrom;reciprocal angstrom
-reciprocal_centimeter	inverse centimetre;reciprocal centimeter
-reciprocal_day	inverse day;per day;reciprocal day
-reciprocal_decimeter	inverse decimetre;reciprocal decimeter
-reciprocal_farad	inverse farad;per farad;reciprocal farad
-reciprocal_henry	henry to the power minus one;inverse henry;per henry;yrneh;reciprocal henry
-reciprocal_hour	inverse hour;per hour;reciprocal hour
-reciprocal_kelvin	inverse kelvin;per kelvin;reciprocal kelvin
-reciprocal_kelvin_difference	inverse kelvin difference;kelvin difference to the power minus one;reciprocal kelvin difference
-reciprocal_kilometer	inverse kilometre;reciprocal kilometer
-reciprocal_megaannum	inverse megaannum;inverse megayear;per megaannum;per megayear;reciprocal megayear;reciprocal megaannum
-reciprocal_megakelvin	reciprocal megakelvin
-reciprocal_meter	1/m;inverse meter;inverse metre;m^-1;m⁻¹;metre to the power minus one;per meter;per metre;permeter;permetre;reciprocal meter;reciprocal meter
-reciprocal_millimeter	inverse millimetre;reciprocal millimeter
-reciprocal_minute	inverse minute;per minute;reciprocal minute
-reciprocal_mole	per mole;inverse mole;reciprocal of mole;reciprocal mole
-reciprocal_month	inverse month;per month;reciprocal month
-reciprocal_pascal	inverse pascal;pascal to the power minus one;per pascal;reciprocal pascal
-reciprocal_pascal_second	reciprocal pascal second
-reciprocal_second	1 per second;1/s;inverse second;per second;s^-1;s⁻¹;second to the power minus one;reciprocal second
-reciprocal_steradian	inverse steradian;sr⁻¹;steradian to the power minus one;reciprocal steradian
-reciprocal_week	inverse week;per week;reciprocal week
-reciprocal_year	inverse year;per year;reciprocal year
-rod	rod (US survey);rods;U.S. survey rod;U.S. survey rods;United States survey rod;United States survey rods;US survey rod;US survey rods
-roentgen	R;röntgen
-roentgen_equivalent_man	rem;Roentgen equivalent man
-second	s;sec;sec.;seconds
-section	survey section;township section
-short_hundredweight	cental;cwt;hundredweight (US);sh cwt;short hundredweights;short hundredweight
-short_ton	ton;U.S. ton;US t;US ton;short ton
-siemens	S
-sievert	Sv
-small_calorie	cal;calorie (thermochemical);gram calorie;thermochemical calorie;small calorie
-smoot	
-somogyi_unit	Somogyi unit
-speed_of_light_in_vacuum	speed of light;light speed;lightspeed;Planck speed;speed of electromagnetic waves in vacuum;speed of light in a vacuum;vacuum speed of light;velocity of light;luminal speed;light speed in vacuum;speed of light in vacuum
-sphere	2-sphere
-standard_acceleration_of_free_fall	g;g-force;acceleration due to gravity on Earth;g_0;g_n;g's;gee;gravities;standard acceleration of gravity;standard gravity;standard acceleration of free fall
-standard_atmosphere	atmosphere;atm;standard atmosphere
-steradian	sr;square radian
-stere	st;stère
-stilb	candela per square centimeter;candela per square centimetre;sb
-stokes	St;stoke
-stone	st;stone (UK);stones
-survey_township	township;congressional township;survey township
-svedberg	S;Sv
-synodic_month	synodal month;synodic month
-teaspoon	metric teaspoon;teaspoonful
-tebi	Ti
-tebibyte	TB;TiB
-technical_atmosphere	at;technical atmosphere
-tera	T;tera-
-teraampere	
-terabecquerel	TBq
-terabit	Tb
-terabyte	TB;TByte
-teracandela	
-teracoulomb	TC
-teradegree_celsius	T°C;teradegree Celsius
-teraelectronvolt	teraelectron volt;TeV
-terafarad	TF
-teragram	Tg;megaton
-teragray	TGy
-terahenry	TH
-terahertz	THz
-terajoule	
-terakatal	
-terakelvin	TK
-teraliter	teraliter
-teralumen	Tlm
-teralux	Tlx
-terameter	Tm;terameter
-teramole	Tmol
-teranewton	TN
-teraohm	TΩ
-terapascal	
-teraradian	Trad
-terasecond	1 E12 s
-terasiemens	TS
-terasievert	TSv
-terasteradian	Tsr
-teratesla	TT
-teravolt	
-terawatt	TW
-terawatt_hour	terawatt-hour;terawatthour;TWh;terawatt hour
-teraweber	TWb
-tesla	T
-tex	
-todd_unit	Todd unit
-township	
-tropical_year	solar year;tropical year
-troy_ounce	oz t;t oz;troy ounce
-troy_pound	t lb;troy pounds;troy pound
-united_states_pharmacopeia_unit	United States Pharmacopeia unit
-united_states_survey_link	link;link for Gunter's chain;links;U.S. survey link;U.S. survey links;United States survey links;US survey link;US survey links;United States survey link
-us_customary_cup	cup;US cup;customary cup;US customary cup
-us_legal_cup	cup;legal cup;US cup;US legal cup
-us_survey_acre	acre (US survey);U.S. survey acre;US survey acre
-us_survey_furlong	U.S. survey furlong;US survey furlong
-us_survey_mil	U.S. survey mil;US survey mil
-us_survey_yards	1893 Mendenhall yard;Mendenhall yard;Mendenhall yards;statue yard;statue yards;U.S. survey yard;U.S. survey yards;United States survey yard;United States survey yards;US survey yard;US survey yards
-volt	V;KV
-volt_ampere	VA;V·A;volt-ampere;voltampere;volt ampere
-volt_ampere_hour	volt-ampere hour
-volt_ampere_second	volt-ampere second
-volt_meter	volt meter;volt meter
-volt_second	volt second
-watt	W
-watt_hour	Wh;watt-hour;watt hour
-watt_second	W s;W·s;watt-second;watt second
-weber	Wb
-weber_meter	weber meter;weber meter
-week	weekly;week duration;weeks
-white_blood_cell_count	WBC;leucocyte;leucocyte count;leucocyte number;Leukocyte Count;white blood cell;white blood cell number;white blood cell count
-winchester_gallon	historical Winchester gallon;Winchester gallon
-wine_gallon	gallon;Queen Anne's gallon;Queen Anne's wine gallon;wine gallon
-wood_unit	Wood U.;Wood unit
-year	a;anno;annum
-yocto	y
-yoctoampere	
-yoctobecquerel	yBq
-yoctocandela	
-yoctocoulomb	yC
-yoctodegree_celsius	y°C;yoctodegree Celsius
-yoctofarad	yF
-yoctogram	yg
-yoctogray	yGy
-yoctohenry	yH
-yoctohertz	
-yoctojoule	
-yoctokatal	
-yoctokelvin	yK
-yoctoliter	yoctoliter
-yoctolumen	ylm
-yoctolux	ylx
-yoctometer	ym;yoctometer
-yoctomole	ymol
-yoctonewton	yN
-yoctoohm	yΩ
-yoctopascal	
-yoctoradian	yrad
-yoctosecond	ys
-yoctosiemens	yS
-yoctosievert	ySv
-yoctosteradian	ysr
-yoctotesla	yT
-yoctovolt	
-yoctowatt	
-yoctoweber	yWb
-yotta	Y
-yottaampere	
-yottabecquerel	YBq
-yottabit	Yb;Ybit
-yottabyte	YB
-yottacandela	
-yottacoulomb	YC
-yottadegree_celsius	Y°C;yottadegree Celsius
-yottaelectronvolt	YeV
-yottafarad	YF
-yottagram	Yg
-yottagray	YGy
-yottahenry	YH
-yottahertz	
-yottajoule	YJ
-yottakatal	
-yottakelvin	YK
-yottaliter	yottaliter
-yottalumen	Ylm
-yottalux	Ylx
-yottameter	Ym;yottameter
-yottamole	
-yottanewton	YN
-yottaohm	YΩ
-yottapascal	
-yottaradian	Yrad
-yottasecond	
-yottasiemens	YS
-yottasievert	YSv
-yottasteradian	ysr
-yottatesla	YT
-yottavolt	
-yottawatt	
-yottaweber	YWb
-zepto	z
-zeptoampere	
-zeptobecquerel	zBq
-zeptocandela	
-zeptocoulomb	
-zeptodegree_celsius	zeptodegree Celsius
-zeptofarad	
-zeptogram	zg
-zeptogray	zGy
-zeptohenry	zH
-zeptohertz	
-zeptojoule	
-zeptokatal	
-zeptokelvin	
-zeptoliter	zeptoliter;zL
-zeptolumen	
-zeptolux	
-zeptometer	zm;zeptometer
-zeptomole	zmol
-zeptonewton	zN
-zeptoohm	zΩ
-zeptopascal	
-zeptoradian	
-zeptosecond	
-zeptosiemens	zS
-zeptosievert	zSv
-zeptosteradian	
-zeptotesla	
-zeptovolt	
-zeptowatt	
-zeptoweber	
-zetta	Z
-zettaampere	
-zettabecquerel	
-zettabit	Zb;Zbit
-zettabyte	ZB
-zettacandela	
-zettacoulomb	
-zettadegree_celsius	Z°C;zettadegree Celsius
-zettaelectronvolt	ZeV
-zettafarad	ZF
-zettagram	Zg
-zettagray	
-zettahenry	
-zettahertz	
-zettajoule	ZJ
-zettakatal	
-zettakelvin	
-zettaliter	zettaliter
-zettalumen	Zlm
-zettalux	
-zettameter	zettameter;Zm
-zettamole	
-zettanewton	ZN
-zettaohm	ZΩ
-zettapascal	
-zettaradian	Zrad
-zettasecond	
-zettasiemens	ZS
-zettasievert	ZSv
-zettasteradian	Zsr
-zettatesla	ZT
-zettavolt	
-zettawatt	
-zettaweber	ZWb
-ångström	angstrom
+1
+1593_english_statute_mile
+acre
+ampere
+ampere_hour
+ampere_minute
+ampere_second
+ampere_second_metre
+apothecaries_drachm
+apothecaries_ounce
+apothecaries_pound
+apothecaries_scruple
+arbitrary_unit
+arcminute
+arcsecond
+are
+astronomical_unit
+atto
+attoampere
+attobecquerel
+attocandela
+attocoulomb
+attodegree_celsius
+attoelectronvolt
+attofarad
+attogram
+attogray
+attohenry
+attohertz
+attojoule
+attokatal
+attokelvin
+attoliter
+attolumen
+attolux
+attometer
+attomole
+attonewton
+attoohm
+attoparsec
+attopascal
+attoradian
+attosecond
+attosiemens
+attosievert
+attosteradian
+attotesla
+attovolt
+attowatt
+attoweber
+bar
+barn
+baud
+becquerel
+bel
+bel_10_nanovolt
+bel_kilowatt
+bel_microvolt
+bel_millivolt
+bel_sound_pressure_level
+bel_volt
+bel_watt
+bethesda_unit
+biot
+bit
+board_foot
+bodansky_unit
+boltzmann_constant
+british_imperial_fathom
+british_imperial_foot
+british_imperial_inch
+british_imperial_nautical_mile
+british_imperial_rod
+british_imperial_yard
+byte
+candela
+candela_metre
+candela_steradian
+candela_steradian_second
+carat
+carat
+centi
+centiampere
+centibecquerel
+centicandela
+centicoulomb
+centidegree_celsius
+centielectronvolt
+centifarad
+centigram
+centigray
+centihenry
+centihertz
+centijoule
+centikatal
+centikelvin
+centiliter
+centilumen
+centilux
+centimeter
+centimetre_of_mercury
+centimetre_of_water
+centimole
+centinewton
+centinewton_metre
+centiohm
+centipascal
+centipoise
+centiradian
+centisecond
+centisiemens
+centisievert
+centisteradian
+centistokes
+centitesla
+centivolt
+centiwatt
+centiweber
+chain
+cicero
+circle
+circular_mil
+cord
+coulomb
+coulomb_meter
+curie
+dalton
+day
+deca
+decaampere
+decabecquerel
+decacandela
+decacoulomb
+decadegree_celsius
+decaelectronvolt
+decafarad
+decagram
+decagray
+decahenry
+decahertz
+decajoule
+decakatal
+decakelvin
+decaliter
+decalumen
+decalux
+decameter
+decamole
+decanewton
+decaohm
+decapascal
+decaradian
+decare
+decasecond
+decasiemens
+decasievert
+decasteradian
+decatesla
+decavolt
+decawatt
+decaweber
+deci
+deciampere
+deciare
+decibar
+decibecquerel
+decibel
+decicandela
+decicoulomb
+decidegree_celsius
+decielectronvolt
+decifarad
+decigram
+decigray
+decihenry
+decihertz
+decijoule
+decikatal
+decikelvin
+deciliter
+decilumen
+decilux
+decimeter
+decimole
+decinewton
+decinewton_meter
+deciohm
+decipascal
+deciradian
+decisecond
+decisiemens
+decisievert
+decisteradian
+decitesla
+decitonne
+decivolt
+deciwatt
+deciweber
+degree
+degree_celsius
+degree_celsius_difference
+degree_fahrenheit
+degree_rankine
+degree_réaumur
+denier
+didot_point
+dimensionless_unit
+dioptre
+drop
+dry_quart
+dye_unit
+dyne
+e_cm
+ehrlich_unit
+electron_mass
+electronvolt
+electronvolt_second
+elementary_charge
+elisa_unit
+erg
+exa
+exaampere
+exabecquerel
+exabit
+exabyte
+exacandela
+exacoulomb
+exadegree_celsius
+exaelectronvolt
+exafarad
+exagram
+exagray
+exahenry
+exahertz
+exajoule
+exakatal
+exakelvin
+exaliter
+exalumen
+exalux
+exameter
+examole
+exanewton
+exaohm
+exapascal
+exaradian
+exasecond
+exasiemens
+exasievert
+exasteradian
+exatesla
+exavolt
+exawatt
+exaweber
+farad
+fathom
+femto
+femtoampere
+femtobecquerel
+femtocandela
+femtocoulomb
+femtodegree_celsius
+femtoelectronvolt
+femtofarad
+femtogram
+femtogray
+femtohenry
+femtohertz
+femtojoule
+femtokatal
+femtokelvin
+femtoliter
+femtolumen
+femtolux
+femtometer
+femtomole
+femtonewton
+femtoohm
+femtopascal
+femtoradian
+femtosecond
+femtosiemens
+femtosievert
+femtosteradian
+femtotesla
+femtovolt
+femtowatt
+femtoweber
+fluid_ounce
+french_gauge
+gal
+gauss
+gibi
+gibibit
+gibibyte
+giga
+gigaampere
+gigabecquerel
+gigabit
+gigabyte
+gigacandela
+gigacoulomb
+gigadegree_celsius
+gigaelectronvolt
+gigafarad
+gigagram
+gigagray
+gigahenry
+gigahertz
+gigajoule
+gigakatal
+gigakelvin
+gigaliter
+gigalumen
+gigalux
+gigameter
+gigamole
+giganewton
+gigaohm
+gigaparsec
+gigapascal
+gigaradian
+gigasecond
+gigasiemens
+gigasievert
+gigasteradian
+gigatesla
+gigatonne
+gigavolt
+gigawatt
+gigawatt_hour
+gigaweber
+gilbert
+gill
+gill
+grade
+gradian
+grain
+gram
+gram_force
+gram_percent
+gravitational_constant
+gray
+gregorian_year
+hand
+hectare
+hecto
+hectoampere
+hectobar
+hectobecquerel
+hectocandela
+hectocoulomb
+hectodegree_celsius
+hectoelectronvolt
+hectofarad
+hectogram
+hectogray
+hectohenry
+hectohertz
+hectojoule
+hectokatal
+hectokelvin
+hectoliter
+hectolumen
+hectolux
+hectometer
+hectomole
+hectonewton
+hectoohm
+hectopascal
+hectoradian
+hectosecond
+hectosiemens
+hectosievert
+hectosteradian
+hectotesla
+hectovolt
+hectowatt
+hectoweber
+henry
+hertz
+high_power_field
+hounsfield_unit
+hour
+imperial_horsepower
+inch
+inch_of_mercury
+inch_of_water
+international_fathom
+international_foot
+international_inch
+international_mil
+international_mile
+international_nautical_mile
+international_unit
+international_yard
+joule
+joule_second
+julian_year
+katal
+kayser
+kelvin
+kelvin_difference
+kibi
+kibibit
+kibibyte
+kilo
+kiloampere
+kiloannum
+kilobar
+kilobecquerel
+kilobit
+kilobyte
+kilocalorie
+kilocandela
+kilocoulomb
+kilocurie
+kilodegree_celsius
+kiloelectronvolt
+kilofarad
+kilogram
+kilogram_force
+kilogram_force_meter
+kilogray
+kilohenry
+kilohertz
+kilojoule
+kilokatal
+kilokelvin
+kiloliter
+kilolumen
+kilolux
+kilometer
+kilomole
+kilonewton
+kilonewton_meter
+kiloohm
+kiloparsec
+kilopascal
+kiloradian
+kiloroentgen
+kilosecond
+kilosiemens
+kilosievert
+kilosteradian
+kilotesla
+kilotonne
+kilovolt
+kilovolt_ampere
+kilovolt_ampere_hour
+kilowatt
+kilowatt_hour
+kiloweber
+knot
+kunkel_unit
+lambert
+light_year
+ligne
+line
+link
+link_for_ramsdens_chain
+liquid_quart
+liter
+liter_atmosphere
+long_hundredweight
+long_ton
+low_power_field
+lumen
+lumen_hour
+lumen_second
+lux
+lux_hour
+lux_second
+mac_lagan_unit
+magnetic_constant
+maxwell
+mean_calorie
+mean_gregorian_month
+mean_julian_month
+mebi
+mebibit
+mebibyte
+mega
+megaampere
+megabecquerel
+megabit
+megabyte
+megacandela
+megacoulomb
+megadegree_celsius
+megaelectronvolt
+megaerg
+megafarad
+megagram
+megagray
+megahenry
+megahertz
+megajoule
+megakatal
+megakelvin
+megaliter
+megalumen
+megalux
+megameter
+megamole
+meganewton
+meganewton_meter
+megaohm
+megaparsec
+megapascal
+megaradian
+megasecond
+megasiemens
+megasievert
+megasteradian
+megatesla
+megatonne
+megavolt
+megavolt_ampere
+megawatt
+megawatt_hour
+megaweber
+mesh
+metabolic_equivalent
+meter
+metre_kelvin
+metre_of_mercury
+metre_of_water
+metre_second
+metre_to_the_fourth_power
+metre_to_the_power_of_six
+metric_ounce
+metric_ton
+mho
+micro
+microampere
+microarcsecond
+microbar
+microbecquerel
+microcandela
+microcoulomb
+microcurie
+microdegree_celsius
+microelectronvolt
+microfarad
+microgram
+microgray
+microhenry
+microhertz
+microjoule
+microkatal
+microkelvin
+microliter
+microlumen
+microlux
+micrometer
+micromho
+micromole
+micronewton
+micronewton_meter
+microohm
+micropascal
+micropascal_second
+microradian
+microsecond
+microsiemens
+microsievert
+microsteradian
+microtesla
+microvolt
+microwatt
+microwatt_hour
+microweber
+milli
+milliampere
+milliampere_hour
+milliampere_second
+milliarcsecond
+millibar
+millibarn
+millibecquerel
+millicandela
+millicoulomb
+millicurie
+millidegree_celsius
+millielectronvolt
+millifarad
+milligram
+milligray
+millihenry
+millihertz
+millijoule
+millikatal
+millikelvin
+milliliter
+millilumen
+millilux
+millimeter
+millimeter_of_mercury
+millimetre_of_water
+millimole
+millinewton
+millinewton_meter
+milliohm
+millipascal
+millipascal_second
+milliradian
+millirem
+milliroentgen
+millisecond
+millisiemens
+millisievert
+millisteradian
+millitesla
+millivolt
+millivolt_ampere
+milliwatt
+milliwatt_hour
+milliweber
+minute
+molar_equivalent
+mole
+month
+nano
+nanoampere
+nanobecquerel
+nanocandela
+nanocoulomb
+nanodegree_celsius
+nanoelectronvolt
+nanofarad
+nanogram
+nanogray
+nanohenry
+nanohertz
+nanojoule
+nanokatal
+nanokelvin
+nanoliter
+nanolumen
+nanolux
+nanometer
+nanomole
+nanonewton
+nanoohm
+nanopascal
+nanoradian
+nanosecond
+nanosiemens
+nanosievert
+nanosteradian
+nanotesla
+nanovolt
+nanowatt
+nanoweber
+neper
+newton
+newton_centimetre
+newton_meter
+newton_metre_second
+newton_second
+oersted
+ohm
+ohm_centimeter
+ohm_meter
+osmole
+ounce
+pace
+paris_foot
+paris_inch
+parsec
+pascal
+pascal_second
+peck
+peck
+pennyweight
+percent
+peripheral_vascular_resistance_unit
+permittivity_of_vacuum
+peta
+petaampere
+petabecquerel
+petabit
+petabyte
+petacandela
+petacoulomb
+petadegree_celsius
+petaelectronvolt
+petafarad
+petagram
+petagray
+petahenry
+petahertz
+petajoule
+petakatal
+petakelvin
+petaliter
+petalumen
+petalux
+petameter
+petamole
+petanewton
+petaohm
+petapascal
+petaradian
+petasecond
+petasiemens
+petasievert
+petasteradian
+petatesla
+petavolt
+petawatt
+petawatt_hour
+petaweber
+phot
+pi
+pica
+pico
+picoampere
+picobecquerel
+picocandela
+picocoulomb
+picodegree_celsius
+picoelectronvolt
+picofarad
+picogram
+picogray
+picohenry
+picohertz
+picojoule
+picokatal
+picokelvin
+picoliter
+picolumen
+picolux
+picometer
+picomole
+piconewton
+picoohm
+picopascal
+picoradian
+picosecond
+picosiemens
+picosievert
+picosteradian
+picotesla
+picovolt
+picowatt
+picoweber
+pint
+planck_constant
+plaque_forming_unit
+point
+poise
+pound
+pound_force
+power_of_10
+printers_pica
+printers_point
+prism_dioptre
+protein_nitrogen_unit
+proton_mass
+quart
+quarter_of_an_hour
+rad
+radian
+ramsden_chain
+reciprocal_angstrom
+reciprocal_centimeter
+reciprocal_day
+reciprocal_decimeter
+reciprocal_farad
+reciprocal_henry
+reciprocal_hour
+reciprocal_kelvin
+reciprocal_kelvin_difference
+reciprocal_kilometer
+reciprocal_megaannum
+reciprocal_megakelvin
+reciprocal_meter
+reciprocal_millimeter
+reciprocal_minute
+reciprocal_mole
+reciprocal_month
+reciprocal_pascal
+reciprocal_pascal_second
+reciprocal_second
+reciprocal_steradian
+reciprocal_week
+reciprocal_year
+rod
+roentgen
+roentgen_equivalent_man
+second
+section
+short_hundredweight
+short_ton
+siemens
+sievert
+small_calorie
+smoot
+somogyi_unit
+speed_of_light_in_vacuum
+sphere
+standard_acceleration_of_free_fall
+standard_atmosphere
+steradian
+stere
+stilb
+stokes
+stone
+survey_township
+svedberg
+synodic_month
+teaspoon
+tebi
+tebibyte
+technical_atmosphere
+tera
+teraampere
+terabecquerel
+terabit
+terabyte
+teracandela
+teracoulomb
+teradegree_celsius
+teraelectronvolt
+terafarad
+teragram
+teragray
+terahenry
+terahertz
+terajoule
+terakatal
+terakelvin
+teraliter
+teralumen
+teralux
+terameter
+teramole
+teranewton
+teraohm
+terapascal
+teraradian
+terasecond
+terasiemens
+terasievert
+terasteradian
+teratesla
+teravolt
+terawatt
+terawatt_hour
+teraweber
+tesla
+tex
+todd_unit
+township
+tropical_year
+troy_ounce
+troy_pound
+united_states_pharmacopeia_unit
+united_states_survey_link
+us_customary_cup
+us_legal_cup
+us_survey_acre
+us_survey_furlong
+us_survey_mil
+us_survey_yards
+volt
+volt_ampere
+volt_ampere_hour
+volt_ampere_second
+volt_meter
+volt_second
+watt
+watt_hour
+watt_second
+weber
+weber_meter
+week
+white_blood_cell_count
+winchester_gallon
+wine_gallon
+wood_unit
+year
+yocto
+yoctoampere
+yoctobecquerel
+yoctocandela
+yoctocoulomb
+yoctodegree_celsius
+yoctofarad
+yoctogram
+yoctogray
+yoctohenry
+yoctohertz
+yoctojoule
+yoctokatal
+yoctokelvin
+yoctoliter
+yoctolumen
+yoctolux
+yoctometer
+yoctomole
+yoctonewton
+yoctoohm
+yoctopascal
+yoctoradian
+yoctosecond
+yoctosiemens
+yoctosievert
+yoctosteradian
+yoctotesla
+yoctovolt
+yoctowatt
+yoctoweber
+yotta
+yottaampere
+yottabecquerel
+yottabit
+yottabyte
+yottacandela
+yottacoulomb
+yottadegree_celsius
+yottaelectronvolt
+yottafarad
+yottagram
+yottagray
+yottahenry
+yottahertz
+yottajoule
+yottakatal
+yottakelvin
+yottaliter
+yottalumen
+yottalux
+yottameter
+yottamole
+yottanewton
+yottaohm
+yottapascal
+yottaradian
+yottasecond
+yottasiemens
+yottasievert
+yottasteradian
+yottatesla
+yottavolt
+yottawatt
+yottaweber
+zepto
+zeptoampere
+zeptobecquerel
+zeptocandela
+zeptocoulomb
+zeptodegree_celsius
+zeptofarad
+zeptogram
+zeptogray
+zeptohenry
+zeptohertz
+zeptojoule
+zeptokatal
+zeptokelvin
+zeptoliter
+zeptolumen
+zeptolux
+zeptometer
+zeptomole
+zeptonewton
+zeptoohm
+zeptopascal
+zeptoradian
+zeptosecond
+zeptosiemens
+zeptosievert
+zeptosteradian
+zeptotesla
+zeptovolt
+zeptowatt
+zeptoweber
+zetta
+zettaampere
+zettabecquerel
+zettabit
+zettabyte
+zettacandela
+zettacoulomb
+zettadegree_celsius
+zettaelectronvolt
+zettafarad
+zettagram
+zettagray
+zettahenry
+zettahertz
+zettajoule
+zettakatal
+zettakelvin
+zettaliter
+zettalumen
+zettalux
+zettameter
+zettamole
+zettanewton
+zettaohm
+zettapascal
+zettaradian
+zettasecond
+zettasiemens
+zettasievert
+zettasteradian
+zettatesla
+zettavolt
+zettawatt
+zettaweber
+ångström

--- a/mira/dkg/resources/unit_names.tsv
+++ b/mira/dkg/resources/unit_names.tsv
@@ -1,107 +1,39 @@
 1
-1593 English statute mile
-Bethesda unit
-Bodansky unit
-Boltzmann constant
-British Imperial fathom
-British Imperial foot
-British Imperial inch
-British Imperial nautical mile
-British Imperial rod
-British Imperial yard
-British thermal unit (39 °F)
-British thermal unit (59 °F)
-British thermal unit (60 °F)
-British thermal unit (IT)
-British thermal unit (mean)
-British thermal unit (thermochemical)
-British thermal unit (thermochemical)
-Didot point
-Dye unit
-ELISA unit
-Ehrlich unit
-French gauge
-Gregorian year
-Gunter's chain (UK)
-Gunter's chain (US survey)
-Hounsfield unit
-Julian year
-Kunkel unit
-Mac Lagan unit
-Paris foot
-Paris inch
-Planck constant
-Printer's pica
-Printer's point
-Ramsden chain
-Roentgen equivalent man
-Somogyi unit
-Todd unit
-US customary cup
-US legal cup
-US survey acre
-US survey furlong
-US survey mil
-US survey yards
-United States Pharmacopeia unit
-United States survey link
-Winchester gallon
-Wood unit
+1593_english_statute_mile
 acre
 ampere
-ampere hour
-ampere hour per cubic decimetre
-ampere hour per kilogram
-ampere minute
-ampere per degree
-ampere per joule
-ampere per kilogram
-ampere per metre
-ampere per radian
-ampere per square metre
-ampere per square metre square kelvin
-ampere per volt
-ampere per volt metre
-ampere second
-ampere second metre
-ampere second per cubic metre
-ampere second per kilogram
-ampere second per metre
-ampere second per square metre
-ampere square metre
-ampere square metre per joule second
-apothecaries' drachm
-apothecaries' ounce
-apothecaries' pound
-apothecaries' scruple
-arbitrary unit
+ampere_hour
+ampere_minute
+ampere_second
+ampere_second_metre
+apothecaries_drachm
+apothecaries_ounce
+apothecaries_pound
+apothecaries_scruple
+arbitrary_unit
 arcminute
 arcsecond
 are
-astronomical unit
-astronomical unit per year
+astronomical_unit
 atto
 attoampere
 attobecquerel
 attocandela
 attocoulomb
-attodegree Celsius
+attodegree_celsius
 attoelectronvolt
 attofarad
 attogram
-attogram per litre
 attogray
 attohenry
 attohertz
 attojoule
 attokatal
 attokelvin
-attolitre
+attoliter
 attolumen
 attolux
-attometre
-attometre per second
-attometre per square second
+attometer
 attomole
 attonewton
 attoohm
@@ -118,54 +50,33 @@ attowatt
 attoweber
 bar
 barn
-barn per electronvolt
-barn per steradian
-barn per steradian electronvolt
-barrel (US) for petroleum
-barrels per day
 baud
-beats per minute
 becquerel
-becquerel per cubic metre
-becquerel per kilogram
-becquerel per litre
-becquerel per square metre
 bel
-bel 10 nanovolt
-bel kilowatt
-bel microvolt
-bel millivolt
-bel sound pressure level
-bel volt
-bel watt
+bel_10_nanovolt
+bel_kilowatt
+bel_microvolt
+bel_millivolt
+bel_sound_pressure_level
+bel_volt
+bel_watt
+bethesda_unit
 biot
 bit
-bit per cubic metre
-bit per metre
-bit per second
-bit per square metre
-board foot
-breath per minute
-bushel (UK)
-bushel (US)
+board_foot
+bodansky_unit
+boltzmann_constant
+british_imperial_fathom
+british_imperial_foot
+british_imperial_inch
+british_imperial_nautical_mile
+british_imperial_rod
+british_imperial_yard
 byte
-byte per second
-calorie (15 °C)
-calorie (20 °C)
-calorie (international table)
 candela
-candela metre
-candela per hertz
-candela per metre
-candela per square centimetre
-candela per square foot
-candela per square metre
-candela square millimetre per square metre
-candela steradian
-candela steradian cubic second per kilogram square metre
-candela steradian per square metre
-candela steradian second
-candela steradian second per square metre
+candela_metre
+candela_steradian
+candela_steradian_second
 carat
 carat
 centi
@@ -173,31 +84,25 @@ centiampere
 centibecquerel
 centicandela
 centicoulomb
-centidegree Celsius
+centidegree_celsius
 centielectronvolt
 centifarad
 centigram
-centigram per litre
 centigray
 centihenry
 centihertz
 centijoule
 centikatal
 centikelvin
-centilitre
+centiliter
 centilumen
 centilux
-centimetre
-centimetre of mercury
-centimetre of water
-centimetre of water
-centimetre per day
-centimetre per hour
-centimetre per second
-centimetre per square second
+centimeter
+centimetre_of_mercury
+centimetre_of_water
 centimole
 centinewton
-centinewton metre
+centinewton_metre
 centiohm
 centipascal
 centipoise
@@ -214,87 +119,11 @@ centiweber
 chain
 cicero
 circle
-circular mil
-cord
+circular_mil
 cord
 coulomb
-coulomb metre
-coulomb per cubic centimetre
-coulomb per cubic metre
-coulomb per cubic millimetre
-coulomb per kilogram
-coulomb per kilogram second
-coulomb per metre
-coulomb per mole
-coulomb per second
-coulomb per square centimetre
-coulomb per square metre
-coulomb per square millimetre
-count per litre
-cubic attometre
-cubic centimetre
-cubic centimetre per cubic metre
-cubic centimetre per day
-cubic centimetre per gram
-cubic centimetre per hour
-cubic centimetre per minute
-cubic centimetre per mole
-cubic centimetre per second
-cubic decametre
-cubic decimetre
-cubic decimetre per cubic metre
-cubic decimetre per hour
-cubic decimetre per kilogram
-cubic decimetre per mole
-cubic exametre
-cubic femtometre
-cubic foot
-cubic foot per minute
-cubic foot per pound
-cubic foot per second
-cubic gigametre
-cubic hectometre
-cubic hectometre per year
-cubic inch
-cubic inch per pound
-cubic kilometre
-cubic megametre
-cubic metre
-cubic metre per coulomb
-cubic metre per cubic metre
-cubic metre per day
-cubic metre per hour
-cubic metre per kilogram
-cubic metre per kilogram square second
-cubic metre per minute
-cubic metre per mole
-cubic metre per second
-cubic metre per second ampere
-cubic metre per ton
-cubic metre per year
-cubic micrometre
-cubic millimetre
-cubic millimetre per cubic metre
-cubic millimetre per cubic millimetre
-cubic nanometre
-cubic petametre
-cubic picometre
-cubic second kelvin per kilogram
-cubic second kelvin per kilogram square metre
-cubic second square ampere per kilogram cubic metre
-cubic second square ampere per kilogram mole
-cubic second square ampere per kilogram square metre
-cubic terametre
-cubic yard
-cubic yoctometre
-cubic yottametre
-cubic zeptometre
-cubic zettametre
+coulomb_meter
 curie
-curie per kilogram
-curie per litre
-dalton
-dalton
 dalton
 day
 deca
@@ -302,23 +131,20 @@ decaampere
 decabecquerel
 decacandela
 decacoulomb
-decadegree Celsius
+decadegree_celsius
 decaelectronvolt
 decafarad
 decagram
-decagram per litre
 decagray
 decahenry
 decahertz
 decajoule
 decakatal
 decakelvin
-decalitre
+decaliter
 decalumen
 decalux
-decametre
-decametre per second
-decametre per square second
+decameter
 decamole
 decanewton
 decaohm
@@ -341,27 +167,23 @@ decibecquerel
 decibel
 decicandela
 decicoulomb
-decidegree Celsius
+decidegree_celsius
 decielectronvolt
 decifarad
 decigram
-decigram per litre
 decigray
 decihenry
 decihertz
 decijoule
 decikatal
 decikelvin
-decilitre
-decilitre per gram
+deciliter
 decilumen
 decilux
-decimetre
-decimetre per second
-decimetre per square second
+decimeter
 decimole
 decinewton
-decinewton metre
+decinewton_meter
 deciohm
 decipascal
 deciradian
@@ -375,65 +197,48 @@ decivolt
 deciwatt
 deciweber
 degree
-degree Celsius
-degree Celsius difference
-degree Fahrenheit
-degree Rankine
-degree Réaumur
-degree per metre
-degree per second
-degree per square second
+degree_celsius
+degree_celsius_difference
+degree_fahrenheit
+degree_rankine
+degree_réaumur
 denier
-dimensionless unit
+didot_point
+dimensionless_unit
 dioptre
-dram (avoirdupois)
 drop
-dry pint (US)
-dry quart
+dry_quart
+dye_unit
 dyne
-dyne per centimetre
-dyne per square centimetre
-e cm
-electron mass
+e_cm
+ehrlich_unit
+electron_mass
 electronvolt
-electronvolt per metre
-electronvolt per square metre
-electronvolt second
-electronvolt square metre per kilogram
-elementary charge
-elementary charge
+electronvolt_second
+elementary_charge
+elisa_unit
 erg
-erg per cubic centimetre
-erg per gram
-erg per gram
-erg per second
-erg per second square centimetre
 exa
 exaampere
 exabecquerel
 exabit
-exabit per second
 exabyte
-exabyte per second
 exacandela
 exacoulomb
-exadegree Celsius
+exadegree_celsius
 exaelectronvolt
 exafarad
 exagram
-exagram per litre
 exagray
 exahenry
 exahertz
 exajoule
 exakatal
 exakelvin
-exalitre
+exaliter
 exalumen
 exalux
-exametre
-exametre per second
-exametre per square second
+exameter
 examole
 exanewton
 exaohm
@@ -448,31 +253,26 @@ exavolt
 exawatt
 exaweber
 farad
-farad per metre
 fathom
 femto
 femtoampere
 femtobecquerel
 femtocandela
 femtocoulomb
-femtodegree Celsius
+femtodegree_celsius
 femtoelectronvolt
 femtofarad
 femtogram
-femtogram per litre
 femtogray
 femtohenry
 femtohertz
 femtojoule
 femtokatal
 femtokelvin
-femtolitre
+femtoliter
 femtolumen
 femtolux
-femtometre
-femtometre
-femtometre per second
-femtometre per square second
+femtometer
 femtomole
 femtonewton
 femtoohm
@@ -486,18 +286,9 @@ femtotesla
 femtovolt
 femtowatt
 femtoweber
-fluid dram (UK)
-fluid dram (US)
-fluid ounce
-fluid ounce (US customary)
-fluid ounce (US nutrition)
-foot (US survey)
-foot per hour
+fluid_ounce
+french_gauge
 gal
-gal
-gallon (UK)
-gallon (UK)
-gauss
 gauss
 gibi
 gibibit
@@ -505,32 +296,24 @@ gibibyte
 giga
 gigaampere
 gigabecquerel
-gigabecquerel per kilogram
 gigabit
-gigabit per second
 gigabyte
-gigabyte per second
 gigacandela
 gigacoulomb
-gigacoulomb per cubic metre
-gigadegree Celsius
+gigadegree_celsius
 gigaelectronvolt
 gigafarad
 gigagram
-gigagram per litre
 gigagray
 gigahenry
 gigahertz
-gigahertz per volt
 gigajoule
 gigakatal
 gigakelvin
-gigalitre
+gigaliter
 gigalumen
 gigalux
-gigametre
-gigametre per second
-gigametre per square second
+gigameter
 gigamole
 giganewton
 gigaohm
@@ -543,68 +326,22 @@ gigasievert
 gigasteradian
 gigatesla
 gigatonne
-gigatonne per year
 gigavolt
 gigawatt
-gigawatt hour
+gigawatt_hour
 gigaweber
 gilbert
 gill
 gill
 grade
 gradian
-gradian
 grain
 gram
-gram per attolitre
-gram per centilitre
-gram per centimetre second
-gram per cubic centimetre
-gram per cubic decimetre
-gram per cubic metre
-gram per day
-gram per decalitre
-gram per decilitre
-gram per exalitre
-gram per femtolitre
-gram per gigalitre
-gram per gram
-gram per hectogram
-gram per hectolitre
-gram per hour
-gram per joule
-gram per kilogram
-gram per kilolitre
-gram per litre
-gram per megajoule
-gram per megalitre
-gram per metre
-gram per microlitre
-gram per millilitre
-gram per millimetre
-gram per minute
-gram per mole
-gram per nanolitre
-gram per petalitre
-gram per picolitre
-gram per second
-gram per square centimetre
-gram per square metre
-gram per square metre day
-gram per square metre second
-gram per square millimetre
-gram per teralitre
-gram per yoctolitre
-gram per yottalitre
-gram per zeptolitre
-gram per zettalitre
-gram percent
-gram-force
-gravitational constant
+gram_force
+gram_percent
+gravitational_constant
 gray
-gray per hour
-gray per minute
-gray per second
+gregorian_year
 hand
 hectare
 hecto
@@ -613,23 +350,20 @@ hectobar
 hectobecquerel
 hectocandela
 hectocoulomb
-hectodegree Celsius
+hectodegree_celsius
 hectoelectronvolt
 hectofarad
 hectogram
-hectogram per litre
 hectogray
 hectohenry
 hectohertz
 hectojoule
 hectokatal
 hectokelvin
-hectolitre
+hectoliter
 hectolumen
 hectolux
-hectometre
-hectometre per second
-hectometre per square second
+hectometer
 hectomole
 hectonewton
 hectoohm
@@ -644,71 +378,29 @@ hectovolt
 hectowatt
 hectoweber
 henry
-henry per metre
 hertz
-hertz per second
-hertz per tesla
-hertz per volt
-high-power field
+high_power_field
+hounsfield_unit
 hour
-imperial horsepower
+imperial_horsepower
 inch
-inch of mercury
-inch of water
-inch per minute
-inch per square second
-inch per year
-international fathom
-international foot
-international inch
-international mil
-international mile
-international nautical mile
-international unit
-international unit
-international yard
+inch_of_mercury
+inch_of_water
+international_fathom
+international_foot
+international_inch
+international_mil
+international_mile
+international_nautical_mile
+international_unit
+international_yard
 joule
-joule per ampere metre
-joule per bit
-joule per cubic metre
-joule per cubic metre hertz
-joule per cubic metre kelvin
-joule per cubic metre nanometre
-joule per day
-joule per gram
-joule per hertz mole
-joule per hour
-joule per kelvin
-joule per kelvin difference
-joule per kilogram
-joule per kilogram kelvin
-joule per kilogram kelvin difference
-joule per metre
-joule per metre to the fourth power
-joule per minute
-joule per mole
-joule per mole kelvin
-joule per mole kelvin difference
-joule per nanometre
-joule per second
-joule per square centimetre
-joule per square metre
-joule per square metre hertz
-joule per square metre nanometre
-joule per tesla
-joule second
-joule square metre
-joule square metre per kilogram
+joule_second
+julian_year
 katal
-katal per cubic metre
 kayser
 kelvin
-kelvin difference
-kelvin difference per metre
-kelvin metre per watt
-kelvin metre per watt
-kelvin per pascal
-kelvin per watt
+kelvin_difference
 kibi
 kibibit
 kibibyte
@@ -717,124 +409,31 @@ kiloampere
 kiloannum
 kilobar
 kilobecquerel
-kilobecquerel per kilogram
 kilobit
-kilobit per second
 kilobyte
-kilobyte per second
 kilocalorie
-kilocalorie
-kilocalorie
-kilocalorie per mole
 kilocandela
 kilocoulomb
-kilocoulomb per cubic metre
-kilocoulomb per square metre
 kilocurie
-kilodegree Celsius
+kilodegree_celsius
 kiloelectronvolt
 kilofarad
 kilogram
-kilogram cubic metre per cubic second square ampere
-kilogram cubic metre per square second ampere
-kilogram metre per cubic second
-kilogram metre per cubic second ampere
-kilogram metre per cubic second kelvin
-kilogram metre per cubic second steradian
-kilogram metre per second
-kilogram metre per square second
-kilogram metre per square second ampere
-kilogram metre per square second square ampere
-kilogram per cubic centimetre
-kilogram per cubic decimetre
-kilogram per cubic metre
-kilogram per cubic second
-kilogram per cubic second kelvin
-kilogram per cubic second steradian
-kilogram per day
-kilogram per gigajoule
-kilogram per hectare
-kilogram per hour
-kilogram per joule
-kilogram per kilogram
-kilogram per kilometre
-kilogram per kilomole
-kilogram per litre
-kilogram per metre
-kilogram per metre cubic second
-kilogram per metre cubic second steradian
-kilogram per metre day
-kilogram per metre hour
-kilogram per metre minute
-kilogram per metre second
-kilogram per metre square second
-kilogram per metre square second kelvin
-kilogram per millimetre
-kilogram per minute
-kilogram per mole
-kilogram per quartic metre second
-kilogram per second
-kilogram per square centimetre
-kilogram per square metre
-kilogram per square metre second
-kilogram per square metre square second
-kilogram per square second
-kilogram per square second ampere
-kilogram square centimetre
-kilogram square metre
-kilogram square metre per cubic second
-kilogram square metre per cubic second ampere
-kilogram square metre per cubic second ampere kelvin
-kilogram square metre per cubic second kelvin
-kilogram square metre per cubic second square ampere
-kilogram square metre per cubic second steradian
-kilogram square metre per second
-kilogram square metre per square second
-kilogram square metre per square second ampere
-kilogram square metre per square second kelvin
-kilogram square metre per square second kelvin
-kilogram square metre per square second kelvin mole
-kilogram square metre per square second kelvin mole
-kilogram square metre per square second mole
-kilogram square metre per square second square ampere
-kilogram square millimetre
-kilogram-force
-kilogram-force
-kilogram-force metre
-kilogram-force per square metre
+kilogram_force
+kilogram_force_meter
 kilogray
 kilohenry
 kilohertz
 kilojoule
-kilojoule per day
-kilojoule per gram
-kilojoule per hectogram
-kilojoule per hour
-kilojoule per kilogram
-kilojoule per kilogram kelvin difference
-kilojoule per minute
-kilojoule per mole
-kilojoule per second
-kilojoule per square metre
 kilokatal
 kilokelvin
-kilolitre
-kilolitre per hour
+kiloliter
 kilolumen
 kilolux
-kilometre
-kilometre per hour
-kilometre per litre
-kilometre per second
-kilometre per second megaparsec
-kilometre per square kilometre
-kilometre per square second
+kilometer
 kilomole
-kilomole per cubic metre
-kilomole per kilogram
 kilonewton
-kilonewton metre
-kilonewton per square metre
+kilonewton_meter
 kiloohm
 kiloparsec
 kilopascal
@@ -842,377 +441,205 @@ kiloradian
 kiloroentgen
 kilosecond
 kilosiemens
-kilosiemens per metre
 kilosievert
 kilosteradian
 kilotesla
 kilotonne
-kilotonne
 kilovolt
-kilovolt ampere
-kilovolt-ampere hour
+kilovolt_ampere
+kilovolt_ampere_hour
 kilowatt
-kilowatt hour
-kilowatt hour per square metre
-kilowatt hour per square metre per day
-kilowatt hour per square metre per year
+kilowatt_hour
 kiloweber
-kiloweber per metre
 knot
-knot (UK)
+kunkel_unit
 lambert
-light-year
+light_year
 ligne
 line
 link
-link for Ramsden's chain
-liquid pint (US)
-liquid quart
-litre
-litre
-litre atmosphere
-litre per day
-litre per hour
-litre per kilogram
-litre per litre
-litre per minute
-litre per mole
-litre per month
-litre per second
-litre per year
-long hundredweight
-long ton
-low-power field
+link_for_ramsdens_chain
+liquid_quart
+liter
+liter_atmosphere
+long_hundredweight
+long_ton
+low_power_field
 lumen
-lumen hour
-lumen per square metre
-lumen per watt
-lumen second
+lumen_hour
+lumen_second
 lux
-lux hour
-lux second
-magnetic constant
+lux_hour
+lux_second
+mac_lagan_unit
+magnetic_constant
 maxwell
-mean Gregorian month
-mean Julian month
-mean calorie
+mean_calorie
+mean_gregorian_month
+mean_julian_month
 mebi
 mebibit
 mebibyte
 mega
 megaampere
 megabecquerel
-megabecquerel per kilogram
 megabit
-megabit per second
 megabyte
-megabyte per second
 megacandela
 megacoulomb
-megacoulomb per cubic metre
-megacoulomb per square metre
-megadegree Celsius
+megadegree_celsius
 megaelectronvolt
 megaerg
 megafarad
 megagram
-megagram per cubic metre
-megagram per litre
 megagray
 megahenry
 megahertz
-megahertz per tesla
 megajoule
-megajoule per cubic metre
-megajoule per kilogram
-megajoule per square metre
 megakatal
 megakelvin
-megalitre
+megaliter
 megalumen
 megalux
-megametre
-megametre per second
-megametre per square second
+megameter
 megamole
 meganewton
-meganewton metre
+meganewton_meter
 megaohm
 megaparsec
 megapascal
 megaradian
 megasecond
 megasiemens
-megasiemens per metre
 megasievert
 megasteradian
 megatesla
 megatonne
 megavolt
-megavolt ampere
+megavolt_ampere
 megawatt
-megawatt hour
+megawatt_hour
 megaweber
 mesh
-metabolic equivalent
-metre
-metre kelvin
-metre of mercury
-metre of water
-metre per attosecond
-metre per centisecond
-metre per cubic second
-metre per day
-metre per decasecond
-metre per decisecond
-metre per exasecond
-metre per farad
-metre per femtosecond
-metre per gigasecond
-metre per hectosecond
-metre per hour
-metre per kilogram
-metre per kilosecond
-metre per megasecond
-metre per microsecond
-metre per millisecond
-metre per minute
-metre per nanosecond
-metre per petasecond
-metre per picosecond
-metre per radian
-metre per second
-metre per second to the fourth power
-metre per square attosecond
-metre per square centisecond
-metre per square decasecond
-metre per square decisecond
-metre per square exasecond
-metre per square femtosecond
-metre per square gigasecond
-metre per square hectosecond
-metre per square kilosecond
-metre per square megasecond
-metre per square microsecond
-metre per square millisecond
-metre per square nanosecond
-metre per square petasecond
-metre per square picosecond
-metre per square second
-metre per square terasecond
-metre per square yoctosecond
-metre per square yottasecond
-metre per square zeptosecond
-metre per square zettasecond
-metre per terasecond
-metre per yoctosecond
-metre per yottasecond
-metre per zeptosecond
-metre per zettasecond
-metre second
-metre square second kelvin per kilogram
-metre square second per kilogram
-metre to the fourth power
-metre to the power of six
-metric ounce
+metabolic_equivalent
+meter
+metre_kelvin
+metre_of_mercury
+metre_of_water
+metre_second
+metre_to_the_fourth_power
+metre_to_the_power_of_six
+metric_ounce
+metric_ton
 mho
 micro
 microampere
 microarcsecond
-microarcsecond per year
 microbar
 microbecquerel
 microcandela
 microcoulomb
-microcoulomb per cubic metre
-microcoulomb per square metre
 microcurie
-microdegree Celsius
+microdegree_celsius
 microelectronvolt
 microfarad
 microgram
-microgram per cubic centimetre
-microgram per cubic metre
-microgram per decilitre
-microgram per hectogram
-microgram per joule
-microgram per kilogram
-microgram per litre
-microgram per square metre second
 microgray
-microgray per hour
-microgray per minute
-microgray per second
 microhenry
-microhenry per metre
 microhertz
 microjoule
 microkatal
 microkelvin
-microlitre
-microlitre per litre
+microliter
 microlumen
 microlux
-micrometre
-micrometre per metre kelvin
-micrometre per second
-micrometre per square second
+micrometer
 micromho
 micromole
 micronewton
-micronewton metre
+micronewton_meter
 microohm
 micropascal
-micropascal second
+micropascal_second
 microradian
 microsecond
 microsiemens
-microsiemens per centimetre
-microsiemens per metre
 microsievert
-microsievert per hour
-microsievert per minute
-microsievert per second
-microsievert per year
 microsteradian
 microtesla
 microvolt
 microwatt
-microwatt per square metre
-microwatt-hour
+microwatt_hour
 microweber
-mile (US survey)
-mile per minute
-mile per second
 milli
 milliampere
-milliampere hour
-milliampere second
+milliampere_hour
+milliampere_second
 milliarcsecond
-milliarcsecond per year
 millibar
 millibarn
 millibecquerel
 millicandela
 millicoulomb
-millicoulomb per cubic metre
-millicoulomb per kilogram
-millicoulomb per square metre
 millicurie
-millidegree Celsius
+millidegree_celsius
 millielectronvolt
 millifarad
 milligram
-milligram per cubic metre
-milligram per day
-milligram per decilitre
-milligram per gram
-milligram per hectogram
-milligram per kilogram
-milligram per kilometre
-milligram per litre
-milligram per metre
-milligram per minute
-milligram per second
-milligram per square centimetre
-milligram per square metre
 milligray
-milligray per hour
-milligray per minute
-milligray per second
 millihenry
 millihertz
 millijoule
 millikatal
 millikelvin
-millilitre
-millilitre per cubic metre
-millilitre per day
-millilitre per hour
-millilitre per kilogram
-millilitre per litre
-millilitre per minute
-millilitre per second
+milliliter
 millilumen
 millilux
-millimetre
-millimetre of mercury
-millimetre of water
-millimetre per day
-millimetre per hour
-millimetre per minute
-millimetre per second
-millimetre per square second
-millimetre per year
+millimeter
+millimeter_of_mercury
+millimetre_of_water
 millimole
-millimole per gram
-millimole per kilogram
-millimole per litre
 millinewton
-millinewton metre
-millinewton per metre
+millinewton_meter
 milliohm
 millipascal
-millipascal second
+millipascal_second
 milliradian
 millirem
 milliroentgen
 millisecond
 millisiemens
-millisiemens per centimetre
 millisievert
-millisievert per hour
-millisievert per minute
-millisievert per second
 millisteradian
 millitesla
 millivolt
-millivolt per kelvin
-millivolt-ampere
+millivolt_ampere
 milliwatt
-milliwatt per square metre
-milliwatt-hour
+milliwatt_hour
 milliweber
-minim (UK)
-minim (US)
 minute
-molar equivalent
+molar_equivalent
 mole
-mole per cubic decimetre
-mole per cubic metre
-mole per joule
-mole per kilogram
-mole per litre
-mole per second
 month
 nano
 nanoampere
 nanobecquerel
 nanocandela
 nanocoulomb
-nanodegree Celsius
+nanodegree_celsius
 nanoelectronvolt
 nanofarad
 nanogram
-nanogram per decilitre
-nanogram per kilogram
-nanogram per litre
 nanogray
-nanogray per hour
-nanogray per minute
-nanogray per second
 nanohenry
-nanohenry per metre
 nanohertz
 nanojoule
 nanokatal
 nanokelvin
-nanolitre
+nanoliter
 nanolumen
 nanolux
-nanometre
-nanometre per second
-nanometre per square second
+nanometer
 nanomole
 nanonewton
 nanoohm
@@ -1220,99 +647,57 @@ nanopascal
 nanoradian
 nanosecond
 nanosiemens
-nanosiemens per centimetre
-nanosiemens per metre
 nanosievert
-nanosievert per hour
-nanosievert per minute
-nanosievert per second
 nanosteradian
 nanotesla
 nanovolt
 nanowatt
 nanoweber
-nautical mile per hour
 neper
-neper per metre
-neper per second
 newton
-newton centimetre
-newton metre
-newton metre per kilogram
-newton metre per radian
-newton metre per second
-newton metre second
-newton per cubic metre
-newton per metre
-newton per millimetre
-newton per square ampere
-newton per square metre
-newton per square millimetre
-newton second
-newton second per metre
-newton square metre per square kilogram
+newton_centimetre
+newton_meter
+newton_metre_second
+newton_second
 oersted
 ohm
-ohm centimeter
-ohm metre
-ohm square metre
+ohm_centimeter
+ohm_meter
 osmole
 ounce
-ounce per square foot
-ounce per square yard
 pace
+paris_foot
+paris_inch
 parsec
-part per billion
-parts per million
-parts per thousand
-parts per trillion
 pascal
-pascal per kelvin difference
-pascal second
-pascal second per cubic metre
-pascal second per metre
+pascal_second
 peck
 peck
 pennyweight
-pennyweight
-per 100 electronvolt
-per cubic centimetre minute
-per cubic metre second
-per kilogram second
-per microlitre
-per second metre
-per second steradian
-per square metre second
-per square metre second steradian
-per tesla second
 percent
-peripheral vascular resistance unit
-permittivity of vacuum
+peripheral_vascular_resistance_unit
+permittivity_of_vacuum
 peta
 petaampere
 petabecquerel
 petabit
 petabyte
-petabyte per second
 petacandela
 petacoulomb
-petadegree Celsius
+petadegree_celsius
 petaelectronvolt
 petafarad
 petagram
-petagram per litre
 petagray
 petahenry
 petahertz
 petajoule
 petakatal
 petakelvin
-petalitre
+petaliter
 petalumen
 petalux
-petametre
-petametre per second
-petametre per square second
+petameter
 petamole
 petanewton
 petaohm
@@ -1325,7 +710,7 @@ petasteradian
 petatesla
 petavolt
 petawatt
-petawatt hour
+petawatt_hour
 petaweber
 phot
 pi
@@ -1335,25 +720,20 @@ picoampere
 picobecquerel
 picocandela
 picocoulomb
-picodegree Celsius
+picodegree_celsius
 picoelectronvolt
 picofarad
-picofarad per metre
 picogram
-picogram per decilitre
-picogram per litre
 picogray
 picohenry
 picohertz
 picojoule
 picokatal
 picokelvin
-picolitre
+picoliter
 picolumen
 picolux
-picometre
-picometre per second
-picometre per square second
+picometer
 picomole
 piconewton
 picoohm
@@ -1361,199 +741,102 @@ picopascal
 picoradian
 picosecond
 picosiemens
-picosiemens per metre
 picosievert
 picosteradian
 picotesla
 picovolt
 picowatt
-picowatt per square metre
 picoweber
 pint
-pint
-plaque-forming unit
+planck_constant
+plaque_forming_unit
 point
 poise
 pound
-pound per cubic foot
-pound per cubic inch
-pound per cubic yard
-pound per pound
-pound per square inch
-pound per square yard
-pound-force
-power of 10
-power of 10
-prism dioptre
-protein nitrogen unit
-proton mass
+pound_force
+power_of_10
+printers_pica
+printers_point
+prism_dioptre
+protein_nitrogen_unit
+proton_mass
 quart
-quarter of an hour
-quartic metre per square second
+quarter_of_an_hour
 rad
 radian
-radian per metre
-radian per second
-radian per square second
-radian square metre per kilogram
-radian square metre per mole
-reciprocal angstrom
-reciprocal centimetre
-reciprocal cubic centimetre
-reciprocal cubic metre
-reciprocal day
-reciprocal decimetre
-reciprocal electronvolt cubic metre
-reciprocal farad
-reciprocal henry
-reciprocal hour
-reciprocal joule cubic metre
-reciprocal kelvin
-reciprocal kelvin difference
-reciprocal kilometre
-reciprocal megaannum
-reciprocal megakelvin
-reciprocal metre
-reciprocal millimetre
-reciprocal minute
-reciprocal mole
-reciprocal month
-reciprocal pascal
-reciprocal pascal second
-reciprocal second
-reciprocal square inch
-reciprocal square metre
-reciprocal square second
-reciprocal steradian
-reciprocal week
-reciprocal year
-rem per second
+ramsden_chain
+reciprocal_angstrom
+reciprocal_centimeter
+reciprocal_day
+reciprocal_decimeter
+reciprocal_farad
+reciprocal_henry
+reciprocal_hour
+reciprocal_kelvin
+reciprocal_kelvin_difference
+reciprocal_kilometer
+reciprocal_megaannum
+reciprocal_megakelvin
+reciprocal_meter
+reciprocal_millimeter
+reciprocal_minute
+reciprocal_mole
+reciprocal_month
+reciprocal_pascal
+reciprocal_pascal_second
+reciprocal_second
+reciprocal_steradian
+reciprocal_week
+reciprocal_year
 rod
 roentgen
-roentgen per second
+roentgen_equivalent_man
 second
-second per cubic metre
-second to the fourth power ampere squared per kilogram metre squared
-second to the fourth power square ampere per kilogram cubic metre
 section
-short hundredweight
-short ton
-short ton
+short_hundredweight
+short_ton
 siemens
-siemens per centimetre
-siemens per metre
-siemens square metre per mole
 sievert
-sievert per hour
-sievert per minute
-sievert per second
-small calorie
-small calorie
+small_calorie
 smoot
-speed of light in vacuum
+somogyi_unit
+speed_of_light_in_vacuum
 sphere
-square arcsecond
-square attometre
-square centimetre
-square centimetre per erg
-square centimetre per gram
-square centimetre per second
-square centimetre per steradian erg
-square decametre
-square decimetre
-square degree
-square exametre
-square femtometre
-square foot
-square foot per hour
-square foot per second
-square gigametre
-square hectometre
-square inch
-square inch per second
-square kilogram per square metre cubic second
-square kilogram quartic metre per sextic second square ampere square kelvin
-square kilometre
-square litre bar per square mole
-square megametre
-square metre
-square metre kelvin per watt
-square metre per cubic second
-square metre per joule
-square metre per kilogram
-square metre per mole
-square metre per second
-square metre per square second
-square metre per square second kelvin
-square metre per square second kelvin
-square metre per steradian
-square metre per steradian joule
-square metre per volt second
-square micrometre
-square micropascal second
-square mile
-square millimetre
-square millimetre per second
-square nanometre
-square pascal second
-square petametre
-square picometre
-square rod
-square second ampere per kilogram
-square second per kilogram
-square second per kilogram quintic metre
-square second square ampere per kilogram square metre
-square terametre
-square tesla metre per henry
-square volt per square kelvin
-square yard
-square yoctometre
-square yottametre
-square zeptometre
-square zettametre
-standard acceleration of free fall
-standard atmosphere
+standard_acceleration_of_free_fall
+standard_atmosphere
 steradian
 stere
 stilb
 stokes
 stone
-survey township
+survey_township
 svedberg
-synodic month
-tablespoon (US)
-tablespoon (metric)
+synodic_month
 teaspoon
-teaspoon (US)
 tebi
 tebibyte
-technical atmosphere
+technical_atmosphere
 tera
 teraampere
 terabecquerel
 terabit
-terabit per second
 terabyte
-terabyte per second
 teracandela
 teracoulomb
-teradegree Celsius
+teradegree_celsius
 teraelectronvolt
 terafarad
 teragram
-teragram per litre
 teragray
 terahenry
 terahertz
 terajoule
 terakatal
 terakelvin
-teralitre
+teraliter
 teralumen
 teralux
-terametre
-terametre per second
-terametre per square second
+terameter
 teramole
 teranewton
 teraohm
@@ -1566,90 +849,58 @@ terasteradian
 teratesla
 teravolt
 terawatt
-terawatt hour
+terawatt_hour
 teraweber
 tesla
 tex
-tonne
-tonne per cubic metre
-tonne per cubic metre
-tonne per hectare
+todd_unit
 township
-tropical year
-troy ounce
-troy pound
+tropical_year
+troy_ounce
+troy_pound
+united_states_pharmacopeia_unit
+united_states_survey_link
+us_customary_cup
+us_legal_cup
+us_survey_acre
+us_survey_furlong
+us_survey_mil
+us_survey_yards
 volt
-volt ampere
-volt metre
-volt per ampere
-volt per kelvin
-volt per metre
-volt second
-volt-ampere hour
-volt-ampere second
+volt_ampere
+volt_ampere_hour
+volt_ampere_second
+volt_meter
+volt_second
 watt
-watt hour
-watt hour per litre
-watt hour per square metre
-watt per cubic metre
-watt per hertz
-watt per kelvin
-watt per kilogram
-watt per metre
-watt per metre kelvin
-watt per nanometre
-watt per square centimetre
-watt per square metre
-watt per square metre hertz
-watt per square metre kelvin
-watt per square metre kelvin to the fourth power
-watt per square metre nanometre
-watt per square metre steradian
-watt per square metre steradian
-watt per steradian
-watt per steradian hertz
-watt per steradian metre
-watt per steradian nanometre
-watt per steradian square metre hertz
-watt per steradian square metre nanometre
-watt second
-watt square metre
-watt year per square metre kilogram
-watt-hour per kilogram
+watt_hour
+watt_second
 weber
-weber metre
-weber per metre
-weber per millimetre
-weber per square metre
+weber_meter
 week
-white blood cell count
-wine gallon
-yard per hour
-yard per minute
-yard per second
-yard per square second
+white_blood_cell_count
+winchester_gallon
+wine_gallon
+wood_unit
 year
 yocto
 yoctoampere
 yoctobecquerel
 yoctocandela
 yoctocoulomb
-yoctodegree Celsius
+yoctodegree_celsius
 yoctofarad
 yoctogram
-yoctogram per litre
 yoctogray
 yoctohenry
 yoctohertz
 yoctojoule
 yoctokatal
 yoctokelvin
-yoctolitre
+yoctoliter
 yoctolumen
 yoctolux
-yoctometre
-yoctometre per second
-yoctometre per square second
+yoctometer
 yoctomole
 yoctonewton
 yoctoohm
@@ -1667,28 +918,23 @@ yotta
 yottaampere
 yottabecquerel
 yottabit
-yottabit per second
 yottabyte
-yottabyte per second
 yottacandela
 yottacoulomb
-yottadegree Celsius
+yottadegree_celsius
 yottaelectronvolt
 yottafarad
 yottagram
-yottagram per litre
 yottagray
 yottahenry
 yottahertz
 yottajoule
 yottakatal
 yottakelvin
-yottalitre
+yottaliter
 yottalumen
 yottalux
-yottametre
-yottametre per second
-yottametre per square second
+yottameter
 yottamole
 yottanewton
 yottaohm
@@ -1707,22 +953,19 @@ zeptoampere
 zeptobecquerel
 zeptocandela
 zeptocoulomb
-zeptodegree Celsius
+zeptodegree_celsius
 zeptofarad
 zeptogram
-zeptogram per litre
 zeptogray
 zeptohenry
 zeptohertz
 zeptojoule
 zeptokatal
 zeptokelvin
-zeptolitre
+zeptoliter
 zeptolumen
 zeptolux
-zeptometre
-zeptometre per second
-zeptometre per square second
+zeptometer
 zeptomole
 zeptonewton
 zeptoohm
@@ -1740,28 +983,23 @@ zetta
 zettaampere
 zettabecquerel
 zettabit
-zettabit per second
 zettabyte
-zettabyte per second
 zettacandela
 zettacoulomb
-zettadegree Celsius
+zettadegree_celsius
 zettaelectronvolt
 zettafarad
 zettagram
-zettagram per litre
 zettagray
 zettahenry
 zettahertz
 zettajoule
 zettakatal
 zettakelvin
-zettalitre
+zettaliter
 zettalumen
 zettalux
-zettametre
-zettametre per second
-zettametre per square second
+zettameter
 zettamole
 zettanewton
 zettaohm

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -20,7 +20,7 @@ SPARQL = dedent("""\
       ?item wdt:P7825 ?umuc .
       OPTIONAL { ?item wdt:P8769 ?uo }
       OPTIONAL { ?item wdt:P2968 ?qudt }
-      SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". } # Helps get the label in your language, if not, then en language
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "en-us, en". } # Helps get the label in your language, if not, then en language
     }
 """)
 

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -64,7 +64,8 @@ def get_unit_terms():
 
         synonyms = [
             synonym.strip()
-            for synonym in (record["itemAltLabel"]["value"] or "").split(",")
+            for synonym in (record.get("itemAltLabel", {}).get("value") or "").split(",")
+            if synonym.strip()
         ]
 
         rv.append((

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -93,7 +93,7 @@ def get_unit_terms():
 def update_unit_names_resource():
     """Update a resource file with all unit names."""
     path = get_resource_path("unit_names.tsv")
-    unit_names = sorted([unit_row[1] + "\t" + ";".join(unit_row[3]) for unit_row in get_unit_terms()])
+    unit_names = sorted([unit_row[1] for unit_row in get_unit_terms()])
     with open(path, "w") as file:
         file.write("\n".join(unit_names))
 

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -52,7 +52,7 @@ def get_unit_terms():
         if not label:
             continue
 
-        if "per " in label or "square " in label or "cubic " in label:
+        if "per " in label or "square " in label or "cubic " in label or "(" in label:
             # skip derived units
             continue
         xrefs = []

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -48,6 +48,13 @@ def get_unit_terms():
     records = query_wikidata(SPARQL)
     rv = []
     for record in records:
+        label = record["itemLabel"]["value"].strip()
+        if not label:
+            continue
+
+        if "per " in label or "square " in label or "cubic " in label:
+            # skip derived units
+            continue
         xrefs = []
         for prefix in [
             # "umuc",
@@ -70,7 +77,7 @@ def get_unit_terms():
 
         rv.append((
             record["item"]["value"][len("http://www.wikidata.org/entity/"):],
-            record["itemLabel"]["value"],
+            label,
             description,
             synonyms,
             xrefs,

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 WIKIDATA_ENDPOINT = "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
 
 SPARQL = dedent("""\
-    SELECT ?item ?itemLabel ?itemDescription ?umuc ?uo ?qudt
+    SELECT ?item ?itemLabel ?itemDescription ?itemAltLabel ?umuc ?uo ?qudt
     WHERE 
     {
       ?item wdt:P7825 ?umuc .
@@ -55,10 +55,17 @@ def get_unit_terms():
             description = record["itemDescription"]["value"]
         except KeyError:
             description = ""
+
+        synonyms = [
+            synonym.strip()
+            for synonym in (record["itemAltLabel"]["value"] or "").split(",")
+        ]
+
         rv.append((
             record["item"]["value"][len("http://www.wikidata.org/entity/"):],
             record["itemLabel"]["value"],
             description,
+            synonyms,
             xrefs,
         ))
     return rv

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -75,6 +75,11 @@ def get_unit_terms():
             if synonym.strip()
         ]
 
+        label_norm = label.replace(" ", "_").replace("-", "_").replace("'", "").lower()
+        if label_norm != label:
+            synonyms.append(label)
+            label = label_norm
+
         rv.append((
             record["item"]["value"][len("http://www.wikidata.org/entity/"):],
             label,

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -93,6 +93,10 @@ def get_unit_terms():
 def update_unit_names_resource():
     """Update a resource file with all unit names."""
     path = get_resource_path("unit_names.tsv")
-    unit_names = sorted([unit_row[1] for unit_row in get_unit_terms()])
+    unit_names = sorted([unit_row[1] + "\t" + ";".join(unit_row[3]) for unit_row in get_unit_terms()])
     with open(path, "w") as file:
         file.write("\n".join(unit_names))
+
+
+if __name__ == '__main__':
+    update_unit_names_resource()

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -398,9 +398,10 @@ def process_unit_definition(unit_definition):
             unit_symbol *= 10 ** unit.scale
         full_unit_expr *= unit_symbol
     # We apply some mappings for canonical units we want to change
-    for unit_expr, new_unit_expr in unit_expression_mappings.items():
-        if full_unit_expr == unit_expr:
-            full_unit_expr = new_unit_expr
+    # We use equals here since == in sympy is structural equality
+    for k, v in unit_expression_mappings.items():
+        if full_unit_expr.equals(k):
+            full_unit_expr = v
     return full_unit_expr
 
 

--- a/tests/test_sbml.py
+++ b/tests/test_sbml.py
@@ -1,3 +1,5 @@
+import sympy
+
 from mira.sources.sbml.processor import parse_assignment_rule, \
     process_unit_definition
 
@@ -29,4 +31,4 @@ def test_unit_processing():
     day = MockUnit(28, 86400, -1, 0)
     person = MockUnit(12, 1, -1, 0)
     res = process_unit_definition(MockUnitDefinition([day, person]))
-    print(res)
+    assert res == 1 / (sympy.Symbol('day') * sympy.Symbol('person'))

--- a/tests/test_sbml.py
+++ b/tests/test_sbml.py
@@ -1,4 +1,5 @@
-from mira.sources.sbml.processor import parse_assignment_rule
+from mira.sources.sbml.processor import parse_assignment_rule, \
+    process_unit_definition
 
 
 def test_parse_expr():
@@ -11,3 +12,21 @@ def test_parse_expr():
     # TODO: transform the piecewise/and/gt/lt functions to be valid
     # in formulas so the expression can be parsed
     assert rule is None
+
+
+def test_unit_processing():
+    class MockUnit:
+        def __init__(self, kind, multiplier, exponent, scale):
+            self.kind = kind
+            self.multiplier = multiplier
+            self.exponent = exponent
+            self.scale = scale
+
+    class MockUnitDefinition:
+        def __init__(self, units):
+            self.units = units
+
+    day = MockUnit(28, 86400, -1, 0)
+    person = MockUnit(12, 1, -1, 0)
+    res = process_unit_definition(MockUnitDefinition([day, person]))
+    print(res)


### PR DESCRIPTION
As a follow-up to https://github.com/indralab/mira/pull/179, I started looking more carefully into the SPARQL query that gets units out of Wikidata. I have extended it to https://w.wiki/6rjM

- [x] This new query is able to get synonyms as well as show the parents of all units.
- [x] It appears that "SI unit" might work as a way to filter to non-derived/complex/compound units. Needs further investigation. Simple first solution - some text based rules
- [x] I can also do some kinds of string processing to get the primary labels to not include spaces, parentheses
- [x] Aggregate on qudt since multiple annotations of the `wdt:P2968` property resulted in duplicate nodes
- [x] Prioritize american english labels (5b9e5f4)
- [x] Solve issue with duplicate entities due to SPARQL query returning multiple rows when there are multiple xrefs (using group by + group concat)

## Local tests:

1. http://0.0.0.0:8771/api/search?q=fluid gives:
   ```
   [
    {
    "id": "wikidata:Q69878540",
    "name": "fluid_ounce",
    "type": "class",
    "obsolete": false,
    "description": "unit of volume in Great Britain",
    "synonyms": [],
    "xrefs": [],
    "labels": [
      "unit",
      "wikidata"
    ],
    "properties": {}
    },
    ...   
   ```

2. http://0.0.0.0:8771/api/search?q=meter gives:
    ```
     [
     {
    "id": "wikidata:Q11573",
    "name": "meter",
    "type": "class",
    "obsolete": false,
    "description": "SI unit of length",
    "synonyms": [],
    "xrefs": [],
    "labels": [
      "unit",
      "wikidata"
    ],
    "properties": {}
     },
    ```