### PR TITLE
Documentation update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           pip install "tox<4.0.0"
       - name: Test with pytest
         run: |
-          export MIRA_REST_URL=https://d1t1rcuq5sa4r0.cloudfront.net
+          export MIRA_REST_URL=http://34.230.33.149:8771
           tox -e py
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,7 @@ modindex_common_prefix = ["mira."]
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_rtd_theme",
     "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -37,6 +37,12 @@ Configuration Models (:py:mod:`mira.dkg.models`)
     :members:
     :show-inheritance:
 
+Units (:py:mod:`mira.dkg.units`)
+--------------------------------
+.. automodule:: mira.dkg.units
+    :members:
+    :show-inheritance:
+
 App Utilities (:py:mod:`mira.dkg.utils`)
 ----------------------------------------
 .. automodule:: mira.dkg.utils

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -1,5 +1,8 @@
 Domain Knowledge Graph
 ======================
+
+DKG (:py:mod:`mira.dkg`)
+------------------------
 .. automodule:: mira.dkg
     :members:
     :show-inheritance:

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -40,7 +40,7 @@ Configuration Models (:py:mod:`mira.dkg.models`)
 Units (:py:mod:`mira.dkg.units`)
 --------------------------------
 .. automodule:: mira.dkg.units
-    :members:
+    :members: query_wikidata, get_unit_terms, update_unit_names_resource
     :show-inheritance:
 
 App Utilities (:py:mod:`mira.dkg.utils`)

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -6,7 +6,7 @@ Domain Knowledge Graph
 
 ASKEMO (:py:mod:`mira.dkg.askemo`)
 ----------------------------------
-.. automodule:: mira.dkg.askemo
+.. automodule:: mira.dkg.askemo.api
     :members:
     :show-inheritance:
 

--- a/docs/source/dkg.rst
+++ b/docs/source/dkg.rst
@@ -4,6 +4,12 @@ Domain Knowledge Graph
     :members:
     :show-inheritance:
 
+ASKEMO (:py:mod:`mira.dkg.askemo`)
+----------------------------------
+.. automodule:: mira.dkg.askemo
+    :members:
+    :show-inheritance:
+
 Client (:py:mod:`mira.dkg.client`)
 ----------------------------------
 .. automodule:: mira.dkg.client

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Table of Contents
    modeling
    dkg
    metaregistry
+   terarium_client
 
 Indices and Tables
 ------------------

--- a/docs/source/metamodel.rst
+++ b/docs/source/metamodel.rst
@@ -4,8 +4,8 @@ Meta-model
    :members:
    :show-inheritance:
 
-Template model
---------------
+Template model (:py:mod:`mira.metamodel.template_model`)
+--------------------------------------------------------
 .. automodule:: mira.metamodel.template_model
    :members:
    :show-inheritance:

--- a/docs/source/metamodel.rst
+++ b/docs/source/metamodel.rst
@@ -46,3 +46,15 @@ Template utilities (:py:mod:`mira.metamodel.templates`)
     :members:
     :exclude-members: Concept, ControlledConversion, NaturalConversion, Provenance, Template, NaturalDegradation, NaturalProduction, GroupedControlledConversion
     :show-inheritance:
+
+Units (:py:mod:`mira.metamodel.units`)
+--------------------------------------
+.. automodule:: mira.metamodel.units
+   :members:
+   :show-inheritance:
+
+Model utilities (:py:mod:`mira.metamodel.utils`)
+------------------------------------------------
+.. automodule:: mira.metamodel.utils
+   :members:
+   :show-inheritance:

--- a/docs/source/metamodel.rst
+++ b/docs/source/metamodel.rst
@@ -10,6 +10,13 @@ Template model (:py:mod:`mira.metamodel.template_model`)
    :members:
    :show-inheritance:
 
+Templates (:py:mod:`mira.metamodel.templates`)
+----------------------------------------------
+.. automodule:: mira.metamodel.templates
+    :members:
+    :exclude-members: Concept, ControlledConversion, NaturalConversion, Provenance, Template, NaturalDegradation, NaturalProduction, GroupedControlledConversion
+    :show-inheritance:
+
 Operations (:py:mod:`mira.metamodel.ops`)
 -----------------------------------------
 .. automodule:: mira.metamodel.ops
@@ -40,21 +47,14 @@ Model I/O (:py:mod:`mira.metamodel.io`)
    :members:
    :show-inheritance:
 
-Template utilities (:py:mod:`mira.metamodel.templates`)
--------------------------------------------------------
-.. automodule:: mira.metamodel.templates
-    :members:
-    :exclude-members: Concept, ControlledConversion, NaturalConversion, Provenance, Template, NaturalDegradation, NaturalProduction, GroupedControlledConversion
-    :show-inheritance:
-
 Units (:py:mod:`mira.metamodel.units`)
 --------------------------------------
 .. automodule:: mira.metamodel.units
    :members:
    :show-inheritance:
 
