### PR TITLE
Updating OpenAI client to accept parameters

### DIFF
--- a/mira/openai_utility/client.py
+++ b/mira/openai_utility/client.py
@@ -16,12 +16,12 @@ class OpenAIClient:
             api_key: str = None, 
             model: str = "gpt-4o-mini", 
             temperature: float = None,
-            max_tokens: int = MAX_TOKENS
+            max_completion_tokens: int = MAX_TOKENS
     ):
         self.client = OpenAI(api_key=api_key)
         self.model = model
         self.temperature = temperature
-        self.max_tokens = max_tokens
+        self.max_completion_tokens = max_completion_tokens
         self.total_input_tokens = 0
         self.total_output_tokens = 0
         # instructions, systerm_prompt, reasoning
@@ -115,7 +115,7 @@ class OpenAIClient:
                     "content": content,
                 }
             ],
-            "max_tokens": self.max_tokens,
+            "max_completion_tokens": self.max_completion_tokens,
         }
 
         if self.temperature is not None:
@@ -191,7 +191,7 @@ class OpenAIClient:
                     "content": content,
                 }
             ],
-            "max_tokens": self.max_tokens,
+            "max_completion_tokens": self.max_completion_tokens,
         }
 
         if self.temperature is not None:
@@ -248,7 +248,7 @@ class OpenAIClient:
                     "content": content,
                 }
             ],
-            "max_tokens": self.max_tokens,
+            "max_completion_tokens": self.max_completion_tokens,
         }
 
         if self.temperature is not None:
@@ -298,7 +298,7 @@ class OpenAIClient:
                     "content": content,
                 }
             ],
-            "max_tokens": self.max_tokens,
+            "max_completion_tokens": self.max_completion_tokens,
         }
 
         if self.temperature is not None:
@@ -353,7 +353,7 @@ class OpenAIClient:
                     "content": content,
                 }
             ],
-            "max_tokens": self.max_tokens,
+            "max_completion_tokens": self.max_completion_tokens,
         }
 
         if self.temperature is not None:

--- a/mira/openai_utility/client.py
+++ b/mira/openai_utility/client.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Literal, Union, List
+from typing import Literal, Optional, Union, List
 
 from openai import OpenAI
 
@@ -11,14 +11,77 @@ MAX_TOKENS = 2048
 
 class OpenAIClient:
 
-    def __init__(self, api_key: str = None):
+    def __init__(
+            self, 
+            api_key: str = None, 
+            model: str = "gpt-4o-mini", 
+            temperature: float = None,
+            max_tokens: int = MAX_TOKENS
+    ):
         self.client = OpenAI(api_key=api_key)
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        # instructions, systerm_prompt, reasoning
+ 
+    def _track_usage(
+            self, 
+            response
+    ) -> None:
+        """Accumulate token usage from a response object.
+ 
+        Parameters
+        ----------
+        response :
+            The raw response object returned by chat.completions.create.
+        """
+        if response.usage:
+            self.total_input_tokens += response.usage.prompt_tokens
+            self.total_output_tokens += response.usage.completion_tokens
 
+
+    def _add_response_schema(
+        self,
+        kwargs: dict,
+        schema: dict | None,
+        strict: bool = True,
+    ) -> None:
+        """Add the response format schema to the kwargs for chat completion
+
+        Parameters
+        ----------
+        kwargs :
+            The kwargs to pass to chat completion
+        schema :
+            The schema to use for the response format. 
+        strict :
+            Whether to enforce the schema strictly.
+        """
+        if schema is None:
+            return
+
+        kwargs["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "response",
+                "schema": schema,
+                "strict": strict,
+            },
+        }
+
+    def reset_token_counts(self):
+        """Reset the session token counters to zero."""
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+
+        
     def run_chat_completion(
         self,
         message: str,
-        model: str = "gpt-4o-mini",
-        max_tokens: int = MAX_TOKENS,
+        schema: Optional[dict] = None,
+        strict: Optional[bool] = True,
     ):
         """Run the OpenAI chat completion
 
@@ -26,12 +89,10 @@ class OpenAIClient:
         ----------
         message :
           The prompt to send for chat completion
-        model :
-            The model to use. The default is the gpt-4o-mini model.
-        max_tokens :
-            The maximum number of tokens to generate for chat completion. One
-            token is roughly one word in plain text, however it can be more per
-            word in some cases. The default is 150.
+        schema :
+            The schema to use for the response format.
+        strict :
+            Whether to enforce the schema strictly.
 
         Returns
         -------
@@ -39,21 +100,30 @@ class OpenAIClient:
             The response from OpenAI as a string.
         """
 
