### PR TITLE
Fix documentation build; add link to MIRA-DB

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,15 @@ MIRA is a framework for representing systems using ontology-grounded **meta-mode
 * Benchmarking the efficacy of DKG groundings on a set of COVID EPI Models: 
   [Notebook 11](https://github.com/gyorilab/mira/blob/main/notebooks/hackathon_2023.10/dkg_grounding_model_comparison.ipynb)
 
+## MIRA-DB
+
+MIRA-DB is a structured database and web explorer for epidemiological ODE
+models extracted from scientific literature. It provides a PostgreSQL backend
+for storing MIRA `TemplateModel` representations along with their source
+metadata, and a web application for browsing, searching, and inspecting
+models and their grounded components. See more on [epimodels.io](https://epimodels.io)
+and on GitHub [MIRA-DB] (https://github.com/gyorilab/miradb).
+
 ## Related work
 
 MIRA builds on and generalizes prior work including:

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,7 @@ docs =
     autodoc-pydantic
     m2r2
     pygraphviz
-    pyobo<0.11
+    pyobo>=0.12.0
     mock
     wget
 sbml =

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,7 @@ install_requires =
     pysd
     more_itertools
     indra @ git+https://github.com/gyorilab/indra.git@master
-    # waiting for the branch below to be merged into pysb and for a new version of pysb to be released
-    # to make it compatible with sympy>=1.12.0
-    pysb @ git+https://github.com/jmuhlich/pysb.git@sympy-numpy-update
+    pysb @ git+https://github.com/pysb/pysb.git
     decorator>=5.0.0
 
 zip_safe = false


### PR DESCRIPTION
This PR updates a pin for pyobo which prevented the documentation to be built on readthedocs.

The README is also updated with a section about MIRA-DB and links to its GitHub repository and epimodels.io.