### PR TITLE
Add Pix2Text, Docling, Chandra, LlamaParse, PaddleOCR, Reducto, GLM-OCR, and Nougat extractors

### DIFF
--- a/mira/sources/sympy_ode/extractors.py
+++ b/mira/sources/sympy_ode/extractors.py
@@ -2,6 +2,7 @@ import gc
 import json
 import logging
 import tarfile
+import re
 
 from indra.literature.pubmed_client import download_package_for_pmid
 
@@ -327,3 +328,84 @@ class XmlExtractor(Extractor):
 
         self.extraction_file = "No intermediate created"
         return {"content_type": "text", "text_content": markdown_text}
+
+
+class Pix2TextExtractor(PdfExtractor):
+    """Extract equations from a PDF using Pix2Text.
+    Text mode only.
+    Uses Math Formula Detection (MFD) and Math Formula Recognition (MFR)
+    to extract LaTeX from scientific PDFs.
+    Install: pip install pix2text
+    """
+
+    supported_methods = {"text"}
+
+    def get_pipeline_inputs(self):
+        import platform
+
+        # CoreML causes failures on Apple Silicon, fall back to CPU
+        if platform.system() == "Darwin":
+            import onnxruntime as ort
+            _orig = ort.get_available_providers
+            ort.get_available_providers = lambda: [
+                p for p in _orig() if p != "CoreMLExecutionProvider"
+            ]
+
+        try:
+            from pix2text import Pix2Text
+        except ImportError:
+            raise ImportError(
+                "pix2text is not installed. "
+                "Install it with: pip install pix2text"
+            )
+
+        out_dir = self.paper_base / "pix2text"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        md_file = out_dir / f"{self.pmid}.md"
+
+        if md_file.is_file():
+            logger.info(f"Found existing Pix2Text output at {md_file}, "
+                        f"loading from file")
+            with open(md_file) as f:
+                markdown_text = f.read()
+        else:
+            logger.info(f"Running Pix2Text pipeline for {self.pdf_file.name}")
+            p2t = Pix2Text(enable_formula=True, enable_table=False)
+            doc = p2t.recognize(str(self.pdf_file), file_type="pdf")
+            markdown_text = doc.to_markdown(
+                out_dir=str(out_dir),
+                markdown_fn=f"{self.pmid}.md",
+            )
+            with open(md_file, "w") as f:
+                f.write(markdown_text)
+            del p2t
+            del doc
+            gc.collect()
+
+        # Pix2Text outputs display math as $$..$$ or named environments
+        display_blocks = re.findall(
+            r'\$\$(.+?)\$\$', markdown_text, re.DOTALL
+        )
+        env_blocks = re.findall(
+            r'\\begin\{(align|equation|eqnarray)\*?\}(.*?)\\end\{\1\*?\}',
+            markdown_text,
+            re.DOTALL,
+        )
+        equation_blocks = [eq.strip() for eq in display_blocks]
+        equation_blocks += [body.strip() for _, body in env_blocks]
+
+        if equation_blocks:
+            logger.info(f"Found {len(equation_blocks)} equation blocks via "
+                        f"Pix2Text output")
+            equation_text = "\n\n".join(
+                [str((eq, "latex")) for eq in equation_blocks]
+            )
+        else:
+            logger.warning(
+                f"No equation blocks found in Pix2Text output for "
+                f"{self.pmid}, passing full markdown to pipeline"
+            )
+            equation_text = markdown_text
+
+        self.extraction_file = str(md_file)
+        return {"content_type": "text", "text_content": equation_text}

--- a/mira/sources/sympy_ode/extractors.py
+++ b/mira/sources/sympy_ode/extractors.py
@@ -409,3 +409,194 @@ class Pix2TextExtractor(PdfExtractor):
 
         self.extraction_file = str(md_file)
         return {"content_type": "text", "text_content": equation_text}