-        response = self.client.chat.completions.create(
-            model=model,
-            messages=[
+        content = [
+                    {
+                        "type": "text",
+                        "text": message,
+                    }
+                ]
+        
+        kwargs = {
+            "model": self.model,
+            "messages": [
                 {
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": message,
-                        }
-                    ],
+                    "content": content,
                 }
             ],
-            max_tokens=max_tokens,
-        )
+            "max_tokens": self.max_tokens,
+        }
+
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+
+        self._add_response_schema(kwargs, schema, strict)
+        response = self.client.chat.completions.create(**kwargs)
+        self._track_usage(response)
         return response.choices[0]
 
     def run_chat_completion_with_image(
@@ -61,8 +131,8 @@ class OpenAIClient:
         message: str,
         image_format: Union[ImageFmts, List[ImageFmts]],
         base64_image: Union[str, List[str]],
-        model: str = "gpt-4o-mini",
-        max_tokens: int = MAX_TOKENS,
+        schema: Optional[dict] = None,
+        strict: Optional[bool] = True,
     ):
         """Run the OpenAI chat completion with an image or a list of images
 
@@ -78,86 +148,65 @@ class OpenAIClient:
         image_format :
             The format of the image. The default is "jpeg". Currently supports
             "jpeg", "jpg", "png", "webp", "gif". GIF images cannot be animated.
-        max_tokens :
-            The maximum number of tokens to generate for chat completion. One
-            token is roughly one word in plain text, however it can be more per
-            word in some cases. The default is 150.
+        schema :
+            The schema to use for the response format.
+        strict :
+            Whether to enforce the schema strictly.
 
         Returns
         -------
         :
             The response from OpenAI as a string.
         """
-        if not isinstance(image_format,List):
-            if image_format not in ALLOWED_FORMATS:
+
+        if not isinstance(image_format, list):
+            image_format = [image_format]
+            base64_image = [base64_image]
+
+        for fmt in image_format:
+            if fmt not in ALLOWED_FORMATS:
                 raise ValueError(
-                    f"Image format {image_format} not supported."
+                    f"Image format {fmt} not supported. "
                     f"Supported formats are {ALLOWED_FORMATS}"
                 )
-            response = self.client.chat.completions.create(
-                model=model,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": message,
-                            },
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    # Supports PNG, JPEG, WEBP, non-animated GIF
-                                    "url": f"data:image/{image_format};base64,{base64_image}",
-                                    "detail": "high"
-                                },
-                            },
-                        ],
-                    }
-                ],
-                max_tokens=max_tokens,
-            )
-        else:
-            for fmt in image_format:
-                if fmt not in ALLOWED_FORMATS:
-                    raise ValueError(
-                        f"Image format {fmt} not supported."
-                        f"Supported formats are {ALLOWED_FORMATS}"
-                    )
-            response = self.client.chat.completions.create(
-                model=model,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": message,
-                            },
-                            *[
-                                {
-                                    "type": "image_url",
-                                    "image_url": {
-                                        "url": f"data:image/{fmt};base64,{img}",
-                                        "detail": "high"
-                                    }
-                                }
-                                for img, fmt in zip(base64_image, image_format)
-                            ]
-                        ],
-                    }
-                ],
-                max_tokens=max_tokens,
-            )
+        content = [
+                    {"type": "text", "text": message},
+                    *[
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/{fmt};base64,{img}",
+                                "detail": "high"
+                            }
+                        }
+                        for img, fmt in zip(base64_image, image_format)
+                    ]
+                ]
 
