### PR TITLE
Add Marker parameter extraction utility

### DIFF
--- a/json_to_readable_docx.py
+++ b/json_to_readable_docx.py
@@ -1,0 +1,216 @@
+import json
+from pathlib import Path
+from docx import Document
+from docx.enum.section import WD_ORIENT
+from docx.enum.table import WD_TABLE_ALIGNMENT, WD_CELL_VERTICAL_ALIGNMENT
+from docx.enum.text import WD_BREAK
+from docx.shared import Inches, Pt
+
+
+INPUT_FOLDER = Path(
+    "../miradb/table_extraction_eval/results/structured_outputs_v2"
+)
+
+OUTPUT_FILE = Path(
+    "../miradb/table_extraction_eval/results/"
+    "Structured_Parameter_Extraction_Report.docx"
+)
+
+
+def safe_text(value):
+    if value is None:
+        return "-"
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value)
+    return str(value)
+
+
+def evidence_text(evidence):
+    if not evidence:
+        return "-"
+
+    entries = []
+    for item in evidence:
+        table = item.get("source_table", "-")
+        row = item.get("source_row", "-")
+        column = item.get("source_column")
+
+        text = f"{table}, row {row}"
+        if column:
+            text += f", column {column}"
+
+        entries.append(text)
+
+    return "; ".join(entries)
+
+
+def set_cell_text(cell, text, bold=False, font_size=8):
+    cell.text = ""
+    paragraph = cell.paragraphs[0]
+    run = paragraph.add_run(safe_text(text))
+    run.bold = bold
+    run.font.size = Pt(font_size)
+    cell.vertical_alignment = WD_CELL_VERTICAL_ALIGNMENT.TOP
+
+
+def add_summary(document, data):
+    document.add_paragraph(
+        f"Contains parameter information: "
+        f"{data.get('contains_parameter_information', False)}"
+    )
+
+    parameters = data.get("parameters", [])
+
+    parameter_count = sum(
+        p.get("value_type") == "parameter"
+        for p in parameters
+    )
+    initial_count = sum(
+        p.get("value_type") == "initial_condition"
+        for p in parameters
+    )
+    definition_count = sum(
+        p.get("value_type") == "definition_only"
+        for p in parameters
+    )
+
+    document.add_paragraph(f"Total extracted records: {len(parameters)}")
+    document.add_paragraph(f"Model parameters: {parameter_count}")
+    document.add_paragraph(f"Initial conditions: {initial_count}")
+    document.add_paragraph(f"Definition-only records: {definition_count}")
+
+    notes = data.get("notes")
+    if notes:
+        document.add_paragraph(f"Notes: {notes}")
+
+
+def add_parameter_table(document, parameters):
+    headers = [
+        "No.",
+        "Symbol",
+        "Parameter name",
+        "Description",
+        "Value",
+        "Unit",
+        "Range",
+        "Uncertainty",
+        "Prior",
+        "Source",
+        "Type",
+        "Context",
+        "Evidence",
+    ]
+
+    table = document.add_table(rows=1, cols=len(headers))
+    table.alignment = WD_TABLE_ALIGNMENT.CENTER
+    table.style = "Table Grid"
+
+    for index, header in enumerate(headers):
+        set_cell_text(
+            table.rows[0].cells[index],
+            header,
+            bold=True,
+            font_size=8,
+        )
+
+    for number, parameter in enumerate(parameters, start=1):
+        row = table.add_row().cells
+
+        uncertainty = safe_text(parameter.get("uncertainty"))
+        uncertainty_type = parameter.get("uncertainty_type")
+
+        if uncertainty != "-" and uncertainty_type:
+            uncertainty = f"{uncertainty_type}: {uncertainty}"
+
+        values = [
+            number,
+            parameter.get("symbol"),
+            parameter.get("parameter_name"),
+            parameter.get("description"),
+            parameter.get("value"),
+            parameter.get("unit"),
+            parameter.get("range"),
+            uncertainty,
+            parameter.get("prior"),
+            parameter.get("source"),
+            parameter.get("value_type"),
+            parameter.get("context"),
+            evidence_text(parameter.get("evidence")),
+        ]
+
+        for index, value in enumerate(values):
+            set_cell_text(row[index], value, font_size=7)
+
+    return table
+
+
+def main():
+    json_files = sorted(INPUT_FOLDER.glob("*.json"))
+
+    if not json_files:
+        raise FileNotFoundError(
+            f"No JSON files found in {INPUT_FOLDER.resolve()}"
+        )
+
+    document = Document()
+
+    section = document.sections[0]
+    section.orientation = WD_ORIENT.LANDSCAPE
+    section.page_width, section.page_height = (
+        section.page_height,
+        section.page_width,
+    )
+    section.top_margin = Inches(0.45)
+    section.bottom_margin = Inches(0.45)
+    section.left_margin = Inches(0.35)
+    section.right_margin = Inches(0.35)
+
+    title = document.add_heading(
+        "Structured Parameter Extraction Report",
+        level=0,
+    )
+    title.alignment = 1
+
+    document.add_paragraph(
+        "OpenAI Structured Outputs results for selected biomedical "
+        "modeling papers. Missing values are shown as '-'."
+    )
+
+    document.add_heading("Papers included", level=1)
+
+    for path in json_files:
+        document.add_paragraph(path.stem, style="List Bullet")
+
+    for file_index, json_path in enumerate(json_files):
+        if file_index > 0:
+            document.add_page_break()
+
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        pmid = data.get("pmid", json_path.stem)
+
+        document.add_heading(f"PMID {pmid}", level=1)
+
+        model = data.get("model")
+        if model:
+            document.add_paragraph(f"Model used: {model}")
+
+        add_summary(document, data)
+
+        parameters = data.get("parameters", [])
+
+        if parameters:
+            document.add_heading("Extracted records", level=2)
+            add_parameter_table(document, parameters)
+        else:
+            document.add_paragraph(
+                "No model parameter information was extracted."
+            )
+
+    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    document.save(OUTPUT_FILE)
+
+    print(f"Created: {OUTPUT_FILE.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mira/sources/sympy_ode/marker_parameter_extraction.py
+++ b/mira/sources/sympy_ode/marker_parameter_extraction.py
@@ -1,9 +1,18 @@
 """
-Marker parameter table extraction.
+Marker parameter table extraction utility.
 
-This script reads Marker HTML output, finds the parameter table using
-string matching, extracts only the parameter rows, normalizes parameter
-symbols, and writes the result to a CSV file.
+This script extracts parameter tables from Marker HTML output.
+
+It supports:
+1. Single-file extraction
+2. Batch-folder extraction
+
+Main idea:
+- Convert Marker HTML into pipe-separated text.
+- Find table sections whose captions look parameter-related.
+- Extract 5-column parameter rows:
+  parameter | definition | value | standard_deviation | source
+- Also support shorter 4-column and 3-column parameter tables.
 """
 
 import argparse
@@ -12,7 +21,7 @@ import re
 from dataclasses import asdict, dataclass
 from html import unescape
 from pathlib import Path
-from typing import List
+from typing import Iterable, List, Optional
 
 
 @dataclass
@@ -28,9 +37,8 @@ class ParameterRow:
     raw_parameter: str
 
 
-def clean_text(text: str) -> str:
-    """Basic text cleanup."""
-    text = unescape(text)
+def clean_cell(text: str) -> str:
+    text = unescape(str(text))
     text = text.replace("\xa0", " ")
     text = text.replace("×", "x")
     text = text.replace("−", "-")
@@ -41,54 +49,58 @@ def clean_text(text: str) -> str:
     return text.strip()
 
 
-def html_to_pipe_text(html_text: str) -> str:
-    """
-    Convert Marker HTML into a pipe-separated text representation.
-
-    Marker output often preserves table-like structure with separators,
-    but the text still needs cleanup before row extraction.
-    """
+def html_to_text(html_text: str) -> str:
     text = html_text
 
-    # Preserve cell and row boundaries before removing tags.
-    text = re.sub(r"</td\s*>|</th\s*>", " | ", text, flags=re.IGNORECASE)
-    text = re.sub(r"</tr\s*>", "\n", text, flags=re.IGNORECASE)
-    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"</td\s*>|</th\s*>", " | ", text, flags=re.I)
+    text = re.sub(r"</tr\s*>", "\n", text, flags=re.I)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.I)
+    text = re.sub(r"</p\s*>", "\n", text, flags=re.I)
+    text = re.sub(r"</div\s*>", "\n", text, flags=re.I)
 
-    # Remove remaining HTML tags.
     text = re.sub(r"<[^>]+>", " ", text)
 
-    return clean_text(text)
+    lines = []
+    for line in unescape(text).splitlines():
+        line = re.sub(r"[ \t]+", " ", line).strip()
+        if line:
+            lines.append(line)
+
+    return "\n".join(lines)
 
 
-def normalize_parameter(raw_parameter: str, definition: str) -> str:
-    """
-    Normalize parameter symbols from Marker output.
+def get_pmid_from_filename(path: Path) -> str:
+    match = re.search(r"(\d{7,8})", path.name)
+    return match.group(1) if match else path.stem
 
-    This handles common Greek symbols and Marker symbol errors observed
-    in the PMID 32046137 Marker extraction.
-    """
-    p = clean_text(raw_parameter)
-    p = p.replace("\\", "")
+
+def normalize_parameter(raw_parameter: str, definition: str = "") -> str:
+    p = clean_cell(raw_parameter)
     d = definition.lower()
 
+    p = p.replace("\\", "")
+
     replacements = {
-        "С": "c",          # Cyrillic-looking C sometimes appears instead of c
+        "С": "c",
         "β": "beta",
+        "𝛽": "beta",
         "σ": "sigma",
+        "𝜎": "sigma",
         "λ": "lambda",
+        "𝜆": "lambda",
         "α": "alpha",
-        "δI": "delta_I",
-        "δq": "delta_q",
-        "γI": "gamma_I",
-        "γA": "gamma_A",
-        "γH": "gamma_H",
-        "γн": "gamma_H",
-        "delta I": "delta_I",
-        "delta q": "delta_q",
-        "gamma I": "gamma_I",
-        "gamma A": "gamma_A",
-        "gamma H": "gamma_H",
+        "𝛼": "alpha",
+        "δ": "delta",
+        "𝛿": "delta",
+        "γ": "gamma",
+        "𝛾": "gamma",
+        "ρ": "rho",
+        "ϱ": "varrho",
+        "𝜚": "varrho",
+        "θ": "theta",
+        "𝜃": "theta",
+        "μ": "mu",
+        "𝜇": "mu",
     }
 
     for old, new in replacements.items():
@@ -98,81 +110,199 @@ def normalize_parameter(raw_parameter: str, definition: str) -> str:
     p = p.replace("$", "")
     p = re.sub(r"\s+", "", p)
 