-Model utilities (:py:mod:`mira.metamodel.utils`)
-------------------------------------------------
+Utilities (:py:mod:`mira.metamodel.utils`)
+------------------------------------------
 .. automodule:: mira.metamodel.utils
    :members:
    :show-inheritance:

--- a/docs/source/modeling.rst
+++ b/docs/source/modeling.rst
@@ -27,3 +27,15 @@ Model visualization (:py:mod:`mira.modeling.viz`)
 .. automodule:: mira.modeling.viz
     :members:
     :show-inheritance:
+
+Petrinet (:py:mod:`mira.modeling.askenet.petrinet`)
+---------------------------------------------------
+.. automodule:: mira.modeling.askenet.petrinet
+    :members:
+    :show-inheritance:
+
+Regnet (:py:mod:`mira.modeling.askenet.regnet`)
+-----------------------------------------------
+.. automodule:: mira.modeling.askenet.regnet
+    :members:
+    :show-inheritance:

--- a/docs/source/modeling.rst
+++ b/docs/source/modeling.rst
@@ -4,14 +4,32 @@ Modeling
     :members:
     :show-inheritance:
 
+ASKEM AMR Petri net generation(:py:mod:`mira.modeling.askenet.petrinet`)
+------------------------------------------------------------------------
+.. automodule:: mira.modeling.askenet.petrinet
+    :members:
+    :show-inheritance:
+
+ASKEM AMR Regulatory net generation (:py:mod:`mira.modeling.askenet.regnet`)
+----------------------------------------------------------------------------
+.. automodule:: mira.modeling.askenet.regnet
+    :members:
+    :show-inheritance:
+
+Model visualization (:py:mod:`mira.modeling.viz`)
+-------------------------------------------------
+.. automodule:: mira.modeling.viz
+    :members:
+    :show-inheritance:
+
 ODE model generation and simulation (:py:mod:`mira.modeling.ode`)
 -----------------------------------------------------------------
 .. automodule:: mira.modeling.ode
     :members:
     :show-inheritance:
 
-Petri net model generation (:py:mod:`mira.modeling.petri`)
-----------------------------------------------------------
+ACSets Petri net model generation (:py:mod:`mira.modeling.petri`)
+-----------------------------------------------------------------
 .. automodule:: mira.modeling.petri
     :members:
     :show-inheritance:
@@ -22,20 +40,3 @@ Bilayer model generation (:py:mod:`mira.modeling.bilayer`)
     :members:
     :show-inheritance:
 
-Model visualization (:py:mod:`mira.modeling.viz`)
--------------------------------------------------
-.. automodule:: mira.modeling.viz
-    :members:
-    :show-inheritance:
-
-Petrinet (:py:mod:`mira.modeling.askenet.petrinet`)
----------------------------------------------------
-.. automodule:: mira.modeling.askenet.petrinet
-    :members:
-    :show-inheritance:
-
-Regnet (:py:mod:`mira.modeling.askenet.regnet`)
------------------------------------------------
-.. automodule:: mira.modeling.askenet.regnet
-    :members:
-    :show-inheritance:

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -23,14 +23,32 @@ BioModels client (:py:mod:`mira.sources.biomodels`)
     :show-inheritance:
 
 
-Petri net extraction (:py:mod:`mira.sources.petri`)
+Petri Net extraction (:py:mod:`mira.sources.petri`)
 ---------------------------------------------------
 .. automodule:: mira.sources.petri
     :members:
     :show-inheritance:
 
-Aske net (:py:mod:`mira.sources.askenet`)
+Aske Net (:py:mod:`mira.sources.askenet`)
 -----------------------------------------
 .. automodule:: mira.sources.askenet
+    :members:
+    :show-inheritance:
+
+Aske Net ODE Reconstruction (:py:mod:`mira.sources.askenet.flux_span`)
+----------------------------------------------------------------------
+.. automodule:: mira.sources.askenet.flux_span
+    :members:
+    :show-inheritance:
+
+Aske Net Petri Net (:py:mod:`mira.sources.askenet.petrinet`)
+------------------------------------------------------------
+.. automodule:: mira.sources.askenet.petrinet
+    :members:
+    :show-inheritance:
+
+Aske Net Reg Net (:py:mod:`mira.sources.askenet.regnet`)
+--------------------------------------------------------
+.. automodule:: mira.sources.askenet.regnet
     :members:
     :show-inheritance:

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -4,9 +4,27 @@ Sources of model content
     :members:
     :show-inheritance:
 
-Bilayer extraction (:py:mod:`mira.sources.bilayer`)
----------------------------------------------------
-.. automodule:: mira.sources.bilayer
+ASKEM AMR (:py:mod:`mira.sources.askenet`)
+------------------------------------------
+.. automodule:: mira.sources.askenet
+    :members:
+    :show-inheritance:
+
+ASKEM AMR Petri nets (:py:mod:`mira.sources.askenet.petrinet`)
+--------------------------------------------------------------
+.. automodule:: mira.sources.askenet.petrinet
+    :members:
+    :show-inheritance:
+
+ASKEM AMR Regulatory nets (:py:mod:`mira.sources.askenet.regnet`)
+-----------------------------------------------------------------
+.. automodule:: mira.sources.askenet.regnet
+    :members:
+    :show-inherita
+
+Reconstruct ODE semantics (:py:mod:`mira.sources.askenet.flux_span`)
+--------------------------------------------------------------------
+.. automodule:: mira.sources.askenet.flux_span
     :members:
     :show-inheritance:
 