+        kwargs = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": content,
+                }
+            ],
+            "max_tokens": self.max_tokens,
+        }
+
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        self._add_response_schema(kwargs, schema, strict)
+        response = self.client.chat.completions.create(**kwargs)
+        self._track_usage(response)
         return response.choices[0]
 
     def run_chat_completion_with_pdf(
         self,
         message: str,
         base64_pdf: str,
-        model: str = "gpt-4o",
-        max_tokens: int = MAX_TOKENS,
+        schema: Optional[dict] = None,
+        strict: Optional[bool] = True,
     ):
         """Run the OpenAI chat completion with a PDF file
 
@@ -167,46 +216,54 @@ class OpenAIClient:
             The prompt to send for chat completion together with the PDF
         base64_pdf :
             The PDF data as a base64 string
-        model :
-            The model to use. The default is gpt-4o.
-        max_tokens :
-            The maximum number of tokens to generate for chat completion.
+        schema :
+            The schema to use for the response format.
+        strict :
+            Whether to enforce the schema strictly.
 
         Returns
         -------
         :
             The response from OpenAI as a string
         """
-        response = self.client.chat.completions.create(
-            model=model,
-            messages=[
+        content = [
+                        {
+                        "type": "text",
+                        "text": message,
+                    },
+                    {
+                        "type": "file",
+                        "file": {
+                            "filename": "document.pdf",
+                            "file_data": f"data:application/pdf;base64,{base64_pdf}",
+                        },
+                    },
+                ]
+        
+        kwargs = {
+            "model": self.model,
+            "messages": [
                 {
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": message,
-                        },
-                        {
-                            "type": "file",
-                            "file": {
-                                "filename": "document.pdf",
-                                "file_data": f"data:application/pdf;base64,{base64_pdf}",
-                            },
-                        },
-                    ],
+                    "content": content,
                 }
             ],
-            max_tokens=max_tokens,
-        )
+            "max_tokens": self.max_tokens,
+        }
+
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        self._add_response_schema(kwargs, schema, strict)
+        response = self.client.chat.completions.create(**kwargs)
+        self._track_usage(response)
         return response.choices[0]
 
     def run_chat_completion_with_text(
         self,
         message: str,
         text_content: str,
-        model: str = "gpt-4o-mini",
-        max_tokens: int = MAX_TOKENS,
+        schema: Optional[dict] = None,
+        strict: Optional[bool] = True,
     ):
         """Run the OpenAI chat completion with input text
 
@@ -216,38 +273,47 @@ class OpenAIClient:
             The prompt to send for chat completion together with the PDF
         text_content :
             The input text
-        model :
-            The model to use. The default is gpt-4o.
-        max_tokens :
-            The maximum number of tokens to generate for chat completion.
+        schema :
+            The schema to use for the response format.
+        strict :
+            Whether to enforce the schema strictly.
 
         Returns
         -------
-
+        :
+            The response from OpenAI as a string
         """
-        response = self.client.chat.completions.create(
-            model=model,
-            messages=[
+        content = [
+                    {
+                        "type": "text",
+                        "text": f"{message}\n\n{text_content}" ,
+                    },
+                ]
+        
+        kwargs = {
+            "model": self.model,
+            "messages": [
                 {
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"{message}\n\n{text_content}" ,
-                        },
-                    ],
+                    "content": content,
                 }
             ],
-            max_tokens=max_tokens,
-        )
+            "max_tokens": self.max_tokens,
+        }
+
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        self._add_response_schema(kwargs, schema, strict)
+        response = self.client.chat.completions.create(**kwargs)
+        self._track_usage(response)
         return response.choices[0].message.content
 
     def run_chat_completion_with_image_url(
         self,
         message: str,
         image_url: str,
-        model: str = "gpt-4o-mini",
-        max_tokens: int = MAX_TOKENS,
+        schema: Optional[dict] = None,
+        strict: Optional[bool] = True,
     ):
         """Run the OpenAI chat completion with an image URL
 
@@ -257,41 +323,45 @@ class OpenAIClient:
           The prompt to send for chat completion together with the image
         image_url :
           The URL of the image
-        model :
-            The model to use. The default is the gpt-4o-mini model.
-        max_tokens :
-            The maximum number of tokens to generate for chat completion. One
-            token is roughly one word in plain text, however it can be more per
-            word in some cases. The default is 150.
+        schema :
+            The schema to use for the response format.
+        strict :
+            Whether to enforce the schema strictly.
 
         Returns
         -------
         :
             The response from OpenAI
         """