-    # Marker sometimes reads varrho/rho as Q in the symptoms row.
-    if p in {"Q", "ρ", "𝜚"} and "symptoms" in d and "infected" in d:
+    p = re.sub(r"delta_?I$", "delta_I", p, flags=re.I)
+    p = re.sub(r"delta_?q$", "delta_q", p, flags=re.I)
+    p = re.sub(r"gamma_?I$", "gamma_I", p, flags=re.I)
+    p = re.sub(r"gamma_?A$", "gamma_A", p, flags=re.I)
+    p = re.sub(r"gamma_?H$", "gamma_H", p, flags=re.I)
+
+    p = p.replace("gammaI", "gamma_I")
+    p = p.replace("gammaA", "gamma_A")
+    p = p.replace("gammaH", "gamma_H")
+    p = p.replace("deltaI", "delta_I")
+    p = p.replace("deltaq", "delta_q")
+
+    if p in {"Q", "q", "rho"} and "symptoms" in d and "infected" in d:
         return "varrho"
 
     return p
 
 
 def normalize_value(value: str) -> str:
-    """Normalize numerical values and dashes."""
-    value = clean_text(value)
+    value = clean_cell(value)
     value = value.replace("{", "").replace("}", "")
     value = value.replace("_", "-") if value == "_" else value
     value = value.replace("10^{-", "10^-")
-    value = value.replace("}", "")
-    return value
+    return value.strip()
 
 
 def infer_parameter_type(parameter: str) -> str:
-    """Separate model parameters from initial values."""
     if "(0)" in parameter:
         return "initial_value"
     return "model_parameter"
 
 
-def extract_parameter_table_region(text: str) -> str:
-    """
-    Extract only the parameter table region from the full Marker output.
-
-    This uses string matching to locate the table caption and stop before
-    the next section.
-    """
+def looks_like_parameter_caption(text: str) -> bool:
     lower = text.lower()
 