+
+class DoclingExtractor(PdfExtractor):
+    """Extract equations from a PDF using the Docling pipeline.
+    Text-mode only. 
+    Install: pip install docling
+
+    Uses Docling's structured document output to extract formula elements
+    directly. Prefers the 'orig' field over 'text' since CodeFormulaV2
+    may produce inconsistent output on complex multi-line equation blocks.
+    """
+
+    supported_methods = {"text"}
+
+    def get_pipeline_inputs(self):
+        from docling.document_converter import DocumentConverter, PdfFormatOption
+        from docling.datamodel.pipeline_options import ( PdfPipelineOptions, CodeFormulaVlmOptions)
+        from docling.datamodel.base_models import InputFormat
+        from docling.datamodel.stage_model_specs import EngineModelConfig
+        from docling.models.inference_engines.vlm.base import VlmEngineType
+        from docling_core.types.doc import DocItemLabel
+
+        out_dir = self.paper_base / "docling"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        json_file = out_dir / f"{self.pmid}.json"
+
+        if json_file.is_file():
+            logger.info(f"Found existing Docling output at {json_file}, "
+                        f"loading from file")
+            from docling_core.types.doc import DoclingDocument
+            with open(json_file) as f:
+                doc = DoclingDocument.model_validate_json(f.read())
+
+        else:
+            # CodeFormulaV2 uses Idefics3 under the hood, which crashes on certain
+            # hardware configurations when PyTorch's optimized attention (SDPA) is
+            # enabled. Forcing eager attention is slower but works universally.
+            vlm_opts = CodeFormulaVlmOptions.from_preset("codeformulav2")
+            vlm_opts.model_spec.engine_overrides[VlmEngineType.TRANSFORMERS] = \
+                EngineModelConfig(
+                    extra_config={
+                        'transformers_model_type': 'automodel-imagetexttotext',
+                        'torch_dtype': 'bfloat16',
+                        # Disable SDPA as its incompatible with Idefics3 on some hardware
+                        'attn_implementation': 'eager',
+                        'extra_generation_config': {'skip_special_tokens': False},
+                    }
+                )
+
+            pipeline_options = PdfPipelineOptions()
+            pipeline_options.do_ocr = True
+            pipeline_options.do_table_structure = True
+            pipeline_options.do_formula_enrichment = True
+            pipeline_options.code_formula_options = vlm_opts
+
+            converter = DocumentConverter(
+                format_options={
+                    InputFormat.PDF: PdfFormatOption(
+                        pipeline_options=pipeline_options
+                    )
+                }
+            )
+            result = converter.convert(str(self.pdf_file))
+            doc = result.document
+
+            with open(json_file, "w") as f:
+                f.write(doc.model_dump_json())
+
+            del converter
+            del result
+            gc.collect()
+
+        equations = []
+        for element, _ in doc.iterate_items():
+            if element.label != DocItemLabel.FORMULA:
+                continue
+            if hasattr(element, "orig") and element.orig:
+                equations.append((element.orig.strip(), "text"))
+            elif hasattr(element, "text") and element.text:
+                equations.append((element.text.strip(), "latex"))
+
+        if equations:
+            logger.info(f"Found {len(equations)} formula elements via " f"Docling structured output")
+            equation_text = "\n\n".join(
+                [str((eq, fmt)) for eq, fmt in equations]
+            )
+        else:
+            logger.warning(
+                f"No formula elements found in Docling output for " f"{self.pmid}, passing full markdown to pipeline"
+            )
+            equation_text = doc.export_to_markdown()
+
+        self.extraction_file = str(json_file)
+        return {"content_type": "text", "text_content": equation_text}
+
+class ChandraExtractor(PdfExtractor):
+    """Extract equations from a PDF using Chandra OCR 2.
+
+    Text-mode only.
+    Install: pip install "chandra-ocr[hf]"
+    """
+
+    supported_methods = {"text"}
+
+    def get_pipeline_inputs(self):
+        import re
+        try:
+            from chandra.input import load_pdf_images
+            from chandra.model.hf import load_model, generate_hf
+            from chandra.model.schema import BatchInputItem
+        except ImportError:
+            raise ImportError(
+                "chandra-ocr is not installed. "
+                "Install it with: pip install 'chandra-ocr[hf]'"
+            )
+
+        out_dir = self.paper_base / "chandra"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        md_file = out_dir / f"{self.pmid}.md"
+
+        if md_file.is_file():
+            logger.info(f"Found existing Chandra output at {md_file}, "
+                        f"loading from file")
+            with open(md_file) as f:
+                markdown_text = f.read()
+        else:
+            logger.info(f"Running Chandra OCR on {self.pdf_file.name}")
+
+            # Load PDF pages as images
+            images = load_pdf_images(
+                filepath=str(self.pdf_file),
+                page_range=list(range(len(
+                    __import__('pypdfium2').PdfDocument(str(self.pdf_file))
+                ))),
+            )
+            logger.info(f"Loaded {len(images)} pages from PDF")
+
+            model = load_model()
+            batch = [
+                BatchInputItem(image=img, prompt_type="ocr_layout")
+                for img in images
+            ]
+            results = generate_hf(batch=batch, model=model)
+
+            markdown_text = "\n\n".join(
+                [r.raw for r in results if not r.error]
+            )
+
+            with open(md_file, "w") as f:
+                f.write(markdown_text)
+
+            del model
+            del batch
+            del results
+            gc.collect()
+
+        # Extract block equations.
+        # Chandra outputs display math as $$...$$ and named environments like equation or eqnarray
+        equation_blocks = []
+
+        # Match $$...$$ display math blocks
+        display_blocks = re.findall(
+            r'\$\$(.+?)\$\$',
+            markdown_text,
+            re.DOTALL
+        )
+        equation_blocks.extend([eq.strip() for eq in display_blocks])
+
+        # Match \begin{align}...\end{align} or similar
+        env_blocks = re.findall(
+            r'\\begin\{(align|equation|eqnarray)\*?\}(.*?)'
+            r'\\end\{\1\*?\}',
+            markdown_text,
+            re.DOTALL
+        )
+        equation_blocks.extend([eq.strip() for _, eq in env_blocks])
+
+        if equation_blocks:
+            logger.info(f"Found {len(equation_blocks)} equation blocks via "
+                        f"Chandra output")
+            equation_text = "\n\n".join(
+                [str((eq, "latex")) for eq in equation_blocks]
+            )
+        else:
+            logger.warning(
+                f"No equation blocks found in Chandra output for "
+                f"{self.pmid}, passing full markdown to pipeline"
+            )
+            equation_text = markdown_text
+
+        self.extraction_file = str(md_file)
+        return {"content_type": "text", "text_content": equation_text}

