### PR TITLE
ID indexing on nodes

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -3,6 +3,11 @@ neo4j start
 sleep 100
 neo4j status
 
+# Index nodes on id property
+python -m mira.dkg.indexing --exist-ok
+
+# Start the service
+
 if [ "${ROOT_PATH}" ]; then
   echo "Running with root path set to ${ROOT_PATH}"
   uvicorn --host 0.0.0.0 --port 8771 mira.dkg.wsgi:app --root-path "${ROOT_PATH}"

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -287,6 +287,55 @@ class Neo4jClient:
 
         return values
 
+    def create_tx(self, query: str, **query_params):
+        """Run a query that creates nodes and/or relations.
+
+        Parameters
+        ----------
+        query :
+            The query string to be executed.
+        query_params :
+            The parameters to be used in the query.
+
+        Returns
+        -------
+        :
+            The result of the query
+        """
+        with self.driver.session() as session:
+            return session.write_transaction(do_cypher_tx,
+                                             query,
+                                             **query_params)
+
+    def create_single_property_node_index(
+        self,
+        index_name: str,
+        label: str,
+        property_name: str,
+        exist_ok: bool = False
+    ):
+        """Create a single-property node index.
+
+        Parameters
+        ----------
+        index_name :
+            The name of the index to create.
+        label :
+            The label of the nodes to index.
+        property_name :
+            The node property to index.
+        exist_ok :
+            If True, do not raise an exception if the index already exists.
+            Default: False.
+        """
+        if_not = " IF NOT EXISTS" if exist_ok else ""
+        query = (
+            f"CREATE INDEX {index_name}{if_not} "
+            f"FOR (n:{label}) ON (n.{property_name})"
+        )
+
+        self.create_tx(query)
+
     def query_nodes(self, query: str) -> List[Node]:
         """Run a read-only query for nodes.
 

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -264,7 +264,7 @@ class Neo4jClient:
             return curie
         return name.lower().replace(" ", "_")
 
-    def query_tx(self, query: str) -> Optional[TxResult]:
+    def query_tx(self, query: str, **query_params) -> Optional[TxResult]:
         # See the Session Construction section and the Session section
         # immediately following it at:
         # https://neo4j.com/docs/api/python-driver/current/api.html#session-construction
@@ -281,7 +281,9 @@ class Neo4jClient:
             # As stated here, using a context manager allows for the
             # transaction to be rolled back when an exception is raised
             # https://neo4j.com/docs/api/python-driver/current/api.html#explicit-transactions
-            values = session.read_transaction(do_cypher_tx, query)
+            values = session.read_transaction(do_cypher_tx,
+                                              query,
+                                              **query_params)
 
         return values
 
@@ -571,7 +573,7 @@ class Neo4jClient:
 def do_cypher_tx(
         tx: Transaction,
         query: str,
-        query_params: Optional[Dict] = None
+        **query_params
 ) -> List[List]:
     result = tx.run(query, parameters=query_params)
     return [record.values() for record in result]

--- a/mira/dkg/indexing/__init__.py
+++ b/mira/dkg/indexing/__init__.py
@@ -1,0 +1,32 @@
+import time
+
+from tqdm import tqdm
+
+from mira.dkg.client import Neo4jClient
+
+
+def index_nodes_on_id(client: Neo4jClient, exist_ok: bool = False):
+    """Index all nodes on the id property
+
+    Parameters
+    ----------
+    client :
+        Neo4jClient instance to the graph database to be indexed
+    exist_ok :
+        If False, raise an exception if the index already exists. Default: False.
+    """
+    # A label has to be provided to build the index, so we have to loop over
+    # all labels and build the index for each one.
+    labels = [
+        ll[0]
+        for ll in client.query_tx("CALL db.labels() YIELD label RETURN label")
+    ]
+    for label in tqdm(labels, desc="Indexing nodes on id", unit="label"):
+        client.create_single_property_node_index(
+            index_name=f"node_id_{label.lower()}",
+            label=label,
+            property_name="id",
+            exist_ok=exist_ok,
+        )
+        # Wait a bit just to be on the safe side
+        time.sleep(0.1)

--- a/mira/dkg/indexing/__init__.py
+++ b/mira/dkg/indexing/__init__.py
@@ -21,6 +21,7 @@ def index_nodes_on_id(client: Neo4jClient, exist_ok: bool = False):
         ll[0]
         for ll in client.query_tx("CALL db.labels() YIELD label RETURN label")
     ]
+    print(f"Indexing nodes on id property for the following labels: {labels}")
     for label in tqdm(labels, desc="Indexing nodes on id", unit="label"):
         client.create_single_property_node_index(
             index_name=f"node_id_{label.lower()}",

--- a/mira/dkg/indexing/__main__.py
+++ b/mira/dkg/indexing/__main__.py
@@ -1,0 +1,8 @@
+# -*- coding -*-: utf-8
+
+"""Run the database indexing using ``python -m mira.dkg.indexing``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/mira/dkg/indexing/cli.py
+++ b/mira/dkg/indexing/cli.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""Run the database indexing"""
+import click
+
+
+@click.command(name="indexing")
+@click.option(
+    "--exist-ok",
+    is_flag=True,
+    help="If set, skip already set indices silently, otherwise an exception "
+         "is raised if attempting to set an index that already exists.",
+)
+def main(exist_ok: bool = False):
+    """Build indexes on the database."""
+    from . import index_nodes_on_id
+    from mira.dkg.client import Neo4jClient
+
+    client = Neo4jClient()
+    click.secho("Indexing all nodes on the id property.", fg="green")
+    index_nodes_on_id(client, exist_ok=exist_ok)


### PR DESCRIPTION
This PR sets up the functions needed to index nodes and adds a script that creates an index on the id property for all nodes.

The script that adds the index is added to the docker startup shell script so that it's run on startup.