### PR TITLE
Implement unit normalization

### DIFF
--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -88,6 +88,9 @@ template_model_example_w_context = TemplateModel(
 #: PetriNetModel json example
 petrinet_json = PetriNetModel(Model(sir)).to_pydantic()
 askenet_petrinet_json = AskeNetPetriNetModel(Model(sir)).to_pydantic()
+askenet_petrinet_json_units_values = AskeNetPetriNetModel(
+    Model(sir_parameterized_init)
+).to_pydantic()
 
 
 @model_blueprint.post(
@@ -256,7 +259,7 @@ def dimension_transform(
         query: Dict[str, Any] = Body(
             ...,
             example={
-                "model": askenet_petrinet_json,  # fixme: is this the right example?
+                "model": askenet_petrinet_json_units_values,
                 "counts_units": "persons",
                 "norm_factor": 1e5,
             },

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -247,6 +247,33 @@ def dimension_transform(
     return tm_dimless
 
 
+@model_blueprint.post(
+    "/counts_to_dimensionless_amr",
+    response_model=ModelSpecification,
+    tags=["modeling"]
+)
+def dimension_transform(
+        query: Dict[str, Any] = Body(
+            ...,
+            example={
+                "model": askenet_petrinet_json,  # fixme: is this the right example?
+                "counts_units": "persons",
+                "norm_factor": 1e5,
+            },
+        )
+):
+    """Convert all entity concentrations to dimensionless units"""
+    # convert to template model
+    amr_json = query.pop("model")
+    tm = template_model_from_askenet_json(amr_json)
+
+    # Create a dimensionless model
+    dimless_model = counts_to_dimensionless(tm=tm, **query)
+
+    # Transform back to askenet model
+    return AskeNetPetriNetModel(Model(dimless_model)).to_pydantic()
+
+
 @model_blueprint.get(
     "/biomodels/{model_id}",
     response_model=TemplateModel,

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -21,7 +21,7 @@ from fastapi import (
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
-from mira.examples.sir import sir_bilayer, sir
+from mira.examples.sir import sir_bilayer, sir, sir_parameterized_init
 from mira.metamodel import (
     NaturalConversion, Template, ControlledConversion,
     stratify, Concept, ModelComparisonGraphdata, TemplateModelDelta,
@@ -231,7 +231,7 @@ def dimension_transform(
         query: Dict[str, Any] = Body(
             ...,
             example={
-                "model": askenet_petrinet_json,  # fixme: this should be a template model
+                "model": sir_parameterized_init,
                 "counts_unit": "person",
                 "norm_factor": 1e5,
             },

--- a/mira/examples/sir.py
+++ b/mira/examples/sir.py
@@ -6,7 +6,7 @@ import sympy
 
 from mira.metamodel import ControlledConversion, NaturalConversion, \
     GroupedControlledConversion, TemplateModel, Initial, Parameter, \
-    safe_parse_expr
+    safe_parse_expr, Unit
 from .concepts import susceptible, infected, recovered, infected_symptomatic, \
     infected_asymptomatic
 
@@ -16,6 +16,7 @@ __all__ = [
     "sir_2_city",
     "sir_bilayer",
     "sir_parameterized",
+    "sir_parameterized_init",
     "svir",
 ]
 
@@ -136,3 +137,20 @@ svir = TemplateModel(
         infection_asymptomatic,
     ],
 )
+
+# SIR Parameterized Model with initial values and units, used as example in
+# docs and tests
+sir_parameterized_init = _d(sir_parameterized)
+for template in sir_parameterized_init.templates:
+    for concept in template.get_concepts():
+        concept.units = Unit(expression=sympy.Symbol('person'))
+sir_parameterized_init.initials['susceptible_population'].value = 1e5 - 1
+sir_parameterized_init.initials['infected_population'].value = 1
+sir_parameterized_init.initials['immune_population'].value = 0
+
+sir_parameterized_init.parameters['beta'].units = \
+    Unit(expression=1 / (sympy.Symbol('person') * sympy.Symbol('day')))
+old_beta = sir_parameterized_init.parameters['beta'].value
+
+for initial in sir_parameterized_init.initials.values():
+    initial.concept.units = Unit(expression=sympy.Symbol('person'))

--- a/mira/examples/sir.py
+++ b/mira/examples/sir.py
@@ -141,10 +141,12 @@ svir = TemplateModel(
 # SIR Parameterized Model with initial values and units, used as example in
 # docs and tests
 sir_parameterized_init = _d(sir_parameterized)
+sir_init_val_norm = 1e5
 for template in sir_parameterized_init.templates:
     for concept in template.get_concepts():
         concept.units = Unit(expression=sympy.Symbol('person'))
-sir_parameterized_init.initials['susceptible_population'].value = 1e5 - 1
+sir_parameterized_init.initials['susceptible_population'].value = \
+    sir_init_val_norm - 1
 sir_parameterized_init.initials['infected_population'].value = 1
 sir_parameterized_init.initials['immune_population'].value = 0
 

--- a/mira/metamodel/__init__.py
+++ b/mira/metamodel/__init__.py
@@ -6,4 +6,5 @@ from .comparison import *
 from .schema import *
 from .search import *
 from .ops import *
+from .units import *
 from .utils import *

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -9,7 +9,8 @@ import sympy
 
 from .template_model import TemplateModel, Initial, Parameter
 from .templates import *
-from .units import Unit, dimensionless_units
+from .units import Unit
+from .utils import SympyExprStr
 
 
 __all__ = [
@@ -438,7 +439,8 @@ def counts_to_dimensionless(tm: TemplateModel,
                 # If the exponent is other than zero then normalization is needed
                 if exponent:
                     concept.units.expression = \
-                        concept.units.expression.args[0] / (counts_unit_symbol ** exponent)
+                        SympyExprStr(concept.units.expression.args[0] /
+                                     (counts_unit_symbol ** exponent))
                     # We not try to see if there is a corresponding initial condition
                     # for the concept and if so, we normalize it as well
                     if concept.name in tm.initials and concept.name not in initials_normalized:
@@ -447,7 +449,8 @@ def counts_to_dimensionless(tm: TemplateModel,
                             init.value /= (norm_factor ** exponent)
                             if init.concept.units:
                                 init.concept.units.expression = \
-                                    init.concept.units.expression.args[0] / (counts_unit_symbol ** exponent)
+                                    SympyExprStr(init.concept.units.expression.args[0] /
+                                                 (counts_unit_symbol ** exponent))
                             initials_normalized.add(concept.name)
     # Now we do the same for parameters
     for p_name, p in tm.parameters.items():
@@ -456,7 +459,8 @@ def counts_to_dimensionless(tm: TemplateModel,
                 p.units.expression.args[0].as_coeff_exponent(counts_unit_symbol)
             if exponent:
                 p.units.expression = \
-                    p.units.expression.args[0] / (counts_unit_symbol ** exponent)
+                    SympyExprStr(p.units.expression.args[0] /
+                                 (counts_unit_symbol ** exponent))
                 p.value /= (norm_factor ** exponent)
 
     return tm

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -432,7 +432,7 @@ def counts_to_dimensionless(tm: TemplateModel,
         # template by template
         for concept in template.get_concepts():
             if concept.units:
-                # We figure out what the exponent of the coutns unit is
+                # We figure out what the exponent of the counts unit is
                 # if it appears in the units of the concept
                 (coeff, exponent) = \
                     concept.units.expression.args[0].as_coeff_exponent(counts_unit_symbol)

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -453,10 +453,10 @@ def counts_to_dimensionless(tm: TemplateModel,
     for p_name, p in tm.parameters.items():
         if p.units:
             (coeff, exponent) = \
-                p.units.expression = \
-                    p.units.expression.args[0].as_coeff_exponent(counts_unit_symbol)
+                p.units.expression.args[0].as_coeff_exponent(counts_unit_symbol)
             if exponent:
-                p.units /= (counts_unit_symbol ** exponent)
+                p.units.expression = \
+                    p.units.expression.args[0] / (counts_unit_symbol ** exponent)
                 p.value /= (norm_factor ** exponent)
 
     return tm

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -9,7 +9,7 @@ import sympy
 
 from .template_model import TemplateModel, Initial, Parameter
 from .templates import *
-from .units import Unit
+from .units import Unit, dimensionless_units
 from .utils import SympyExprStr
 
 

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -9,6 +9,8 @@ import sympy
 
 from .template_model import TemplateModel, Initial, Parameter
 from .templates import *
+from .units import Unit
+
 
 __all__ = [
     "stratify",

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -9,13 +9,15 @@ import sympy
 
 from .template_model import TemplateModel, Initial, Parameter
 from .templates import *
-from .units import Unit
+from .units import Unit, dimensionless_units
 
 
 __all__ = [
     "stratify",
     "simplify_rate_laws",
-    "aggregate_parameters"
+    "aggregate_parameters",
+    "get_term_roles",
+    "counts_to_dimensionless"
 ]
 
 
@@ -395,3 +397,66 @@ def get_term_roles(term, template, parameters):
         else:
             term_roles['other'].append(symbol.name)
     return dict(term_roles)
+
+
+def counts_to_dimensionless(tm: TemplateModel,
+                            counts_unit: str,
+                            norm_factor: float):
+    """Convert all entity concentrations to dimensionless units.
+
+    Parameters
+    ----------
+    tm :
+        A template model.
+    counts_unit :
+        The unit of the counts.
+    norm_factor :
+        The normalization factor to convert counts to concentration.
+
+    Returns
+    -------
+    :
+        A template model with all entity concentrations converted to
+        dimensionless units.
+    """
+    # Make a deepcopy up front so we don't change the original template model
+    tm = deepcopy(tm)
+    # Make a symbol of the counts unit for calculations
+    counts_unit_symbol = sympy.Symbol(counts_unit)
+
+    initials_normalized = set()
+    # First we normalize concepts and their initials
+    for template in tm.templates:
+        # Since concepts can be distributed across templates, we have to go
+        # template by template
+        for concept in template.get_concepts():
+            if concept.units:
+                # We figure out what the exponent of the coutns unit is
+                # if it appears in the units of the concept
+                (coeff, exponent) = \
+                    concept.units.expression.args[0].as_coeff_exponent(counts_unit_symbol)
+                # If the exponent is other than zero then normalization is needed
+                if exponent:
+                    concept.units.expression = \
+                        concept.units.expression.args[0] / (counts_unit_symbol ** exponent)
+                    # We not try to see if there is a corresponding initial condition
+                    # for the concept and if so, we normalize it as well
+                    if concept.name in tm.initials and concept.name not in initials_normalized:
+                        init = tm.initials[concept.name]
+                        if init.value is not None:
+                            init.value /= (norm_factor ** exponent)
+                            if init.concept.units:
+                                init.concept.units.expression = \
+                                    init.concept.units.expression.args[0] / (counts_unit_symbol ** exponent)
+                            initials_normalized.add(concept.name)
+    # Now we do the same for parameters
+    for p_name, p in tm.parameters.items():
+        if p.units:
+            (coeff, exponent) = \
+                p.units.expression = \
+                    p.units.expression.args[0].as_coeff_exponent(counts_unit_symbol)
+            if exponent:
+                p.units /= (counts_unit_symbol ** exponent)
+                p.value /= (norm_factor ** exponent)
+
+    return tm

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -3,7 +3,7 @@ __all__ = ["Annotations", "TemplateModel", "Initial", "Parameter",
 
 import datetime
 import sys
-from typing import List, Dict, Set, Optional, Mapping, Tuple
+from typing import List, Dict, Set, Optional, Mapping, Tuple, Any
 
 import networkx as nx
 import sympy
@@ -19,6 +19,23 @@ class Initial(BaseModel):
 
     concept: Concept
     value: float
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {
+            SympyExprStr: lambda e: str(e),
+        }
+        json_decoders = {
+            SympyExprStr: lambda e: sympy.parse_expr(e)
+        }
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "Initial":
+        value = data.pop('value')
+        concept_json = data.pop('concept')
+        # Get Concept
+        concept = Concept.from_json(concept_json)
+        return cls(concept=concept, value=value)
 
 
 class Distribution(BaseModel):

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -10,7 +10,8 @@ import sympy
 from pydantic import BaseModel, Field
 
 from .templates import *
-from .utils import safe_parse_expr
+from .units import Unit
+from .utils import safe_parse_expr, SympyExprStr
 
 
 class Initial(BaseModel):

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -381,24 +381,28 @@ class TemplateModel(BaseModel):
             for concept in template.get_concepts()
         }
 
-        initials = {
-            name: (
-                Initial(
+        initials = {}
+        for name, value in data.get('initials', {}).items():
+            if isinstance(value, float):
+                # If the data is just a float, upgrade it to
+                # a :class:`Initial` instance
+                initials[name] = Initial(
                     concept=concepts[name],
                     value=value,
                 )
-                # If the data is just a float, upgrade it to
-                # a :class:`Initial` instance
-                if isinstance(value, float)
+            else:
                 # If the data is not a float, assume it's JSON
-                # for a :class:`Initial` instance
-                else value
-            )
-            for name, value in data.get('initials', {}).items()
+                # for a :class:`Initial` instance and parse it to Initial
+                initials[name] = Initial.from_json(value)
+
+        # Handle parameters
+        parameters = {
+            par_key: Parameter.from_json(par_dict)
+            for par_key, par_dict in data.get('parameters', {}).items()
         }
 
         return cls(templates=templates,
-                   parameters=data.get('parameters', {}),
+                   parameters=parameters,
                    initials=initials,
                    annotations=data.get('annotations'))
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -7,7 +7,6 @@ __all__ = [
     "Concept",
     "Template",
     "Provenance",
-    "Unit",
     "ControlledConversion",
     "ControlledProduction",
     "ControlledDegradation",
@@ -21,7 +20,6 @@ __all__ = [
     "SympyExprStr",
     "templates_equal",
     "context_refinement",
-    "UNIT_SYMBOLS"
 ]
 
 import logging
@@ -52,7 +50,9 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
+from .units import Unit, UNIT_SYMBOLS
 from .utils import safe_parse_expr
+
 
 IS_EQUAL = "is_equal"
 REFINEMENT_OF = "refinement_of"
@@ -103,6 +103,7 @@ class SympyExprStr(sympy.Expr):
         return str(self)
 
 
+<<<<<<< HEAD
 class Unit(BaseModel):
     """A unit of measurement."""
     class Config:
@@ -119,6 +120,8 @@ class Unit(BaseModel):
     )
 
 
+=======
+>>>>>>> 6b3a24e (Reorganize units)
 class Concept(BaseModel):
     """A concept is specified by its identifier(s), name, and - optionally -
     its context.
@@ -1082,17 +1085,3 @@ def has_controller(template: Template, controller: Concept) -> bool:
         return template.controller == controller
     else:
         raise NotImplementedError
-
-
-def load_units():
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                        os.pardir, 'dkg', 'resources', 'unit_names.tsv')
-    with open(path, 'r') as fh:
-        units = {}
-        for line in fh.readlines():
-            symbol = line.strip()
-            units[symbol] = sympy.Symbol(symbol)
-    return units
-
-
-UNIT_SYMBOLS = load_units()

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -269,7 +269,9 @@ class Concept(BaseModel):
     @classmethod
     def from_json(cls, data) -> "Concept":
         # Handle Units
-        if data.get('units'):
+        if isinstance(data, Concept):
+            return data
+        elif data.get('units'):
             data['units'] = Unit.from_json(data['units'])
 
         return cls(**data)

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -48,7 +48,7 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
-from .units import Unit
+from .units import Unit, UNIT_SYMBOLS
 from .utils import safe_parse_expr, SympyExprStr
 
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -307,6 +307,12 @@ class Template(BaseModel):
             rate = safe_parse_expr(rate_str, local_dict=rate_symbols)
         else:
             rate = None
+
+        # Handle concepts
+        for concept_key in stmt_cls.concept_keys:
+            if concept_key in data:
+                data[concept_key] = Concept.from_json(data[concept_key])
+
         return stmt_cls(**{k: v for k, v in data.items()
                            if k not in {'rate_law', 'type'}},
                         rate_law=rate)
@@ -701,7 +707,6 @@ class GroupedControlledProduction(Template):
             provenance=self.provenance,
             rate_law=self.rate_law,
         )
-
 
 
 class ControlledProduction(Template):

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -78,6 +78,7 @@ DEFAULT_CONFIG = Config(
     ],
 )
 
+
 class Concept(BaseModel):
     """A concept is specified by its identifier(s), name, and - optionally -
     its context.

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -17,13 +17,11 @@ __all__ = [
     "GroupedControlledProduction",
     "GroupedControlledDegradation",
     "SpecifiedTemplate",
-    "SympyExprStr",
     "templates_equal",
     "context_refinement",
 ]
 
 import logging
-import os
 import sys
 from collections import ChainMap
 from itertools import product
@@ -50,8 +48,8 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
-from .units import Unit, UNIT_SYMBOLS
-from .utils import safe_parse_expr
+from .units import Unit
+from .utils import safe_parse_expr, SympyExprStr
 
 
 IS_EQUAL = "is_equal"
@@ -81,6 +79,7 @@ DEFAULT_CONFIG = Config(
 )
 
 
+<<<<<<< HEAD
 class SympyExprStr(sympy.Expr):
     @classmethod
     def __get_validators__(cls):
@@ -122,6 +121,8 @@ class Unit(BaseModel):
 
 =======
 >>>>>>> 6b3a24e (Reorganize units)
+=======
+>>>>>>> 3f8513d (Implement model normalization)
 class Concept(BaseModel):
     """A concept is specified by its identifier(s), name, and - optionally -
     its context.

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -102,6 +102,15 @@ class Concept(BaseModel):
     )
     _base_name: str = pydantic.PrivateAttr(None)
 
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {
+            SympyExprStr: lambda e: str(e),
+        }
+        json_decoders = {
+            SympyExprStr: lambda e: sympy.parse_expr(e)
+        }
+
     def with_context(self, do_rename=False, **context) -> "Concept":
         """Return this concept with extra context.
 
@@ -256,6 +265,14 @@ class Concept(BaseModel):
                 context_refinement(self.context, other.context)
 
         return ontological_refinement and contextual_refinement
+
+    @classmethod
+    def from_json(cls, data) -> "Concept":
+        # Handle Units
+        if data.get('units'):
+            data['units'] = Unit.from_json(data['units'])
+
+        return cls(**data)
 
 
 class Template(BaseModel):

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -78,51 +78,6 @@ DEFAULT_CONFIG = Config(
     ],
 )
 
-
-<<<<<<< HEAD
-class SympyExprStr(sympy.Expr):
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v):
-        if isinstance(v, cls):
-            return v
-        return cls(v)
-
-    @classmethod
-    def __modify_schema__(cls, field_schema):
-        field_schema.update(type="string", example="2*x")
-
-    def __str__(self):
-        return super().__str__()[len(self.__class__.__name__)+1:-1]
-
-    def __repr__(self):
-        return str(self)
-
-
-<<<<<<< HEAD
-class Unit(BaseModel):
-    """A unit of measurement."""
-    class Config:
-        arbitrary_types_allowed = True
-        json_encoders = {
-            SympyExprStr: lambda e: str(e),
-        }
-        json_decoders = {
-            SympyExprStr: lambda e: safe_parse_expr(e)
-        }
-
-    expression: SympyExprStr = Field(
-        description="The expression for the unit."
-    )
-
-
-=======
->>>>>>> 6b3a24e (Reorganize units)
-=======
->>>>>>> 3f8513d (Implement model normalization)
 class Concept(BaseModel):
     """A concept is specified by its identifier(s), name, and - optionally -
     its context.

--- a/mira/metamodel/units.py
+++ b/mira/metamodel/units.py
@@ -9,9 +9,25 @@ __all__ = [
 ]
 
 import os
+from typing import Dict, Any
+
 import sympy
 from pydantic import BaseModel, Field
 from .utils import SympyExprStr
+
+
+def load_units():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        os.pardir, 'dkg', 'resources', 'unit_names.tsv')
+    with open(path, 'r') as fh:
+        units = {}
+        for line in fh.readlines():
+            symbol = line.strip()
+            units[symbol] = sympy.Symbol(symbol)
+    return units
+
+
+UNIT_SYMBOLS = load_units()
 
 
 class Unit(BaseModel):
@@ -29,23 +45,22 @@ class Unit(BaseModel):
         description="The expression for the unit."
     )
 
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "Unit":
+        expr_str = data.get('expression')
+        if expr_str:
+            data['expression'] = sympy.parse_expr(
+                expr_str, local_dict=UNIT_SYMBOLS
+            )
+
+        assert data.get('expression') is None or not isinstance(
+            data['expression'], str
+        )
+        return cls(**data)
+
 
 person_units = Unit(expression=sympy.Symbol('person'))
 day_units = Unit(expression=sympy.Symbol('day'))
 per_day_units = Unit(expression=1/sympy.Symbol('day'))
 dimensionless_units = Unit(expression=sympy.Integer('1'))
 per_day_per_person_units = Unit(expression=1/(sympy.Symbol('day')*sympy.Symbol('person')))
-
-
-def load_units():
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                        os.pardir, 'dkg', 'resources', 'unit_names.tsv')
-    with open(path, 'r') as fh:
-        units = {}
-        for line in fh.readlines():
-            symbol = line.strip()
-            units[symbol] = sympy.Symbol(symbol)
-    return units
-
-
-UNIT_SYMBOLS = load_units()

--- a/mira/metamodel/units.py
+++ b/mira/metamodel/units.py
@@ -1,0 +1,51 @@
+__all__ = [
+    'Unit',
+    'person_units',
+    'day_units',
+    'per_day_units',
+    'dimensionless_units',
+    'per_day_per_person_units',
+    'UNIT_SYMBOLS'
+]
+
+import os
+import sympy
+from pydantic import BaseModel, Field
+from .utils import SympyExprStr
+
+
+class Unit(BaseModel):
+    """A unit of measurement."""
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {
+            SympyExprStr: lambda e: str(e),
+        }
+        json_decoders = {
+            SympyExprStr: lambda e: sympy.parse_expr(e)
+        }
+
+    expression: SympyExprStr = Field(
+        description="The expression for the unit."
+    )
+
+
+person_units = Unit(expression=sympy.Symbol('person'))
+day_units = Unit(expression=sympy.Symbol('day'))
+per_day_units = Unit(expression=1/sympy.Symbol('day'))
+dimensionless_units = Unit(expression=sympy.Integer('1'))
+per_day_per_person_units = Unit(expression=1/(sympy.Symbol('day')*sympy.Symbol('person')))
+
+
+def load_units():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        os.pardir, 'dkg', 'resources', 'unit_names.tsv')
+    with open(path, 'r') as fh:
+        units = {}
+        for line in fh.readlines():
+            symbol = line.strip()
+            units[symbol] = sympy.Symbol(symbol)
+    return units
+
+
+UNIT_SYMBOLS = load_units()

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -1,5 +1,5 @@
 __all__ = ['get_parseable_expression', 'revert_parseable_expression',
-           'safe_parse_expr']
+           'safe_parse_expr', 'SympyExprStr']
 
 import sympy
 
@@ -20,3 +20,25 @@ def safe_parse_expr(s: str, local_dict=None) -> sympy.Expr:
                             local_dict={get_parseable_expression(k): v
                                         for k, v in local_dict.items()}
                                         if local_dict else None)
+
+
+class SympyExprStr(sympy.Expr):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if isinstance(v, cls):
+            return v
+        return cls(v)
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        field_schema.update(type="string", example="2*x")
+
+    def __str__(self):
+        return super().__str__()[len(self.__class__.__name__)+1:-1]
+
+    def __repr__(self):
+        return str(self)

--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -88,7 +88,7 @@ class AskeNetPetriNetModel:
             # }
             initial = var.data.get('initial_value')
             if initial is not None:
-                if isinstance(initial, float):
+                if isinstance(initial, (float, int)):
                     initial = safe_parse_expr(str(initial))
                 initial_data = {
                     'target': name,

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -255,9 +255,13 @@ def parameter_to_mira(parameter):
     """Return a MIRA parameter from a parameter"""
     distr = Distribution(**parameter['distribution']) \
         if parameter.get('distribution') else None
-    return Parameter(name=parameter['id'],
-                     value=parameter.get('value'),
-                     distribution=distr)
+    data = {
+        "name": parameter['id'],
+        "value": parameter.get('value'),
+        "distribution": distr,
+        "units": parameter.get('units')
+    }
+    return Parameter.from_json(data)
 
 
 def transition_to_templates(transition_rate, input_concepts, output_concepts,

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -121,8 +121,10 @@ def template_model_from_askenet_json(model_json) -> TemplateModel:
             except TypeError:
                 continue
 
-            initial = Initial(concept=concepts[initial_state['target']],
-                              value=initial_val)
+            initial = Initial(
+                concept=concepts[initial_state['target']].copy(deep=True),
+                value=initial_val
+            )
             initials[initial.concept.name] = initial
 
     # We get observables from the semantics
@@ -188,9 +190,9 @@ def template_model_from_askenet_json(model_json) -> TemplateModel:
             both = set(inputs) & set(outputs)
 
         # We can now get the appropriate concepts for each group
-        input_concepts = [concepts[i] for i in inputs]
-        output_concepts = [concepts[i] for i in outputs]
-        controller_concepts = [concepts[i] for i in controllers]
+        input_concepts = [concepts[i].copy(deep=True) for i in inputs]
+        output_concepts = [concepts[i].copy(deep=True) for i in outputs]
+        controller_concepts = [concepts[i].copy(deep=True) for i in controllers]
 
         templates.extend(transition_to_templates(rate_obj,
                                                  input_concepts,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -333,6 +333,11 @@ def test_counts_to_dimensionless():
     tm.initials['susceptible_population'].value = 1e5-1
     tm.initials['infected_population'].value = 1
     tm.initials['immune_population'].value = 0
+
+    tm.parameters['beta'].units = \
+        Unit(expression=1/(sympy.Symbol('person')*sympy.Symbol('day')))
+    old_beta = tm.parameters['beta'].value
+
     for initial in tm.initials.values():
         initial.concept.units = Unit(expression=sympy.Symbol('person'))
 
@@ -340,6 +345,9 @@ def test_counts_to_dimensionless():
     for template in tm.templates:
         for concept in template.get_concepts():
             assert concept.units.expression.equals(1), concept.units
+
+    assert tm.parameters['beta'].units.expression.equals(1/sympy.Symbol('day'))
+    assert tm.parameters['beta'].value == old_beta*1e5
 
     assert tm.initials['susceptible_population'].value == (1e5-1)/1e5
     assert tm.initials['infected_population'].value == 1/1e5

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -344,9 +344,9 @@ def test_counts_to_dimensionless():
     tm = counts_to_dimensionless(tm, 'person', 1e5)
     for template in tm.templates:
         for concept in template.get_concepts():
-            assert concept.units.expression.equals(1), concept.units
+            assert concept.units.expression.args[0].equals(1), concept.units
 
-    assert tm.parameters['beta'].units.expression.equals(1/sympy.Symbol('day'))
+    assert tm.parameters['beta'].units.expression.args[0].equals(1/sympy.Symbol('day'))
     assert tm.parameters['beta'].value == old_beta*1e5
 
     assert tm.initials['susceptible_population'].value == (1e5-1)/1e5
@@ -354,4 +354,4 @@ def test_counts_to_dimensionless():
     assert tm.initials['immune_population'].value == 0
 
     for initial in tm.initials.values():
-        assert initial.concept.units.expression.equals(1)
+        assert initial.concept.units.expression.args[0].equals(1)


### PR DESCRIPTION
This PR implements an approach to normalize any unit in a model that represents an absolute count of something (e.g., population).

## todo

- [x] Add endpoint consuming mira template model
- [x] Add endpoint consuming AskePetriNet JSON