### PR TITLE
Handle static states

### DIFF
--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -481,6 +481,44 @@
         "subject"
       ]
     },
+    "StaticConcept": {
+      "title": "StaticConcept",
+      "description": "Specifies a standalone Concept.",
+      "type": "object",
+      "properties": {
+        "rate_law": {
+          "title": "Rate Law",
+          "type": "string",
+          "example": "2*x"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "type": {
+          "title": "Type",
+          "default": "StaticConcept",
+          "const": "StaticConcept",
+          "enum": [
+            "StaticConcept"
+          ],
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/definitions/Concept"
+        },
+        "provenance": {
+          "title": "Provenance",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Provenance"
+          }
+        }
+      },
+      "required": [
+        "subject"
+      ]
+    },
     "Distribution": {
       "title": "Distribution",
       "description": "A distribution of values for a parameter.",
@@ -838,7 +876,8 @@
                 "NaturalProduction": "#/definitions/NaturalProduction",
                 "ControlledProduction": "#/definitions/ControlledProduction",
                 "GroupedControlledConversion": "#/definitions/GroupedControlledConversion",
-                "GroupedControlledProduction": "#/definitions/GroupedControlledProduction"
+                "GroupedControlledProduction": "#/definitions/GroupedControlledProduction",
+                "StaticConcept": "#/definitions/StaticConcept"
               }
             },
             "oneOf": [
@@ -868,6 +907,9 @@
               },
               {
                 "$ref": "#/definitions/GroupedControlledProduction"
+              },
+              {
+                "$ref": "#/definitions/StaticConcept"
               }
             ]
           }

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -704,6 +704,8 @@ def _iter_concepts(template_model: TemplateModel):
         elif isinstance(template, GroupedControlledDegradation):
             yield from template.controllers
             yield template.subject
+        elif isinstance(template, StaticConcept):
+            yield template.subject
         else:
             raise TypeError(f"could not handle template: {template}")
 

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -145,6 +145,11 @@ class Model:
                                        placeholder=False))
 
         for template in self.template_model.templates:
+            if isinstance(template, StaticConcept):
+                self.assemble_variable(template.subject,
+                                       self.template_model.initials)
+                continue
+
             # Handle subjects
             if has_subject(template):
                 s = self.assemble_variable(template.subject,

--- a/tests/test_modeling/test_askenet.py
+++ b/tests/test_modeling/test_askenet.py
@@ -136,6 +136,16 @@ def test_static_states():
     assert len(aj['model']['states']) == 4
     assert aj['model']['states'][-1]['id'] == 'X'
 
+    tm2 = stratify(
+        tm,
+        key='age',
+        strata=['young', 'old'],
+        structure=[],
+        concepts_to_stratify={'X'}
+    )
+    assert tm2.get_concepts_by_name('X_young') is not None
+    assert tm2.get_concepts_by_name('X_old') is not None
+
 
 def test_lambda():
     """Make sure we can go end-to-end and correctly represent lambda as a parameter"""

--- a/tests/test_modeling/test_askenet.py
+++ b/tests/test_modeling/test_askenet.py
@@ -105,6 +105,38 @@ def test_validate_example():
         ) from e
 
 
+def test_static_states():
+    model_url = ('https://raw.githubusercontent.com/DARPA-ASKEM/'
+                 'Model-Representations/main/petrinet/examples/sir.json')
+    model_json = requests.get(model_url).json()
+    model_json['model']['states'].append(
+        {
+            "id": "X",
+            "name": "Isolated",
+            "description": "Individuals that don't interact with anyone",
+            "grounding": {
+                "identifiers": {
+                    "ido": "12345"
+                }
+            },
+            "units": {
+                "expression": "person",
+                "expression_mathml": "<ci>person</ci>"
+            }
+        }
+    )
+    tm = template_model_from_askenet_json(model_json)
+    assert len(tm.templates) == 3
+    assert isinstance(tm.templates[-1], StaticConcept)
+    assert tm.templates[-1].subject.name == 'X'
+    model = Model(tm)
+    assert ('X', ('identity', 'ido:12345')) in model.variables
+    am = AskeNetPetriNetModel(model)
+    aj = am.to_json()
+    assert len(aj['model']['states']) == 4
+    assert aj['model']['states'][-1]['id'] == 'X'
+
+
 def test_lambda():
     """Make sure we can go end-to-end and correctly represent lambda as a parameter"""
     amr_model = {


### PR DESCRIPTION
This PR implements handling of static states to make sure we can fully represent and propagate states from Petri nets that aren't taking part in any transitions. After weighing some options, the best approach here seemed to be to use a template class so that these states can be represented as inherent parts of the model structure and handled along with other templates.