-    start_candidates = [
-        lower.find("table 1"),
-        lower.find("parameter estimates"),
+    phrases = [
+        "parameter estimates",
+        "parameter estimation",
+        "parameter inference",
+        "parameter values",
+        "estimated parameters",
+        "model parameters",
+        "input parameters",
+        "parameters used",
+        "parameter description",
+        "parameter definitions",
     ]
-    start_candidates = [idx for idx in start_candidates if idx != -1]
 
-    if not start_candidates:
-        raise ValueError("Could not find the parameter table caption.")
+    return any(phrase in lower for phrase in phrases)
 
-    start = min(start_candidates)
 
-    end_candidates = [
-        lower.find("2.3. model-based", start),
-        lower.find("model-based method", start),
-        lower.find("given the model structure", start),
+def split_into_table_sections(text: str) -> List[str]:
+    matches = list(re.finditer(r"\bTable\s+\d+\.?", text, flags=re.I))
+
+    if not matches:
+        return [text]
+
+    sections = []
+    for i, match in enumerate(matches):
+        start = match.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        sections.append(text[start:end])
+
+    return sections
+
+
+def extract_table_id(section: str, fallback: str = "auto") -> str:
+    match = re.search(r"\bTable\s+(\d+)", section, flags=re.I)
+    return f"Table {match.group(1)}" if match else fallback
+
+
+def split_cells(section: str) -> List[str]:
+    cells = [clean_cell(cell) for cell in section.split("|")]
+    return [cell for cell in cells if cell]
+
+
+def looks_like_source(text: str) -> bool:
+    text = clean_cell(text)
+    s = text.lower().replace(" ", "")
+
+    if not s:
+        return False
+
+    known_sources = {
+        "mcmc",
+        "who",
+        "cdc",
+        "nih",
+        "literature",
+        "estimated",
+        "assumed",
+        "fitted",
+        "calculated",
+        "reported",
+        "data",
+        "thisstudy",
+        "modelcalibration",
+    }
+
+    if s in known_sources:
+        return True
+
+    if re.search(r"\[\d+", s):
+        return True
+
+    keywords = [
+        "assumed",
+        "estimate",
+        "estimated",
+        "fitted",
+        "calibrated",
+        "calculated",
+        "literature",
+        "reported",
+        "derived",
+        "reference",
+        "data",
+        "study",
+        "baseline",
+        "supplement",
     ]
-    end_candidates = [idx for idx in end_candidates if idx != -1]
 
-    if end_candidates:
-        end = min(end_candidates)
-    else:
-        end = min(len(text), start + 15000)
-
-    return text[start:end]
+    return any(keyword in s for keyword in keywords)
 
 
-def extract_marker_parameters(marker_html_path: Path, pmid: str, table_id: str) -> List[ParameterRow]:
+def looks_like_value(text: str) -> bool:
+    text = clean_cell(text).lower()
+
+    if not text:
+        return False
+
+    if text in {"-", "_", "na", "n/a"}:
+        return True
+
+    if re.search(r"\d", text):
+        return True
+
+    return False
+
+
+def looks_like_parameter_name(text: str) -> bool:
+    text = clean_cell(text)
+    lower = text.lower()
+
+    if not text or len(text) > 100:
+        return False
+
+    banned = {
+        "parameter",
+        "parameters",
+        "definition",
+        "definitions",
+        "description",
+        "estimated mean value",
+        "standard deviation",
+        "data source",
+        "source",
+        "value",
+        "values",
+        "initial values",
+        "peak time",
+        "value of i at peak time",
+        "figure",
+        "note",
+    }
+
+    if lower in banned:
+        return False
+
+    if lower.startswith("table "):
+        return False
+
+    # Marker sometimes outputs contact-rate c as a Cyrillic-looking C.
+    if text in {"c", "C", "С"}:
+        return True
+
+    return bool(re.search(r"[A-Za-zСαβγδλσρϱθ_()]", text))
+
+
+def parse_source_based_rows(
+    cells: List[str],
+    pmid: str,
+    table_id: str,
+) -> List[ParameterRow]:
     """
-    Extract parameter rows from a Marker HTML file.
+    Parse rows using the pattern:
+    parameter | definition | value | standard_deviation | source
 
-    The parser expects the parameter table to have five logical columns:
-    Parameter, Definitions, Estimated Mean Value, Standard Deviation, Data Source.
+    This is useful for Marker outputs where the table is flattened but
+    source cells like MCMC, WHO, [18], etc. are preserved.
     """
-    raw_html = marker_html_path.read_text(errors="ignore")
-    pipe_text = html_to_pipe_text(raw_html)
-    table_region = extract_parameter_table_region(pipe_text)
-
-    cells = [clean_text(cell) for cell in table_region.split("|")]
-    cells = [cell for cell in cells if cell]
-
-    valid_sources = {"mcmc", "who", "[18]", "[18,19]"}
     rows: List[ParameterRow] = []
+    seen = set()
 
     i = 0
     while i <= len(cells) - 5:
@@ -182,31 +312,29 @@ def extract_marker_parameters(marker_html_path: Path, pmid: str, table_id: str) 
         standard_deviation = cells[i + 3]
         source = cells[i + 4]
 
-        source_key = source.lower().replace(" ", "")
-
-        # This is the key string-matching rule:
-        # A valid parameter row should end with a known source field.
-        if source_key in valid_sources:
+        if (
+            looks_like_parameter_name(raw_parameter)
+            and looks_like_value(value)
+            and looks_like_source(source)
+        ):
             parameter = normalize_parameter(raw_parameter, definition)
 
-            # Skip accidental header rows.
-            if parameter.lower() in {"parameter", "initialvalues", "definitions"}:
-                i += 1
-                continue
-
-            rows.append(
-                ParameterRow(
-                    pmid=pmid,
-                    table_id=table_id,
-                    parameter=parameter,
-                    definition=definition,
-                    value=normalize_value(value),
-                    standard_deviation=normalize_value(standard_deviation),
-                    source=source,
-                    parameter_type=infer_parameter_type(parameter),
-                    raw_parameter=raw_parameter,
+            key = (parameter, normalize_value(value), source)
+            if key not in seen:
+                seen.add(key)
+                rows.append(
+                    ParameterRow(
+                        pmid=pmid,
+                        table_id=table_id,
+                        parameter=parameter,
+                        definition=definition,
+                        value=normalize_value(value),
+                        standard_deviation=normalize_value(standard_deviation),
+                        source=source,
+                        parameter_type=infer_parameter_type(parameter),
+                        raw_parameter=raw_parameter,
+                    )
                 )
-            )
 
             i += 5
         else:
@@ -215,8 +343,103 @@ def extract_marker_parameters(marker_html_path: Path, pmid: str, table_id: str) 
     return rows
 
 
-def write_csv(rows: List[ParameterRow], output_path: Path) -> None:
-    """Write extracted parameter rows to CSV."""
+def parse_short_rows(
+    cells: List[str],
+    pmid: str,
+    table_id: str,
+) -> List[ParameterRow]:
+    """
+    Fallback for parameter tables with fewer columns:
+    parameter | definition | value
+    parameter | definition | value | source
+    """
+    rows: List[ParameterRow] = []
+    seen = set()
+
+    for width in [4, 3]:
+        i = 0
+        while i <= len(cells) - width:
+            raw_parameter = cells[i]
+            definition = cells[i + 1]
+            value = cells[i + 2]
+            source = cells[i + 3] if width == 4 else ""
+
+            if not looks_like_parameter_name(raw_parameter):
+                i += 1
+                continue
+
+            if not looks_like_value(value):
+                i += 1
+                continue
+
+            if width == 4 and source and not looks_like_source(source):
+                i += 1
+                continue
+
+            parameter = normalize_parameter(raw_parameter, definition)
+            key = (parameter, normalize_value(value), source)
+
+            if key not in seen:
+                seen.add(key)
+                rows.append(
+                    ParameterRow(
+                        pmid=pmid,
+                        table_id=table_id,
+                        parameter=parameter,
+                        definition=definition,
+                        value=normalize_value(value),
+                        standard_deviation="",
+                        source=source,
+                        parameter_type=infer_parameter_type(parameter),
+                        raw_parameter=raw_parameter,
+                    )
+                )
+
+            i += width
+
+    return rows
+
+
+def extract_marker_parameters(
+    marker_html_path: Path,
+    pmid: Optional[str] = None,
+    table_id: str = "auto",
+) -> List[ParameterRow]:
+    if pmid is None:
+        pmid = get_pmid_from_filename(marker_html_path)
+
+    html_text = marker_html_path.read_text(errors="ignore")
+    text = html_to_text(html_text)
+
+    all_rows: List[ParameterRow] = []
+    seen = set()
+
+    for section in split_into_table_sections(text):
+        caption_window = section[:1200]
+
+        if not looks_like_parameter_caption(caption_window):
+            continue
+
+        current_table_id = extract_table_id(section, fallback=table_id)
+        cells = split_cells(section)
+
+        rows = parse_source_based_rows(cells, pmid=pmid, table_id=current_table_id)
+
+        # If no 5-column rows are found, try shorter layouts.
+        if not rows:
+            rows = parse_short_rows(cells, pmid=pmid, table_id=current_table_id)
+
+        for row in rows:
+            key = (row.pmid, row.table_id, row.parameter, row.value)
+            if key not in seen:
+                seen.add(key)
+                all_rows.append(row)
+
+    return all_rows
+
+
+def write_csv(rows: Iterable[ParameterRow], output_path: Path) -> None:
+    rows = list(rows)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     fieldnames = [
@@ -238,17 +461,7 @@ def write_csv(rows: List[ParameterRow], output_path: Path) -> None:
             writer.writerow(asdict(row))
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Extract parameter rows from Marker HTML output."
-    )
-    parser.add_argument("marker_html", type=Path, help="Path to Marker HTML file.")
-    parser.add_argument("--pmid", required=True, help="PMID for the paper.")
-    parser.add_argument("--table-id", default="Table 1", help="Table identifier.")
-    parser.add_argument("--out", type=Path, required=True, help="Output CSV path.")
-
-    args = parser.parse_args()
-
+def run_single_file(args) -> None:
     rows = extract_marker_parameters(
         marker_html_path=args.marker_html,
         pmid=args.pmid,
@@ -261,10 +474,84 @@ def main() -> None:
     print(f"Saved to: {args.out}")
 
     for row in rows:
-        print(
-            f"{row.parameter} | {row.value} | "
-            f"{row.standard_deviation} | {row.source}"
+        print(f"{row.parameter} | {row.value} | {row.standard_deviation} | {row.source}")
+
+
+def run_batch(args) -> None:
+    input_dir = args.input_dir
+    output_dir = args.output_dir
+    summary_path = args.summary
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    html_files = sorted(input_dir.glob("*.html"))
+    summary_rows = []
+
+    for html_file in html_files:
+        pmid = get_pmid_from_filename(html_file)
+        out_csv = output_dir / f"{pmid}_marker_parameters.csv"
+
+        try:
+            rows = extract_marker_parameters(html_file, pmid=pmid, table_id="auto")
+            write_csv(rows, out_csv)
+
+            status = "extracted" if rows else "zero_rows_needs_review"
+            print(f"{pmid}: {len(rows)} rows ({status})")
+
+            summary_rows.append({
+                "pmid": pmid,
+                "rows_extracted": len(rows),
+                "status": status,
+                "input_file": str(html_file),
+                "output_file": str(out_csv),
+            })
+
+        except Exception as error:
+            print(f"{pmid}: failed ({error})")
+            summary_rows.append({
+                "pmid": pmid,
+                "rows_extracted": 0,
+                "status": f"failed: {error}",
+                "input_file": str(html_file),
+                "output_file": str(out_csv),
+            })
+
+    with summary_path.open("w", newline="") as file:
+        writer = csv.DictWriter(
+            file,
+            fieldnames=["pmid", "rows_extracted", "status", "input_file", "output_file"],
         )
+        writer.writeheader()
+        writer.writerows(summary_rows)
+
+    print(f"\nBatch summary saved to: {summary_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract parameter rows from Marker HTML output."
+    )
+
+    parser.add_argument("marker_html", type=Path, nargs="?", help="Path to one Marker HTML file.")
+    parser.add_argument("--pmid", help="PMID for single-file mode.")
+    parser.add_argument("--table-id", default="auto", help="Table identifier.")
+    parser.add_argument("--out", type=Path, help="Output CSV path for single-file mode.")
+
+    parser.add_argument("--input-dir", type=Path, help="Folder containing Marker HTML files.")
+    parser.add_argument("--output-dir", type=Path, help="Folder for batch CSV outputs.")
+    parser.add_argument("--summary", type=Path, help="Path to batch summary CSV.")
+
+    args = parser.parse_args()
+
+    if args.input_dir:
+        if not args.output_dir or not args.summary:
+            raise ValueError("Batch mode requires --output-dir and --summary.")
+        run_batch(args)
+    else:
+        if not args.marker_html or not args.out:
+            raise ValueError("Single-file mode requires marker_html and --out.")
+        run_single_file(args)
 
 
 if __name__ == "__main__":

--- a/mira/sources/sympy_ode/marker_parameter_extraction.py
+++ b/mira/sources/sympy_ode/marker_parameter_extraction.py
@@ -1,0 +1,271 @@
+"""
+Marker parameter table extraction.
+
+This script reads Marker HTML output, finds the parameter table using
+string matching, extracts only the parameter rows, normalizes parameter
+symbols, and writes the result to a CSV file.
+"""
+
+import argparse
+import csv
+import re
+from dataclasses import asdict, dataclass
+from html import unescape
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class ParameterRow:
+    pmid: str
+    table_id: str
+    parameter: str
+    definition: str
+    value: str
+    standard_deviation: str
+    source: str
+    parameter_type: str
+    raw_parameter: str
+
+
+def clean_text(text: str) -> str:
+    """Basic text cleanup."""
+    text = unescape(text)
+    text = text.replace("\xa0", " ")
+    text = text.replace("×", "x")
+    text = text.replace("−", "-")
+    text = text.replace("–", "-")
+    text = text.replace("—", "-")
+    text = text.replace("\\times", "x")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def html_to_pipe_text(html_text: str) -> str:
+    """
+    Convert Marker HTML into a pipe-separated text representation.
+
+    Marker output often preserves table-like structure with separators,
+    but the text still needs cleanup before row extraction.
+    """
+    text = html_text
+
+    # Preserve cell and row boundaries before removing tags.
+    text = re.sub(r"</td\s*>|</th\s*>", " | ", text, flags=re.IGNORECASE)
+    text = re.sub(r"</tr\s*>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+
+    # Remove remaining HTML tags.
+    text = re.sub(r"<[^>]+>", " ", text)
+
+    return clean_text(text)
+
+
+def normalize_parameter(raw_parameter: str, definition: str) -> str:
+    """
+    Normalize parameter symbols from Marker output.
+
+    This handles common Greek symbols and Marker symbol errors observed
+    in the PMID 32046137 Marker extraction.
+    """
+    p = clean_text(raw_parameter)
+    p = p.replace("\\", "")
+    d = definition.lower()
+
+    replacements = {
+        "С": "c",          # Cyrillic-looking C sometimes appears instead of c
+        "β": "beta",
+        "σ": "sigma",
+        "λ": "lambda",
+        "α": "alpha",
+        "δI": "delta_I",
+        "δq": "delta_q",
+        "γI": "gamma_I",
+        "γA": "gamma_A",
+        "γH": "gamma_H",
+        "γн": "gamma_H",
+        "delta I": "delta_I",
+        "delta q": "delta_q",
+        "gamma I": "gamma_I",
+        "gamma A": "gamma_A",
+        "gamma H": "gamma_H",
+    }
+
+    for old, new in replacements.items():
+        p = p.replace(old, new)
+
+    p = p.replace("{", "").replace("}", "")
+    p = p.replace("$", "")
+    p = re.sub(r"\s+", "", p)
+
+    # Marker sometimes reads varrho/rho as Q in the symptoms row.
+    if p in {"Q", "ρ", "𝜚"} and "symptoms" in d and "infected" in d:
+        return "varrho"
+
+    return p
+
+
+def normalize_value(value: str) -> str:
+    """Normalize numerical values and dashes."""
+    value = clean_text(value)
+    value = value.replace("{", "").replace("}", "")
+    value = value.replace("_", "-") if value == "_" else value
+    value = value.replace("10^{-", "10^-")
+    value = value.replace("}", "")
+    return value
+
+
+def infer_parameter_type(parameter: str) -> str:
+    """Separate model parameters from initial values."""
+    if "(0)" in parameter:
+        return "initial_value"
+    return "model_parameter"
+
+
+def extract_parameter_table_region(text: str) -> str:
+    """
+    Extract only the parameter table region from the full Marker output.
+
+    This uses string matching to locate the table caption and stop before
+    the next section.
+    """
+    lower = text.lower()
+
+    start_candidates = [
+        lower.find("table 1"),
+        lower.find("parameter estimates"),
+    ]
+    start_candidates = [idx for idx in start_candidates if idx != -1]
+
+    if not start_candidates:
+        raise ValueError("Could not find the parameter table caption.")
+
+    start = min(start_candidates)
+
+    end_candidates = [
+        lower.find("2.3. model-based", start),
+        lower.find("model-based method", start),
+        lower.find("given the model structure", start),
+    ]
+    end_candidates = [idx for idx in end_candidates if idx != -1]
+
+    if end_candidates:
+        end = min(end_candidates)
+    else:
+        end = min(len(text), start + 15000)
+
+    return text[start:end]
+
+
+def extract_marker_parameters(marker_html_path: Path, pmid: str, table_id: str) -> List[ParameterRow]:
+    """
+    Extract parameter rows from a Marker HTML file.
+
+    The parser expects the parameter table to have five logical columns:
+    Parameter, Definitions, Estimated Mean Value, Standard Deviation, Data Source.
+    """
+    raw_html = marker_html_path.read_text(errors="ignore")
+    pipe_text = html_to_pipe_text(raw_html)
+    table_region = extract_parameter_table_region(pipe_text)
+
+    cells = [clean_text(cell) for cell in table_region.split("|")]
+    cells = [cell for cell in cells if cell]
+
+    valid_sources = {"mcmc", "who", "[18]", "[18,19]"}
+    rows: List[ParameterRow] = []
+
+    i = 0
+    while i <= len(cells) - 5:
+        raw_parameter = cells[i]
+        definition = cells[i + 1]
+        value = cells[i + 2]
+        standard_deviation = cells[i + 3]
+        source = cells[i + 4]
+
+        source_key = source.lower().replace(" ", "")
+
+        # This is the key string-matching rule:
+        # A valid parameter row should end with a known source field.
+        if source_key in valid_sources:
+            parameter = normalize_parameter(raw_parameter, definition)
+
+            # Skip accidental header rows.
+            if parameter.lower() in {"parameter", "initialvalues", "definitions"}:
+                i += 1
+                continue
+
+            rows.append(
+                ParameterRow(
+                    pmid=pmid,
+                    table_id=table_id,
+                    parameter=parameter,
+                    definition=definition,
+                    value=normalize_value(value),
+                    standard_deviation=normalize_value(standard_deviation),
+                    source=source,
+                    parameter_type=infer_parameter_type(parameter),
+                    raw_parameter=raw_parameter,
+                )
+            )
+
+            i += 5
+        else:
+            i += 1
+
+    return rows
+
+
+def write_csv(rows: List[ParameterRow], output_path: Path) -> None:
+    """Write extracted parameter rows to CSV."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fieldnames = [
+        "pmid",
+        "table_id",
+        "parameter",
+        "definition",
+        "value",
+        "standard_deviation",
+        "source",
+        "parameter_type",
+        "raw_parameter",
+    ]
+
+    with output_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(asdict(row))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract parameter rows from Marker HTML output."
+    )
+    parser.add_argument("marker_html", type=Path, help="Path to Marker HTML file.")
+    parser.add_argument("--pmid", required=True, help="PMID for the paper.")
+    parser.add_argument("--table-id", default="Table 1", help="Table identifier.")
+    parser.add_argument("--out", type=Path, required=True, help="Output CSV path.")
+
+    args = parser.parse_args()
+
+    rows = extract_marker_parameters(
+        marker_html_path=args.marker_html,
+        pmid=args.pmid,
+        table_id=args.table_id,
+    )
+
+    write_csv(rows, args.out)
+
+    print(f"Extracted {len(rows)} parameter rows")
+    print(f"Saved to: {args.out}")
+
+    for row in rows:
+        print(
+            f"{row.parameter} | {row.value} | "
+            f"{row.standard_deviation} | {row.source}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mira/sources/sympy_ode/marker_parameter_extraction.py
+++ b/mira/sources/sympy_ode/marker_parameter_extraction.py
@@ -21,7 +21,15 @@ import re
 from dataclasses import asdict, dataclass
 from html import unescape
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Sequence
+from bs4 import BeautifulSoup
+
+try:
+    from .parameter_table_classifier import ParameterTableClassifier
+except ImportError:
+    # Supports running this file directly from Terminal.
+    from parameter_table_classifier import ParameterTableClassifier
+
 
 
 @dataclass
@@ -128,13 +136,75 @@ def normalize_parameter(raw_parameter: str, definition: str = "") -> str:
     return p
 
 
-def normalize_value(value: str) -> str:
-    value = clean_cell(value)
-    value = value.replace("{", "").replace("}", "")
-    value = value.replace("_", "-") if value == "_" else value
-    value = value.replace("10^{-", "10^-")
-    return value.strip()
 
+def clean_parameter_definition(
+    raw_definition: str,
+    parameter_symbol: str,
+) -> str:
+    """Remove a parameter symbol from its descriptive text."""
+
+    definition = clean_cell(raw_definition)
+    symbol = clean_cell(parameter_symbol)
+
+    if not definition:
+        return ""
+
+    if not symbol:
+        return definition
+
+    escaped_symbol = re.escape(symbol)
+
+    # Symbol at the beginning:
+    # beta Transmission rate
+    # beta: Transmission rate
+    # beta - Transmission rate
+    definition = re.sub(
+        rf"^\s*{escaped_symbol}\s*[:;,=\-–—]?\s*",
+        "",
+        definition,
+        flags=re.IGNORECASE,
+    )
+
+    # Symbol inside parentheses:
+    # Transmission rate (beta)
+    definition = re.sub(
+        rf"\(\s*{escaped_symbol}\s*\)",
+        "",
+        definition,
+        flags=re.IGNORECASE,
+    )
+
+    # Symbol at the end:
+    # Transmission rate, beta
+    definition = re.sub(
+        rf"[,;:\s]+{escaped_symbol}\s*$",
+        "",
+        definition,
+        flags=re.IGNORECASE,
+    )
+
+    definition = re.sub(r"\s+", " ", definition)
+
+    return definition.strip(" ,;:-–—")
+
+
+def normalize_value(text: str) -> str:
+    """Keep only the first numerical estimate in a value cell."""
+
+    cleaned = clean_cell(text)
+
+    if not cleaned:
+        return ""
+
+    match = re.search(
+        r"[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?",
+        cleaned,
+    )
+
+    if match:
+        return match.group(0)
+
+    return cleaned
 
 def infer_parameter_type(parameter: str) -> str:
     if "(0)" in parameter:
@@ -400,37 +470,345 @@ def parse_short_rows(
     return rows
 
 
+
+def extract_html_tables(html_text: str) -> List[dict]:
+    """Extract structured rows directly from HTML table elements.
+
+    Each returned dictionary contains:
+
+    - table_id
+    - caption
+    - headers
+    - rows
+
+    The original HTML row and column structure is preserved instead of
+    converting the table into one flattened text section.
+    """
+
+    soup = BeautifulSoup(html_text, "html.parser")
+    extracted_tables: List[dict] = []
+
+    for table_number, table in enumerate(
+        soup.find_all("table"),
+        start=1,
+    ):
+        matrix: List[List[str]] = []
+
+        for tr in table.find_all("tr"):
+            cells = tr.find_all(["th", "td"])
+
+            row = [
+                clean_cell(
+                    cell.get_text(" ", strip=True)
+                )
+                for cell in cells
+            ]
+
+            row = [cell for cell in row if cell]
+
+            if row:
+                matrix.append(row)
+
+        if not matrix:
+            continue
+
+        caption_tag = table.find("caption")
+
+        if caption_tag is not None:
+            caption = clean_cell(
+                caption_tag.get_text(" ", strip=True)
+            )
+        else:
+            caption = ""
+
+            # Marker HTML does not always use a <caption> element.
+            # Look immediately before the table for a likely caption.
+            previous_element = table.find_previous(
+                ["p", "h1", "h2", "h3", "h4", "div"]
+            )
+
+            if previous_element is not None:
+                candidate_caption = clean_cell(
+                    previous_element.get_text(" ", strip=True)
+                )
+
+                if len(candidate_caption) <= 1000:
+                    caption = candidate_caption
+
+        table_id = f"Table {table_number}"
+
+        caption_match = re.search(
+            r"\btable\s+([a-z0-9]+)",
+            caption,
+            re.IGNORECASE,
+        )
+
+        if caption_match:
+            table_id = f"Table {caption_match.group(1)}"
+
+        first_html_row = table.find("tr")
+        first_row_has_header_cells = bool(
+            first_html_row
+            and first_html_row.find_all("th")
+        )
+
+        header_terms = {
+            "parameter",
+            "parameters",
+            "symbol",
+            "description",
+            "definition",
+            "meaning",
+            "value",
+            "values",
+            "estimate",
+            "estimated value",
+            "unit",
+            "units",
+            "source",
+            "standard deviation",
+            "range",
+        }
+
+        first_row_text = " ".join(
+            cell.lower()
+            for cell in matrix[0]
+        )
+
+        first_row_looks_like_header = (
+            first_row_has_header_cells
+            or any(
+                term in first_row_text
+                for term in header_terms
+            )
+        )
+
+        if first_row_looks_like_header:
+            headers = matrix[0]
+            data_rows = matrix[1:]
+        else:
+            headers = []
+            data_rows = matrix
+
+        extracted_tables.append(
+            {
+                "table_id": table_id,
+                "caption": caption,
+                "headers": headers,
+                "rows": data_rows,
+            }
+        )
+
+    return extracted_tables
+
+
+def parse_two_column_rows(
+    table_rows: Sequence[Sequence[str]],
+    pmid: str,
+    table_id: str,
+) -> List[ParameterRow]:
+    """Parse parameter tables with a label column and a value column.
+
+    Example:
+
+        Effective contact rate (beta) | 1.30 [1.21-1.39] day-1
+    """
+
+    rows: List[ParameterRow] = []
+    seen = set()
+
+    for table_row in table_rows:
+        if len(table_row) < 2:
+            continue
+
+        raw_parameter = clean_cell(table_row[0])
+        raw_value = clean_cell(
+            " ".join(table_row[1:])
+        )
+
+        if not raw_parameter or not raw_value:
+            continue
+
+        lowered_parameter = raw_parameter.lower()
+
+        if lowered_parameter in {
+            "parameter",
+            "parameters",
+            "parameter name",
+            "description",
+            "definition",
+            "symbol",
+        }:
+            continue
+
+        if not looks_like_value(raw_value):
+            continue
+
+        parameter = normalize_parameter(
+            raw_parameter,
+            raw_parameter,
+        )
+
+        if not looks_like_parameter_name(parameter):
+            continue
+
+        definition = clean_parameter_definition(
+            raw_parameter,
+            parameter,
+        )
+
+        value = normalize_value(raw_value)
+
+        key = (
+            parameter,
+            value,
+        )
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+
+        rows.append(
+            ParameterRow(
+                pmid=pmid,
+                table_id=table_id,
+                parameter=parameter,
+                definition=definition,
+                value=value,
+                standard_deviation="",
+                source="",
+                parameter_type=infer_parameter_type(parameter),
+                raw_parameter=raw_parameter,
+            )
+        )
+
+    return rows
+
+
+def flatten_table_rows(
+    table_rows: Sequence[Sequence[str]],
+) -> List[str]:
+    """Flatten a real HTML matrix for the existing fallback parsers."""
+
+    return [
+        clean_cell(cell)
+        for row in table_rows
+        for cell in row
+        if clean_cell(cell)
+    ]
+
+
 def extract_marker_parameters(
     marker_html_path: Path,
     pmid: Optional[str] = None,
     table_id: str = "auto",
 ) -> List[ParameterRow]:
+    """Extract parameter rows from structured Marker HTML tables."""
+
     if pmid is None:
         pmid = get_pmid_from_filename(marker_html_path)
 
     html_text = marker_html_path.read_text(errors="ignore")
-    text = html_to_text(html_text)
 
     all_rows: List[ParameterRow] = []
     seen = set()
 
-    for section in split_into_table_sections(text):
-        caption_window = section[:1200]
+    classifier = ParameterTableClassifier(threshold=0.43)
 
-        if not looks_like_parameter_caption(caption_window):
+    html_tables = extract_html_tables(html_text)
+
+    if not html_tables:
+        print(
+            f"{pmid}: no structured HTML tables were found"
+        )
+        return all_rows
+
+    for html_table in html_tables:
+        current_table_id = html_table["table_id"]
+
+        if table_id != "auto":
+            current_table_id = table_id
+
+        caption = html_table["caption"]
+        headers = html_table["headers"]
+        table_rows = html_table["rows"]
+
+        if not table_rows:
             continue
 
-        current_table_id = extract_table_id(section, fallback=table_id)
-        cells = split_cells(section)
+        classification = classifier.predict(
+            caption=caption,
+            headers=headers,
+            rows=table_rows,
+        )
 
-        rows = parse_source_based_rows(cells, pmid=pmid, table_id=current_table_id)
+        print(
+            f"{pmid} | table={current_table_id} | "
+            f"html_rows={len(table_rows)} | "
+            f"columns={max(len(row) for row in table_rows)} | "
+            f"parameter={classification.is_parameter_table} | "
+            f"score={classification.score:.4f} | "
+            f"caption={classification.caption_similarity:.4f} | "
+            f"header={classification.header_similarity:.4f} | "
+            f"keywords={classification.keyword_score:.4f} | "
+            f"numeric={classification.numeric_density:.4f} | "
+            f"symbols={classification.symbol_density:.4f} | "
+            f"negative={classification.negative_keyword_score:.4f}"
+        )
 
-        # If no 5-column rows are found, try shorter layouts.
+        if not classification.is_parameter_table:
+            continue
+
+        # First try the new parser for tables with one label column
+        # and one value column.
+        rows = parse_two_column_rows(
+            table_rows,
+            pmid=pmid,
+            table_id=current_table_id,
+        )
+
+        # Existing parsers remain available for 3-, 4-, and 5-column
+        # parameter tables.
         if not rows:
-            rows = parse_short_rows(cells, pmid=pmid, table_id=current_table_id)
+            flattened_cells = flatten_table_rows(table_rows)
+
+            rows = parse_source_based_rows(
+                flattened_cells,
+                pmid=pmid,
+                table_id=current_table_id,
+            )
+
+            if not rows:
+                rows = parse_short_rows(
+                    flattened_cells,
+                    pmid=pmid,
+                    table_id=current_table_id,
+                )
+
+        if not rows:
+            print(
+                f"  Accepted as a parameter table, "
+                f"but no parameter rows were parsed."
+            )
+
+            print("  First HTML rows:")
+
+            for raw_row in table_rows[:5]:
+                print(f"    {raw_row!r}")
+
+            continue
+
+        print(f"  Parsed parameter rows: {len(rows)}")
 
         for row in rows:
-            key = (row.pmid, row.table_id, row.parameter, row.value)
+            key = (
+                row.pmid,
+                row.table_id,
+                row.parameter,
+                row.value,
+            )
+
             if key not in seen:
                 seen.add(key)
                 all_rows.append(row)

--- a/mira/sources/sympy_ode/marker_table_extraction.py
+++ b/mira/sources/sympy_ode/marker_table_extraction.py
@@ -1,0 +1,75 @@
+import csv
+import sys
+from pathlib import Path
+from bs4 import BeautifulSoup
+
+
+def save_csv(rows, path):
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerows(rows)
+
+
+def extract_file(html_file, output_dir):
+    pmid = html_file.stem
+    paper_dir = output_dir / pmid
+    paper_dir.mkdir(parents=True, exist_ok=True)
+
+    soup = BeautifulSoup(html_file.read_text(encoding="utf-8", errors="ignore"), "html.parser")
+
+    results = []
+    for i, table in enumerate(soup.find_all("table"), 1):
+        rows = [
+            [cell.get_text(" ", strip=True) for cell in tr.find_all(["th", "td"])]
+            for tr in table.find_all("tr")
+        ]
+        rows = [r for r in rows if r]
+
+        caption = table.find("caption")
+        caption_text = caption.get_text(" ", strip=True) if caption else ""
+
+        html_path = paper_dir / f"table_{i}.html"
+        csv_path = paper_dir / f"table_{i}.csv"
+        html_path.write_text(str(table), encoding="utf-8")
+        save_csv(rows, csv_path)
+
+        n_cols = max((len(r) for r in rows), default=0)
+
+        header_text = " ".join(rows[0]).lower() if rows else ""
+        is_param_table = "parameter" in (caption_text + " " + header_text).lower()
+
+        results.append([
+            pmid, i, caption_text, len(rows), n_cols,
+            is_param_table, str(html_path), str(csv_path),
+        ])
+
+    return results
+
+
+def main():
+    if len(sys.argv) != 4:
+        sys.exit("usage: marker_table_extraction.py INPUT_DIR OUTPUT_DIR SUMMARY_CSV")
+
+    input_dir, output_dir, summary_path = (Path(p) for p in sys.argv[1:4])
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    html_files = sorted(input_dir.glob("*.html"))
+    if not html_files:
+        sys.exit(f"no HTML files found in {input_dir}")
+
+    summary = []
+    for html_file in html_files:
+        tables = extract_file(html_file, output_dir)
+        summary.extend(tables)
+        print(f"{html_file.name}: {len(tables)} tables")
+
+    with open(summary_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["pmid", "table_number", "caption", "rows", "columns",
+                          "parameter_table", "html_file", "csv_file"])
+        writer.writerows(summary)
+
+    print(f"\n{len(html_files)} papers, {len(summary)} tables -> {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mira/sources/sympy_ode/parameter_table_classifier.py
+++ b/mira/sources/sympy_ode/parameter_table_classifier.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+PARAMETER_CAPTION_REFERENCES = [
+    "model parameters and values",
+    "parameter values",
+    "estimated parameter values",
+    "estimated model parameters",
+    "parameter estimates",
+    "kinetic parameters",
+    "kinetic constants",
+    "reaction rate constants",
+    "model constants",
+    "initial conditions",
+    "initial parameter values",
+    "parameters used in the model",
+    "calibrated parameter values",
+    "fitted parameter values",
+]
+
+PARAMETER_HEADER_REFERENCES = [
+    "parameter symbol description value unit",
+    "parameter definition estimate unit",
+    "symbol parameter value units",
+    "parameter name value",
+    "parameter meaning estimated value",
+    "parameter initial value unit",
+    "symbol description mean standard deviation unit",
+]
+
+PARAMETER_KEYWORDS = {
+    "parameter", "parameters", "estimate", "estimated", "value", "values",
+    "constant", "constants", "coefficient", "coefficients", "rate", "rates",
+    "kinetic", "calibrated", "calibration", "fitted", "fitting", "symbol",
+    "unit", "units", "initial condition", "initial conditions",
+    "initial value", "initial values",
+}
+
+NEGATIVE_KEYWORDS = {
+    "patient", "patients", "participant", "participants", "demographic",
+    "demographics", "baseline characteristics", "clinical characteristics",
+    "gene expression", "differential expression", "enrichment", "questionnaire",
+    "survey",
+}
+
+# Matches things like k_on, Vmax, beta, gamma_1, or a bare greek letter -
+# the usual shapes a parameter symbol takes at the start of a table row.
+PARAMETER_SYMBOL_PATTERN = re.compile(
+    r"^(?:[a-zA-Z]_\{?\d+\}?|[a-zA-Z]\d+|k(?:on|off|cat|m|\d+)?|v(?:max|\d+)?"
+    r"|r_?\d*|beta|gamma|alpha|delta|lambda|mu|sigma|theta|rho"
+    r"|[αβγδεζηθικλμνξοπρστυφχψω])$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ParameterTableResult:
+    is_parameter_table: bool
+    score: float
+    caption_similarity: float
+    header_similarity: float
+    keyword_score: float
+    numeric_density: float
+    symbol_density: float
+    negative_keyword_score: float
+
+
+def clean_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = re.sub(r"<[^>]+>", " ", str(value))
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def tokenize(text: str) -> list[str]:
+    text = clean_text(text)
+    return re.findall(
+        r"[a-zA-Z]+(?:_\d+|\d+)?|[αβγδεζηθικλμνξοπρστυφχψω]|\d+(?:\.\d+)?",
+        text,
+    )
+
+
+def _term_frequency(tokens: Sequence[str]) -> Counter[str]:
+    counts = Counter(tokens)
+    total = sum(counts.values())
+    if total == 0:
+        return Counter()
+    return Counter({token: count / total for token, count in counts.items()})
+
+
+def cosine_similarity(text_a: str, text_b: str) -> float:
+    """Cosine similarity between two strings using plain token frequencies
+    (no scikit-learn needed - this doesn't need to be fancy)."""
+    vector_a = _term_frequency(tokenize(text_a))
+    vector_b = _term_frequency(tokenize(text_b))
+    if not vector_a or not vector_b:
+        return 0.0
+
+    shared = set(vector_a) & set(vector_b)
+    dot = sum(vector_a[t] * vector_b[t] for t in shared)
+    mag_a = math.sqrt(sum(v * v for v in vector_a.values()))
+    mag_b = math.sqrt(sum(v * v for v in vector_b.values()))
+    if mag_a == 0.0 or mag_b == 0.0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def maximum_similarity(text: str, reference_texts: Iterable[str]) -> float:
+    """Return the strongest similarity found in the text.
+
+    Long Marker sections may contain captions, cells, and footnotes.
+    Comparing only the complete block can dilute an informative caption.
+    Therefore, compare the complete text, individual lines, and short
+    token windows against each reference phrase.
+    """
+
+    normalized = clean_text(text)
+
+    if not normalized:
+        return 0.0
+
+    candidates = {normalized}
+
+    # Compare individual lines or sentence-like fragments.
+    for fragment in re.split(r"[\\n.;:]+", str(text)):
+        cleaned = clean_text(fragment)
+        if cleaned:
+            candidates.add(cleaned)
+
+    # Compare short word windows to detect informative phrases embedded
+    # inside a longer table section.
+    tokens = tokenize(normalized)
+
+    for window_size in range(2, min(9, len(tokens) + 1)):
+        for start in range(len(tokens) - window_size + 1):
+            candidates.add(" ".join(tokens[start:start + window_size]))
+
+    scores = [
+        cosine_similarity(candidate, reference)
+        for candidate in candidates
+        for reference in reference_texts
+    ]
+
+    return max(scores, default=0.0)
+
+
+def keyword_score(text: str) -> float:
+    normalized = clean_text(text)
+    if not normalized:
+        return 0.0
+    matches = sum(1 for kw in PARAMETER_KEYWORDS if kw in normalized)
+    return min(matches / 5.0, 1.0)  # a few hits is enough to max this out
+
+
+def negative_keyword_score(text: str) -> float:
+    normalized = clean_text(text)
+    if not normalized:
+        return 0.0
+    matches = sum(1 for kw in NEGATIVE_KEYWORDS if kw in normalized)
+    return min(matches / 3.0, 1.0)
+
+
+def looks_numeric(value: object) -> bool:
+    text = clean_text(value)
+    if not text or text in {"-", "—", "–", "na", "n/a", "none"}:
+        return False
+
+    patterns = [
+        r"^[+-]?\d+(?:\.\d+)?$",
+        r"^[+-]?\d+(?:\.\d+)?\s*[-–]\s*[+-]?\d+(?:\.\d+)?$",
+        r"^[+-]?\d+(?:\.\d+)?\s*(?:±|\+/-)\s*\d+(?:\.\d+)?$",
+        r"^[+-]?\d+(?:\.\d+)?(?:e[+-]?\d+)$",
+        r"^\d+(?:\.\d+)?\s*%$",
+    ]
+    return any(re.search(p, text, re.IGNORECASE) for p in patterns)
+
+
+def numeric_density(rows: Sequence[Sequence[object]]) -> float:
+    nonempty = 0
+    numeric = 0
+    for row in rows:
+        for cell in row:
+            if not clean_text(cell):
+                continue
+            nonempty += 1
+            if looks_numeric(cell):
+                numeric += 1
+    return numeric / nonempty if nonempty else 0.0
+
+
+def looks_like_parameter_symbol(value: object) -> bool:
+    text = clean_text(value).replace(" ", "")
+    if not text or len(text) > 15:
+        return False
+    return bool(PARAMETER_SYMBOL_PATTERN.match(text))
+
+
+def symbol_density(rows: Sequence[Sequence[object]]) -> float:
+    # only look at the first column - that's where symbols usually live
+    first_cells = [row[0] for row in rows if row]
+    if not first_cells:
+        return 0.0
+    hits = sum(1 for cell in first_cells if looks_like_parameter_symbol(cell))
+    return hits / len(first_cells)
+
+
+class ParameterTableClassifier:
+    """Scores a table on how likely it is to be a parameter table, and
+    flags it as one once the score clears `threshold`."""
+
+    def __init__(self, threshold: float = 0.50) -> None:
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError("threshold must be between 0 and 1")
+        self.threshold = threshold
+
+    def predict(
+        self,
+        caption: str,
+        headers: Sequence[object],
+        rows: Sequence[Sequence[object]],
+    ) -> ParameterTableResult:
+        header_text = " ".join(clean_text(h) for h in headers)
+        combined_text = f"{clean_text(caption)} {header_text}".strip()
+
+        caption_similarity = maximum_similarity(caption, PARAMETER_CAPTION_REFERENCES)
+        header_similarity = maximum_similarity(header_text, PARAMETER_HEADER_REFERENCES)
+        kw_score = keyword_score(combined_text)
+        num_density = numeric_density(rows)
+        sym_density = symbol_density(rows)
+        neg_score = negative_keyword_score(combined_text)
+
+        # weights are hand-picked, not tuned on data - caption/header wording
+        # is the strongest signal, negative keywords just knock the score down
+        raw_score = (
+            0.30 * caption_similarity
+            + 0.25 * header_similarity
+            + 0.20 * kw_score
+            + 0.15 * num_density
+            + 0.10 * sym_density
+            - 0.20 * neg_score
+        )
+        score = max(0.0, min(raw_score, 1.0))
+
+        return ParameterTableResult(
+            is_parameter_table=score >= self.threshold,
+            score=round(score, 4),
+            caption_similarity=round(caption_similarity, 4),
+            header_similarity=round(header_similarity, 4),
+            keyword_score=round(kw_score, 4),
+            numeric_density=round(num_density, 4),
+            symbol_density=round(sym_density, 4),
+            negative_keyword_score=round(neg_score, 4),
+        )

--- a/mira/sources/sympy_ode/parameter_table_references.json
+++ b/mira/sources/sympy_ode/parameter_table_references.json
@@ -1,0 +1,85 @@
+{
+  "caption_references": [
+    "model parameters and values",
+    "parameter values",
+    "estimated parameter values",
+    "estimated model parameters",
+    "parameter estimates",
+    "kinetic parameters",
+    "kinetic constants",
+    "reaction rate constants",
+    "model constants",
+    "initial conditions",
+    "initial parameter values",
+    "parameters used in the model",
+    "calibrated parameter values",
+    "fitted parameter values"
+  ],
+  "header_references": [
+    "parameter symbol description value unit",
+    "parameter definition estimate unit",
+    "symbol parameter value units",
+    "parameter name value",
+    "parameter meaning estimated value",
+    "parameter initial value unit",
+    "symbol description mean standard deviation unit"
+  ],
+  "column_aliases": {
+    "parameter_symbol": [
+      "symbol",
+      "parameter symbol",
+      "notation",
+      "variable symbol"
+    ],
+    "parameter_name": [
+      "parameter",
+      "parameter name",
+      "description",
+      "definition",
+      "meaning",
+      "interpretation"
+    ],
+    "value": [
+      "value",
+      "values",
+      "estimate",
+      "estimated value",
+      "mean",
+      "default value",
+      "initial value",
+      "baseline value"
+    ],
+    "unit": [
+      "unit",
+      "units",
+      "dimension",
+      "dimensions"
+    ],
+    "uncertainty": [
+      "uncertainty",
+      "standard deviation",
+      "standard error",
+      "sd",
+      "se",
+      "confidence interval",
+      "credible interval",
+      "ci",
+      "range",
+      "lower bound",
+      "upper bound"
+    ]
+  },
+  "negative_keywords": [
+    "patient",
+    "patients",
+    "participant",
+    "participants",
+    "demographic",
+    "baseline characteristics",
+    "clinical characteristics",
+    "gene expression",
+    "survey",
+    "questionnaire"
+  ],
+  "classification_threshold": 0.43
+}

--- a/mira/sources/sympy_ode/simple_parameter_table_extractor.py
+++ b/mira/sources/sympy_ode/simple_parameter_table_extractor.py
@@ -1,0 +1,775 @@
+"""Deterministic parameter-table extraction from Marker HTML output.
+
+Parses tables with BeautifulSoup, scores them against reference captions/
+headers plus some keyword and structural heuristics, then maps columns into
+a parameter schema. No LLM or API key needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import shutil
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from bs4 import BeautifulSoup
+
+MODULE_DIR = Path(__file__).resolve().parent
+REFERENCE_FILE = MODULE_DIR / "parameter_table_references.json"
+
+
+@dataclass
+class ParameterRecord:
+    pmid: str
+    table_id: str
+    parameter_name: str
+    parameter_symbol: str
+    value: str
+    unit: str
+    uncertainty: str
+
+
+@dataclass
+class TableDecision:
+    pmid: str
+    table_id: str
+    caption: str
+    headers: str
+    caption_similarity: float
+    header_similarity: float
+    keyword_score: float
+    numeric_density: float
+    symbol_density: float
+    negative_score: float
+    final_score: float
+    is_parameter_table: bool
+    extracted_rows: int
+
+
+def clean_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = text.replace("−", "-").replace("–", "-")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def normalized_text(value: object) -> str:
+    return clean_text(value).casefold()
+
+
+def tokenize(text: str) -> list[str]:
+    pattern = (
+        r"[a-zA-Z]+(?:_\d+|\d+)?|"
+        r"[αβγδεζηθικλμνξοπρστυφχψω]|"
+        r"\d+(?:\.\d+)?"
+    )
+    return re.findall(pattern, normalized_text(text))
+
+
+def term_frequency(tokens: Sequence[str]) -> Counter[str]:
+    counts = Counter(tokens)
+    total = sum(counts.values())
+    if not total:
+        return Counter()
+    return Counter({t: c / total for t, c in counts.items()})
+
+
+def cosine_similarity(text_a: str, text_b: str) -> float:
+    vec_a = term_frequency(tokenize(text_a))
+    vec_b = term_frequency(tokenize(text_b))
+    if not vec_a or not vec_b:
+        return 0.0
+
+    shared = set(vec_a) & set(vec_b)
+    dot = sum(vec_a[t] * vec_b[t] for t in shared)
+    mag_a = math.sqrt(sum(v * v for v in vec_a.values()))
+    mag_b = math.sqrt(sum(v * v for v in vec_b.values()))
+    if mag_a == 0 or mag_b == 0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def maximum_similarity(text: str, references: Iterable[str]) -> float:
+    normalized = clean_text(text)
+    if not normalized:
+        return 0.0
+
+    candidates = {normalized}
+    for fragment in re.split(r"[\n.;:]+", normalized):
+        fragment = clean_text(fragment)
+        if fragment:
+            candidates.add(fragment)
+
+    # also try n-gram windows so partial header/caption matches count
+    tokens = tokenize(normalized)
+    for window in range(2, min(9, len(tokens) + 1)):
+        for start in range(len(tokens) - window + 1):
+            candidates.add(" ".join(tokens[start:start + window]))
+
+    return max(
+        (cosine_similarity(c, r) for c in candidates for r in references),
+        default=0.0,
+    )
+
+
+def load_references() -> dict:
+    with REFERENCE_FILE.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def extract_caption(table, table_number: int) -> str:
+    caption_tag = table.find("caption")
+    if caption_tag:
+        return clean_text(caption_tag.get_text(" ", strip=True))
+
+    previous = table.find_previous(["p", "div", "h1", "h2", "h3", "h4"])
+    if previous:
+        candidate = clean_text(previous.get_text(" ", strip=True))
+        if len(candidate) <= 1000:
+            return candidate
+
+    return f"Table {table_number}"
+
+
+def extract_table_matrix(table) -> list[list[str]]:
+    matrix: list[list[str]] = []
+    for tr in table.find_all("tr"):
+        cells = tr.find_all(["th", "td"])
+        row = [clean_text(cell.get_text(" ", strip=True)) for cell in cells]
+        if any(row):  # keep blanks, column position still matters
+            matrix.append(row)
+    return matrix
+
+
+HEADER_TERMS = {
+    "parameter", "symbol", "description", "definition", "meaning",
+    "value", "estimate", "unit", "uncertainty", "standard deviation", "range",
+}
+
+
+def separate_headers(table, matrix: list[list[str]]) -> tuple[list[str], list[list[str]]]:
+    if not matrix:
+        return [], []
+
+    first_tr = table.find("tr")
+    has_th = bool(first_tr and first_tr.find_all("th"))
+    first_row_text = normalized_text(" ".join(matrix[0]))
+    resembles_header = has_th or any(t in first_row_text for t in HEADER_TERMS)
+
+    if resembles_header:
+        return matrix[0], matrix[1:]
+    return [], matrix
+
+
+def numeric_density(rows: Sequence[Sequence[str]]) -> float:
+    nonempty = numeric = 0
+    for row in rows:
+        for cell in row:
+            text = clean_text(cell)
+            if not text:
+                continue
+            nonempty += 1
+            if re.search(r"[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?", text):
+                numeric += 1
+    return numeric / nonempty if nonempty else 0.0
+
+
+SYMBOL_PATTERN = re.compile(
+    r"^(?:"
+    r"[a-zA-Z](?:_\{?[a-zA-Z0-9]+\}?)?"
+    r"|[a-zA-Z]\d+"
+    r"|alpha|beta|gamma|delta|lambda|mu|sigma|theta|rho"
+    r"|[αβγδεζηθικλμνξοπρστυφχψω]"
+    r")$",
+    re.IGNORECASE,
+)
+
+
+def looks_like_symbol(value: str) -> bool:
+    text = normalized_text(value).replace(" ", "")
+    if not text or len(text) > 20:
+        return False
+    return bool(SYMBOL_PATTERN.match(text))
+
+
+
+def split_parameter_cell(text: str) -> tuple[str, str]:
+    """Split a combined parameter cell into symbol and name.
+
+    Examples:
+        β (transmission rate)
+        beta - transmission rate
+        gamma: recovery rate
+        sigma incubation rate
+    """
+
+    raw = clean_text(text)
+
+    if not raw:
+        return "", ""
+
+    # Example: β (transmission rate)
+    match = re.match(
+        r"^\s*"
+        r"([A-Za-zα-ωΑ-Ω\\][A-Za-z0-9_{}\\]*)"
+        r"\s*\((.+)\)\s*$",
+        raw,
+    )
+
+    if match:
+        symbol = clean_text(match.group(1))
+        name = clean_text(match.group(2))
+        return symbol, name
+
+    # Examples:
+    # beta - transmission rate
+    # gamma: recovery rate
+    # sigma = progression rate
+    match = re.match(
+        r"^\s*"
+        r"([A-Za-zα-ωΑ-Ω\\][A-Za-z0-9_{}\\]*)"
+        r"\s*[:\-–—=]\s*(.+)$",
+        raw,
+    )
+
+    if match:
+        symbol = clean_text(match.group(1))
+        name = clean_text(match.group(2))
+        return symbol, name
+
+    # Example: sigma incubation rate
+    match = re.match(
+        r"^\s*"
+        r"([A-Za-zα-ωΑ-Ω\\][A-Za-z0-9_{}\\]*)"
+        r"\s+(.+)$",
+        raw,
+    )
+
+    if match:
+        candidate_symbol = clean_text(match.group(1))
+        candidate_name = clean_text(match.group(2))
+
+        if looks_like_symbol(candidate_symbol):
+            return candidate_symbol, candidate_name
+
+    # The complete cell contains only a symbol.
+    if looks_like_symbol(raw):
+        return raw, ""
+
+    # Otherwise, treat the complete cell as a parameter name.
+    return "", raw
+
+
+def symbol_density(rows: Sequence[Sequence[str]]) -> float:
+    first_cells = [row[0] for row in rows if row and clean_text(row[0])]
+    if not first_cells:
+        return 0.0
+    return sum(looks_like_symbol(c) for c in first_cells) / len(first_cells)
+
+
+def keyword_score(text: str) -> float:
+    keywords = {
+        "parameter", "parameters", "value", "values", "estimate", "estimated",
+        "constant", "rate", "kinetic", "initial value", "symbol", "unit",
+    }
+    normalized = normalized_text(text)
+    matches = sum(k in normalized for k in keywords)
+    return min(matches / 5.0, 1.0)
+
+
+def negative_keyword_score(text: str, references: dict) -> float:
+    normalized = normalized_text(text)
+    matches = sum(k.casefold() in normalized for k in references["negative_keywords"])
+    return min(matches / 3.0, 1.0)
+
+
+def classify_table(caption, headers, rows, references) -> dict:
+    header_text = " ".join(headers)
+    combined = f"{caption} {header_text}"
+
+    caption_similarity = maximum_similarity(caption, references["caption_references"])
+    header_similarity = maximum_similarity(header_text, references["header_references"])
+    positive_score = keyword_score(combined)
+    number_score = numeric_density(rows)
+    parameter_symbol_score = symbol_density(rows)
+    negative_score = negative_keyword_score(combined, references)
+
+    final_score = (
+        0.30 * caption_similarity
+        + 0.25 * header_similarity
+        + 0.20 * positive_score
+        + 0.15 * number_score
+        + 0.10 * parameter_symbol_score
+        - 0.20 * negative_score
+    )
+    final_score = min(max(final_score, 0.0), 1.0)
+    threshold = references["classification_threshold"]
+
+    return {
+        "caption_similarity": round(caption_similarity, 4),
+        "header_similarity": round(header_similarity, 4),
+        "keyword_score": round(positive_score, 4),
+        "numeric_density": round(number_score, 4),
+        "symbol_density": round(parameter_symbol_score, 4),
+        "negative_score": round(negative_score, 4),
+        "final_score": round(final_score, 4),
+        "is_parameter_table": final_score >= threshold,
+    }
+
+
+def header_alias_score(
+    header: str,
+    alias: str,
+) -> float:
+    """Score how well one table header matches one configured alias."""
+
+    header_text = normalized_text(header)
+    alias_text = normalized_text(alias)
+
+    if not header_text or not alias_text:
+        return 0.0
+
+    # Exact normalized matches are strongest.
+    if header_text == alias_text:
+        return 1.0
+
+    # A full alias appearing in a longer header is also strong.
+    if alias_text in header_text:
+        return 0.95
+
+    # Use cosine similarity only as a weaker fallback.
+    return cosine_similarity(header_text, alias_text)
+
+
+def find_best_unused_column(
+    headers: Sequence[str],
+    aliases: Sequence[str],
+    used_columns: set[int],
+) -> tuple[int | None, float]:
+    """Find the best available column for one standardized field."""
+
+    best_index = None
+    best_score = 0.0
+
+    for index, header in enumerate(headers):
+        if index in used_columns:
+            continue
+
+        score = max(
+            (
+                header_alias_score(header, alias)
+                for alias in aliases
+            ),
+            default=0.0,
+        )
+
+        if score > best_score:
+            best_index = index
+            best_score = score
+
+    # Require a reasonably strong header match.
+    if best_score < 0.60:
+        return None, best_score
+
+    return best_index, best_score
+
+
+def map_columns(
+    headers: Sequence[str],
+    aliases: dict,
+) -> dict[str, int | None]:
+    """Map source columns to unique standardized parameter fields.
+
+    Each source column can be assigned to only one output field.
+    """
+
+    mappings: dict[str, int | None] = {
+        "parameter_symbol": None,
+        "parameter_name": None,
+        "value": None,
+        "unit": None,
+        "uncertainty": None,
+    }
+
+    used_columns: set[int] = set()
+
+    # The ordering matters. Value is mapped before unit and uncertainty,
+    # while symbol and name are kept distinct.
+    field_order = [
+        "parameter_symbol",
+        "parameter_name",
+        "value",
+        "unit",
+        "uncertainty",
+    ]
+
+    for field in field_order:
+        index, _score = find_best_unused_column(
+            headers,
+            aliases.get(field, []),
+            used_columns,
+        )
+
+        mappings[field] = index
+
+        if index is not None:
+            used_columns.add(index)
+
+    return mappings
+
+
+def cell_contains_number(value: str) -> bool:
+    """Return True if a cell contains a numeric value."""
+
+    text = clean_text(value)
+
+    if not text:
+        return False
+
+    return bool(
+        re.search(
+            r"[<>≤≥]?\s*[+-]?\d+(?:\.\d+)?"
+            r"(?:[eE][+-]?\d+)?",
+            text,
+        )
+    )
+
+
+def column_numeric_ratio(
+    rows: Sequence[Sequence[str]],
+    column_index: int | None,
+) -> float:
+    """Calculate the proportion of nonempty cells containing numbers."""
+
+    if column_index is None:
+        return 0.0
+
+    nonempty = 0
+    numeric = 0
+
+    for row in rows:
+        if column_index >= len(row):
+            continue
+
+        cell = clean_text(row[column_index])
+
+        if not cell:
+            continue
+
+        nonempty += 1
+
+        if cell_contains_number(cell):
+            numeric += 1
+
+    return numeric / nonempty if nonempty else 0.0
+
+
+def find_numeric_value_column(
+    rows: Sequence[Sequence[str]],
+    excluded_columns: set[int],
+) -> int | None:
+    """Find the most numeric column not used for symbol or name."""
+
+    maximum_width = max(
+        (len(row) for row in rows),
+        default=0,
+    )
+
+    best_index = None
+    best_ratio = 0.0
+
+    for index in range(maximum_width):
+        if index in excluded_columns:
+            continue
+
+        ratio = column_numeric_ratio(rows, index)
+
+        if ratio > best_ratio:
+            best_index = index
+            best_ratio = ratio
+
+    # Avoid selecting mostly textual columns as values.
+    if best_ratio < 0.40:
+        return None
+
+    return best_index
+
+
+NUMBER_PATTERN = re.compile(r"[<>≤≥]?\s*[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
+
+
+def split_value_unit_uncertainty(text: str) -> tuple[str, str, str]:
+    raw = clean_text(text)
+    if not raw:
+        return "", "", ""
+
+    number_match = NUMBER_PATTERN.search(raw)
+    if not number_match:
+        return raw, "", ""
+
+    value = number_match.group(0).replace(" ", "")
+    remainder = raw[number_match.end():].strip()
+
+    uncertainty = ""
+    uncertainty_match = re.search(
+        r"(?:±\s*[+-]?\d+(?:\.\d+)?)|(?:\[[^\]]+\])|(?:\([^\)]+\))", remainder
+    )
+    if uncertainty_match:
+        uncertainty = clean_text(uncertainty_match.group(0))
+        remainder = (
+            remainder[:uncertainty_match.start()] + " " + remainder[uncertainty_match.end():]
+        ).strip()
+
+    return value, clean_text(remainder), uncertainty
+
+
+def get_cell(row: Sequence[str], index: int | None) -> str:
+    if index is None or index >= len(row):
+        return ""
+    return clean_text(row[index])
+
+
+def extract_records(pmid, table_id, headers, rows, aliases) -> list[ParameterRecord]:
+    if not rows:
+        return []
+
+    mappings = map_columns(headers, aliases)
+
+
+    # Prevent the parameter-name or symbol column from being
+    # incorrectly used as the numerical value column.
+    identity_columns = {
+        index
+        for index in (
+            mappings.get("parameter_symbol"),
+            mappings.get("parameter_name"),
+        )
+        if index is not None
+    }
+
+    mapped_value_index = mappings.get("value")
+    mapped_value_numeric_ratio = column_numeric_ratio(
+        rows,
+        mapped_value_index,
+    )
+
+    if (
+        mapped_value_index in identity_columns
+        or mapped_value_numeric_ratio < 0.40
+    ):
+        mappings["value"] = find_numeric_value_column(
+            rows,
+            excluded_columns=identity_columns,
+        )
+    if not headers:
+        # no reliable header row, just guess positions from column count
+        width = max(len(row) for row in rows)
+        if width >= 3:
+            mappings = {
+                "parameter_symbol": 0,
+                "parameter_name": 1,
+                "value": 2,
+                "unit": 3 if width > 3 else None,
+                "uncertainty": 4 if width > 4 else None,
+            }
+        elif width == 2:
+            mappings = {
+                "parameter_symbol": 0,
+                "parameter_name": None,
+                "value": 1,
+                "unit": None,
+                "uncertainty": None,
+            }
+        else:
+            return []
+
+    records: list[ParameterRecord] = []
+
+    for row in rows:
+        symbol = get_cell(row, mappings.get("parameter_symbol"))
+        name = get_cell(row, mappings.get("parameter_name"))
+        raw_value = get_cell(row, mappings.get("value"))
+        unit = get_cell(row, mappings.get("unit"))
+        uncertainty = get_cell(row, mappings.get("uncertainty"))
+
+        if not raw_value:
+            continue
+
+        parsed_value, parsed_unit, parsed_uncertainty = split_value_unit_uncertainty(raw_value)
+        unit = unit or parsed_unit
+        uncertainty = uncertainty or parsed_uncertainty
+
+        if name and symbol and normalized_text(name) == normalized_text(symbol):
+            name = ""  # don't duplicate the symbol as its own description
+
+        if not symbol and not name:
+            continue
+
+        # Correct symbol-only parameter cells.
+        #
+        # A generic header such as "Parameter" may be mapped to
+        # parameter_name even when the cells contain only symbols
+        # such as beta, gamma, β, σ, or \delta_I.
+        if name and looks_like_symbol(name):
+            if not symbol:
+                symbol = name
+
+            name = ""
+
+        # Also use split_parameter_cell() to distinguish:
+        # β                     -> symbol only
+        # β (transmission rate) -> symbol plus name
+        # transmission rate     -> name only
+        if name:
+            inferred_symbol, inferred_name = split_parameter_cell(name)
+
+            if inferred_symbol and inferred_name:
+                if not symbol:
+                    symbol = inferred_symbol
+
+                name = inferred_name
+
+            elif inferred_symbol and not inferred_name:
+                if not symbol:
+                    symbol = inferred_symbol
+
+                name = ""
+
+        # Never write the same symbol into both output fields.
+        if (
+            symbol
+            and name
+            and normalized_text(symbol) == normalized_text(name)
+        ):
+            name = ""
+
+        records.append(ParameterRecord(
+            pmid=pmid,
+            table_id=table_id,
+            parameter_name=name,
+            parameter_symbol=symbol,
+            value=parsed_value,
+            unit=unit,
+            uncertainty=uncertainty,
+        ))
+
+    return records
+
+
+def write_dict_rows(path: Path, rows: Sequence[dict], fieldnames: Sequence[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def process_collection(input_dir: Path, output_dir: Path) -> None:
+    references = load_references()
+    extracted_dir = output_dir / "extracted_tables"
+    extracted_dir.mkdir(parents=True, exist_ok=True)
+
+    decisions: list[dict] = []
+    observed_headers: list[dict] = []
+    summaries: list[dict] = []
+
+    html_files = sorted(input_dir.rglob("*.html"))
+
+    for paper_index, html_path in enumerate(html_files, start=1):
+        pmid = html_path.stem
+        html = html_path.read_text(encoding="utf-8", errors="ignore")
+        soup = BeautifulSoup(html, "html.parser")
+
+        paper_records: list[ParameterRecord] = []
+        tables = soup.find_all("table")
+
+        for table_number, table in enumerate(tables, start=1):
+            table_id = f"Table {table_number}"
+            caption = extract_caption(table, table_number)
+            matrix = extract_table_matrix(table)
+            headers, rows = separate_headers(table, matrix)
+
+            observed_headers.append({
+                "pmid": pmid,
+                "table_id": table_id,
+                "caption": caption,
+                "headers": " | ".join(headers),
+                "column_count": max((len(r) for r in matrix), default=0),
+                "row_count": len(rows),
+            })
+
+            scores = classify_table(caption, headers, rows, references)
+            records: list[ParameterRecord] = []
+
+            if scores["is_parameter_table"]:
+                records = extract_records(pmid, table_id, headers, rows, references["column_aliases"])
+                paper_records.extend(records)
+
+            decisions.append(asdict(TableDecision(
+                pmid=pmid,
+                table_id=table_id,
+                caption=caption,
+                headers=" | ".join(headers),
+                extracted_rows=len(records),
+                **scores,
+            )))
+
+        output_path = extracted_dir / f"{pmid}_parameters.csv"
+        write_dict_rows(
+            output_path,
+            [asdict(r) for r in paper_records],
+            ["pmid", "table_id", "parameter_symbol", "parameter_name", "value", "unit", "uncertainty"],
+        )
+
+        summaries.append({
+            "pmid": pmid,
+            "tables_found": len(tables),
+            "parameter_rows_extracted": len(paper_records),
+            "status": "extracted" if paper_records else "needs_review",
+        })
+
+        print(f"[{paper_index}/{len(html_files)}] {pmid}: {len(tables)} tables, {len(paper_records)} parameter rows")
+
+    write_dict_rows(
+        output_dir / "table_classification_results.csv",
+        decisions,
+        list(TableDecision.__dataclass_fields__),
+    )
+    write_dict_rows(
+        output_dir / "observed_headers.csv",
+        observed_headers,
+        ["pmid", "table_id", "caption", "headers", "column_count", "row_count"],
+    )
+    write_dict_rows(
+        output_dir / "extraction_summary.csv",
+        summaries,
+        ["pmid", "tables_found", "parameter_rows_extracted", "status"],
+    )
+
+    shutil.copy2(REFERENCE_FILE, output_dir / "reference_snapshot.json")
+
+    print()
+    print(f"Papers processed: {len(html_files)}")
+    print(f"Output directory: {output_dir}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract parameter tables from Marker HTML without an LLM.")
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    process_collection(args.input_dir.expanduser(), args.output_dir.expanduser())
+
+
+if __name__ == "__main__":
+    main()

--- a/mira/sources/sympy_ode/structured_parameter_extraction_simple.py
+++ b/mira/sources/sympy_ode/structured_parameter_extraction_simple.py
@@ -1,0 +1,312 @@
+"""Extract a simplified set of model-parameter fields from CSV tables."""
+
+import argparse
+import csv
+import json
+import os
+from pathlib import Path
+
+from openai import OpenAI
+from pydantic import BaseModel, Field
+
+
+DEFAULT_PMIDS = [
+    "32046137",
+    "32099934",
+    "32703315",
+    "32706790",
+    "32735581",
+    "32834593",
+]
+
+
+class ParameterRecord(BaseModel):
+    """One parameter extracted from a table."""
+
+    symbol: str | None = Field(
+        default=None,
+        description="Mathematical symbol or variable name for the parameter.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Definition, meaning, or description of the parameter.",
+    )
+    value: str | None = Field(
+        default=None,
+        description="Parameter value exactly as written in the table.",
+    )
+    unit: str | None = Field(
+        default=None,
+        description="Unit exactly as written in the table.",
+    )
+    uncertainty: str | None = Field(
+        default=None,
+        description=(
+            "Uncertainty information exactly as written, such as standard "
+            "deviation, standard error, confidence interval, or credible interval."
+        ),
+    )
+
+
+class PaperExtraction(BaseModel):
+    """Structured parameter extraction for one paper."""
+
+    pmid: str
+    contains_parameter_information: bool
+    parameters: list[ParameterRecord]
+
+
+SYSTEM_PROMPT = """
+You are extracting model parameters from CSV tables that were previously
+extracted from a biomedical paper.
+
+The input contains one or more CSV tables from the same paper.
+
+Your task is to determine whether the tables contain model parameter
+information. If they do, extract one record for each parameter.
+
+Extract only these five fields:
+
+1. symbol
+2. description
+3. value
+4. unit
+5. uncertainty
+
+Field mapping:
+
+- Parameter Symbol, Symbol, Variable, or mathematical notation -> symbol
+- Parameter, Definition, Description, Meaning, Interpretation, or
+  Epidemiological Meaning -> description
+- Value, Estimated Mean, Estimated Mean Value, Best-fit Value,
+  Baseline Value, Initial Value, or Default Value -> value
+- Unit or Units -> unit
+- Standard Deviation, Standard Error, Variance, Confidence Interval,
+  Credible Interval, Range used as uncertainty, or another uncertainty
+  measurement -> uncertainty
+
+Extraction rules:
+
+- Extract one record for each distinct parameter.
+- Read all supplied CSV tables from the paper.
+- Preserve mathematical symbols exactly as written.
+- Preserve values and units exactly as written.
+- Do not calculate, estimate, or invent missing values.
+- Return null when a field is not present.
+- Do not place a parameter symbol in the description field.
+- Do not place explanatory text in the symbol field.
+- If one table gives a symbol or description and another gives its value,
+  combine them only when the same symbol clearly connects the records.
+- Never merge two different parameter symbols.
+- If a cell contains several newline-separated symbols, descriptions, or
+  values, align them by position only when the correspondence is clear.
+- If the correspondence is unclear, do not guess.
+- Do not extract ordinary study statistics, participant characteristics,
+  outcome measurements, or table values that are not model parameters.
+- Do not return fields other than symbol, description, value, unit,
+  and uncertainty inside each parameter record.
+
+If none of the tables contain model parameter information, set
+contains_parameter_information to false and return an empty parameter list.
+""".strip()
+
+
+def read_csv_table(csv_path: Path) -> dict:
+    """Read one CSV table and retain its rows and headers."""
+
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as file:
+        reader = csv.DictReader(file)
+
+        headers = reader.fieldnames or []
+        rows = []
+
+        for row_number, row in enumerate(reader, start=2):
+            cleaned_row = {
+                str(key): value
+                for key, value in row.items()
+                if key is not None
+                and value is not None
+                and str(value).strip() != ""
+            }
+
+            if cleaned_row:
+                rows.append(
+                    {
+                        "csv_row_number": row_number,
+                        "cells": cleaned_row,
+                    }
+                )
+
+    return {
+        "table_file": csv_path.name,
+        "headers": headers,
+        "rows": rows,
+    }
+
+
+def find_pmid_directory(input_root: Path, pmid: str) -> Path | None:
+    """Find the directory containing the CSV files for a PMID."""
+
+    direct_path = input_root / pmid
+
+    if direct_path.is_dir():
+        return direct_path
+
+    matches = [
+        path
+        for path in input_root.rglob("*")
+        if path.is_dir() and path.name == pmid
+    ]
+
+    if matches:
+        return matches[0]
+
+    return None
+
+
+def load_paper_tables(input_root: Path, pmid: str) -> list[dict]:
+    """Load all CSV tables belonging to a PMID."""
+
+    pmid_directory = find_pmid_directory(input_root, pmid)
+
+    if pmid_directory is None:
+        return []
+
+    csv_paths = sorted(pmid_directory.glob("*.csv"))
+
+    return [read_csv_table(path) for path in csv_paths]
+
+
+def extract_parameters(
+    client: OpenAI,
+    pmid: str,
+    tables: list[dict],
+    model: str,
+) -> PaperExtraction:
+    """Send all CSV tables for one paper to the model."""
+
+    table_input = json.dumps(
+        {
+            "pmid": pmid,
+            "tables": tables,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    response = client.responses.parse(
+        model=model,
+        input=[
+            {
+                "role": "system",
+                "content": SYSTEM_PROMPT,
+            },
+            {
+                "role": "user",
+                "content": table_input,
+            },
+        ],
+        text_format=PaperExtraction,
+    )
+
+    result = response.output_parsed
+
+    if result is None:
+        raise RuntimeError(f"No parsed structured output returned for {pmid}")
+
+    result.pmid = pmid
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract symbol, description, value, unit, and uncertainty "
+            "from CSV tables."
+        )
+    )
+
+    parser.add_argument(
+        "input_root",
+        type=Path,
+        help="Root folder containing one folder per PMID.",
+    )
+    parser.add_argument(
+        "output_root",
+        type=Path,
+        help="Folder where JSON outputs will be saved.",
+    )
+    parser.add_argument(
+        "--pmids",
+        nargs="+",
+        default=DEFAULT_PMIDS,
+        help="PMIDs to process.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gpt-4.1-mini",
+        help="OpenAI model to use.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read the CSV files without calling the OpenAI API.",
+    )
+
+    args = parser.parse_args()
+    args.output_root.mkdir(parents=True, exist_ok=True)
+
+    client = None
+
+    if not args.dry_run:
+        if not os.getenv("OPENAI_API_KEY"):
+            raise EnvironmentError(
+                "OPENAI_API_KEY is not set in the current terminal."
+            )
+
+        client = OpenAI()
+
+    for pmid in args.pmids:
+        tables = load_paper_tables(args.input_root, pmid)
+
+        if not tables:
+            print(f"{pmid}: no CSV tables found")
+            continue
+
+        row_count = sum(len(table["rows"]) for table in tables)
+
+        if args.dry_run:
+            print(
+                f"{pmid}: {len(tables)} tables, "
+                f"{row_count} non-empty rows"
+            )
+            continue
+
+        print(f"Processing PMID {pmid}...")
+
+        result = extract_parameters(
+            client=client,
+            pmid=pmid,
+            tables=tables,
+            model=args.model,
+        )
+
+        output_path = args.output_root / f"{pmid}.json"
+
+        output_path.write_text(
+            json.dumps(
+                result.model_dump(),
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        print(
+            f"Saved {output_path} "
+            f"({len(result.parameters)} records)"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a first working version of a Marker-specific parameter extraction utility under:

`mira/sources/sympy_ode/marker_parameter_extraction.py`

The script reads Marker HTML output, locates the parameter table using string matching, extracts parameter rows, normalizes parameter symbols, and writes the extracted results to CSV.

## What it does

- Reads Marker-generated HTML output
- Uses string matching to locate the parameter table
- Extracts only the parameter table region
- Parses parameter rows into structured fields:
  - PMID
  - table ID
  - parameter
  - definition
  - value
  - standard deviation
  - source
  - parameter type
  - raw parameter
- Normalizes common parameter symbols such as beta, sigma, lambda, alpha, delta, and gamma
- Writes extracted parameter rows to CSV

## Test case

Tested on PMID `32046137`.

The script extracted 20 rows from Table 1:
- 12 model parameters
- 8 initial values

The extracted output preserved parameter names, definitions, values, standard deviations, and sources.

Example extracted rows include:

- `c | 14.781 | 0.904 | MCMC`
- `beta | 2.1011 x 10^-8 | 1.1886 x 10^-9 | MCMC`
- `q | 1.8887 x 10^-7 | 6.3654 x 10^-8 | MCMC`
- `sigma | 1/7 | - | WHO`
- `S(0) | 11,081,000 | - | [18]`

## Notes

This is a first rule-based implementation. It works on the tested Marker output and can be extended by testing additional papers and improving table detection/generalization.