@@ -22,33 +40,14 @@ BioModels client (:py:mod:`mira.sources.biomodels`)
     :members:
     :show-inheritance:
 
-
-Petri Net extraction (:py:mod:`mira.sources.petri`)
+Bilayer extraction (:py:mod:`mira.sources.bilayer`)
 ---------------------------------------------------
+.. automodule:: mira.sources.bilayer
+    :members:
+    :show-inheritance:
+
+ACSets Petri Net extraction (:py:mod:`mira.sources.petri`)
+----------------------------------------------------------
 .. automodule:: mira.sources.petri
-    :members:
-    :show-inheritance:
-
-Aske Net (:py:mod:`mira.sources.askenet`)
------------------------------------------
-.. automodule:: mira.sources.askenet
-    :members:
-    :show-inheritance:
-
-Aske Net ODE Reconstruction (:py:mod:`mira.sources.askenet.flux_span`)
-----------------------------------------------------------------------
-.. automodule:: mira.sources.askenet.flux_span
-    :members:
-    :show-inheritance:
-
-Aske Net Petri Net (:py:mod:`mira.sources.askenet.petrinet`)
-------------------------------------------------------------
-.. automodule:: mira.sources.askenet.petrinet
-    :members:
-    :show-inheritance:
-
-Aske Net Reg Net (:py:mod:`mira.sources.askenet.regnet`)
---------------------------------------------------------
-.. automodule:: mira.sources.askenet.regnet
     :members:
     :show-inheritance:

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -12,7 +12,7 @@ Bilayer extraction (:py:mod:`mira.sources.bilayer`)
 
 SBML extraction (:py:mod:`mira.sources.sbml`)
 ---------------------------------------------
-.. automodule:: mira.sources.sbml
+.. automodule:: mira.sources.sbml.api
     :members:
     :show-inheritance:
 

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -28,3 +28,9 @@ Petri net extraction (:py:mod:`mira.sources.petri`)
 .. automodule:: mira.sources.petri
     :members:
     :show-inheritance:
+
+Aske net (:py:mod:`mira.sources.askenet`)
+-----------------------------------------
+.. automodule:: mira.sources.askenet
+    :members:
+    :show-inheritance:

--- a/docs/source/terarium_client.rst
+++ b/docs/source/terarium_client.rst
@@ -1,0 +1,9 @@
+Terarium Client
+===============
+
+Terarium Client (:py:mod:`mira.terarium_client`)
+------------------------------------------------
+
+.. automodule:: mira.terarium_client
+    :members:
+    :show-inheritance:

--- a/mira/dkg/askemo/api.py
+++ b/mira/dkg/askemo/api.py
@@ -38,6 +38,7 @@ SYNONYM_TYPES = {
 
 
 class Term(BaseModel):
+    """A term in the ASKEMO ontology."""
     # TODO combine with dkg.client.Entity class
 
     id: str

--- a/mira/dkg/units.py
+++ b/mira/dkg/units.py
@@ -33,8 +33,15 @@ SPARQL = dedent("""\
 def query_wikidata(sparql: str) -> List[Mapping[str, Any]]:
     """Query Wikidata's sparql service.
 
-    :param sparql: A SPARQL query string
-    :return: A list of bindings
+    Parameters
+    ----------
+    sparql :
+        A SPARQL query string
+
+    Returns
+    -------
+    :
+        A list of bindings
     """
     logger.debug("running query: %s", sparql)
     res = requests.get(WIKIDATA_ENDPOINT, params={"query": sparql, "format": "json"})

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -2,6 +2,7 @@
 https://github.com/DARPA-ASKEM/Model-Representations/tree/main/petrinet.
 
 MIRA TemplateModel representation limitations to keep in mind:
+
 - Model version not supported
 - Model schema not supported
 - Initials only have a value, cannot be expressions so information on

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ docs =
     bioontologies
     biomappings
     sphinx<7.0.0
-    sphinx-rtd-theme
+    sphinx-rtd-theme>=0.5.1
     sphinx-autodoc-typehints
     sphinx-automodapi
     autodoc-pydantic

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ gunicorn =
 docs =
     bioregistry
     bioontologies
+    biomappings
     sphinx<7.0.0
     sphinx-rtd-theme
     sphinx-autodoc-typehints


### PR DESCRIPTION
This PR does a significant update to the documentation for Mira to add missing modules and fix paths after submodules have moved.

See the latest docs build for this branch at https://miramodel.readthedocs.io/en/fix-docs/index.html