--- a/mira/sources/sympy_ode/paper_extraction.py
+++ b/mira/sources/sympy_ode/paper_extraction.py
@@ -12,6 +12,7 @@ from mira.sources.sympy_ode.extractors import (
     MineruExtractor,
     MarkerExtractor,
     XmlExtractor,
+    Pix2TextExtractor,
 )
 from mira.sources.sympy_ode.llm_util import (
     execute_template_model_from_sympy_odes,
@@ -80,6 +81,11 @@ def get_template_model_from_pmid(pmid: str, extractor: str = "mineru",
                                         ode_extraction_method)
     elif extractor == "xml":
         extractor_obj = XmlExtractor(pmid, pmc)
+
+    elif extractor == "pix2text":
+        extractor_obj = Pix2TextExtractor(pmid, pmc, paper_base,
+                                          pmid_to_download_mapping,
+                                          ode_extraction_method)
     else:
         raise ValueError(f"Unknown extractor: {extractor}")
 

--- a/mira/sources/sympy_ode/paper_extraction.py
+++ b/mira/sources/sympy_ode/paper_extraction.py
@@ -13,6 +13,7 @@ from mira.sources.sympy_ode.extractors import (
     MarkerExtractor,
     XmlExtractor,
     Pix2TextExtractor,
+    DoclingExtractor,
 )
 from mira.sources.sympy_ode.llm_util import (
     execute_template_model_from_sympy_odes,
@@ -86,6 +87,10 @@ def get_template_model_from_pmid(pmid: str, extractor: str = "mineru",
         extractor_obj = Pix2TextExtractor(pmid, pmc, paper_base,
                                           pmid_to_download_mapping,
                                           ode_extraction_method)
+    elif extractor == "docling":
+        extractor_obj = DoclingExtractor(pmid, pmc, paper_base,
+                                         pmid_to_download_mapping,
+                                         ode_extraction_method)
     else:
         raise ValueError(f"Unknown extractor: {extractor}")
 

--- a/mira/sources/sympy_ode/paper_extraction.py
+++ b/mira/sources/sympy_ode/paper_extraction.py
@@ -14,6 +14,7 @@ from mira.sources.sympy_ode.extractors import (
     XmlExtractor,
     Pix2TextExtractor,
     DoclingExtractor,
+    ChandraExtractor,
 )
 from mira.sources.sympy_ode.llm_util import (
     execute_template_model_from_sympy_odes,
@@ -91,6 +92,11 @@ def get_template_model_from_pmid(pmid: str, extractor: str = "mineru",
         extractor_obj = DoclingExtractor(pmid, pmc, paper_base,
                                          pmid_to_download_mapping,
                                          ode_extraction_method)
+    elif extractor == "chandra":
+        extractor_obj = ChandraExtractor(pmid, pmc, paper_base,
+                                     pmid_to_download_mapping,
+                                     ode_extraction_method)
+                                     
     else:
         raise ValueError(f"Unknown extractor: {extractor}")
 


### PR DESCRIPTION
Extends `get_template_model_from_pmid`'s `extractor` argument to support 8 additional ODE extraction backends, alongside the existing `mineru`, `marker`, and `xml` options.

**Extraction methods**

* `get_template_model_from_pmid`'s `extractor` argument now additionally accepts `pix2text`, `docling`, `chandra`, `llamaparse`, `paddleocr`, `reducto`, `glmocr`, or `nougat`.
* Pix2Text: uses Math Formula Detection and Recognition to extract LaTeX equations directly from rendered PDF pages (text only).
* Docling: converts the PDF with formula enrichment, reading equations from the resulting document's formula elements (text only).
* Chandra: runs Chandra OCR 2's model page-by-page over the PDF and parses equations from the OCR'd markdown (text only).
* LlamaParse: cloud API extraction with a custom prompt instructing exact preservation of equation notation and subscripts (text only).
* PaddleOCR: uses PP-StructureV3 with formula recognition, supports text mode (markdown output) and image mode (cropped equation images).
* Reducto: cloud API extraction using a parse step followed by a structured-schema extract step to pull out equations in reading order (text only).
* GLM-OCR: cloud API extraction via Zhipu's GLM-OCR service, parsing equations from the returned markdown (text only).
* Nougat: runs Meta's `facebook/nougat-base` model page-by-page over the PDF and parses equations from the generated markdown (text only).

**Pipeline**

*  Updated `paper_extraction.py` to support selecting any of the new extractors.