-        response = self.client.chat.completions.create(
-            model=model,
-            messages=[
+        content = [
+                    {
+                        "type": "text",
+                        "text": message,
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": image_url,
+                        },
+                    },
+                ]
+        kwargs = {
+            "model": self.model,
+            "messages": [
                 {
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": message,
-                        },
-                        {
-                            "type": "image_url",
-                            "image_url": {
-                                "url": image_url,
-                            },
-                        },
-                    ],
+                    "content": content,
                 }
             ],
-            max_tokens=max_tokens,
-        )
-        return response.choices[0]
+            "max_tokens": self.max_tokens,
+        }
 
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        self._add_response_schema(kwargs, schema, strict)
+        response = self.client.chat.completions.create(**kwargs)
+        self._track_usage(response)
+        return response.choices[0]  
 
 # encode an image file
 def encode_image(image_path: str):

--- a/mira/sources/sympy_ode/paper_extraction.py
+++ b/mira/sources/sympy_ode/paper_extraction.py
@@ -40,7 +40,8 @@ def get_pmid_pmc_download_mapping():
 
 def get_template_model_from_pmid(pmid: str, extractor: str = "mineru",
                                  ode_extraction_method: ExtractionMethod = "text",
-                                 pmid_to_download_mapping=None) -> Tuple[TemplateModel, str]:
+                                 pmid_to_download_mapping=None, client=None) \
+        -> Tuple[TemplateModel, str]:
     """
     Return a template model and the accompanying ODE string retrieved from a
     PubMed article representing an epidemiological model
@@ -56,6 +57,9 @@ def get_template_model_from_pmid(pmid: str, extractor: str = "mineru",
         equations (i.e. text or images).
     pmid_to_download_mapping :
         A dictionary mapping pmids to their corresponding download paths.
+    client :
+        An instance of the OpenAIClient to use for LLM interactions. If None,
+        a default client will be created.
 
     Returns
     -------
@@ -65,7 +69,8 @@ def get_template_model_from_pmid(pmid: str, extractor: str = "mineru",
         The pipeline result containing the extracted ODEs, corrected ODEs,
         grounded concepts and the path to the file used for extraction.
     """
-    client = OpenAIClient(model="gpt-5.4-mini", temperature=0.2)
+    if client is None:
+        client = OpenAIClient(model="gpt-5.4-mini", temperature=0.2)
 
     paper_base = BASE.join(pmid)
 

--- a/mira/sources/sympy_ode/paper_extraction.py
+++ b/mira/sources/sympy_ode/paper_extraction.py
@@ -17,9 +17,6 @@ from mira.sources.sympy_ode.llm_util import (
     execute_template_model_from_sympy_odes,
 )
 
-import sys
-sys.path.insert(0, "/Users/mohbe.r/Documents/CODE/NEU/mira")
-
 from mira.openai_utility import OpenAIClient
 from mira.metamodel import TemplateModel
 

--- a/mira/sources/sympy_ode/paper_extraction.py
+++ b/mira/sources/sympy_ode/paper_extraction.py
@@ -16,6 +16,10 @@ from mira.sources.sympy_ode.extractors import (
 from mira.sources.sympy_ode.llm_util import (
     execute_template_model_from_sympy_odes,
 )
+
+import sys
+sys.path.insert(0, "/Users/mohbe.r/Documents/CODE/NEU/mira")
+
 from mira.openai_utility import OpenAIClient
 from mira.metamodel import TemplateModel
 
@@ -64,7 +68,7 @@ def get_template_model_from_pmid(pmid: str, extractor: str = "mineru",
         The pipeline result containing the extracted ODEs, corrected ODEs,
         grounded concepts and the path to the file used for extraction.
     """
-    client = OpenAIClient()
+    client = OpenAIClient(model="gpt-5.4-mini", temperature=0.2)
 
     paper_base = BASE.join(pmid)
 


### PR DESCRIPTION
This PR updates the openai client to now accept parameters. 

**Updates:**
Allows users to:
- Assign gpt model
- Set temperature (reproducibility of llm output)
- Send customs schema to structure llm outputs
- Track input/output token usage